### PR TITLE
Object Builder Fixes

### DIFF
--- a/alpha/apps/kaltura/lib/propel/php5/KalturaObjectBuilder.php
+++ b/alpha/apps/kaltura/lib/propel/php5/KalturaObjectBuilder.php
@@ -605,7 +605,6 @@ abstract class ".$this->getClassname()." extends ".ClassTools::classname($this->
 		if($customDataColumn)
 		$script .= "
 		\$this->oldCustomDataValues = array();
-		\$this->oldCustomDataValueWasNull = false; 
     	";
 				
 		$script .= " 
@@ -854,13 +853,6 @@ abstract class ".$this->getClassname()." extends ".ClassTools::classname($this->
 		
 		$clo = strtolower($col->getName());
 		
-		if ($clo === self::KALTURA_COLUMN_CUSTOM_DATA){
-			$script .= "
-		if (is_null(\$this->custom_data))
-			\$this->oldCustomDataValueWasNull = true;
-		";
-		}
-			
 		if(in_array($clo, self::$systemColumns))
 			return;
 			
@@ -983,12 +975,6 @@ abstract class ".$this->getClassname()." extends ".ClassTools::classname($this->
 	protected \$oldCustomDataValues = array();
 	
 	/**
-	 * Flag to indicate if old custom_data value was null
-	 * @var 	   boolean
-	 */
-	protected \$oldCustomDataValueWasNull = false;
-	
-	/**
 	 * @return array
 	 */
 	public function getCustomDataOldValues()
@@ -1095,7 +1081,7 @@ abstract class ".$this->getClassname()." extends ".ClassTools::classname($this->
 	{
 		if ( \$this->m_custom_data != null )
 		{
-			\$this->custom_data_md5 = md5(\$this->custom_data);
+			\$this->custom_data_md5 = is_null(\$this->custom_data) ? null : md5(\$this->custom_data);
 			\$this->setCustomData( \$this->m_custom_data->toString() );
 		}
 	}
@@ -1122,7 +1108,7 @@ abstract class ".$this->getClassname()." extends ".ClassTools::classname($this->
 			$script .= "
 			if (\$this->isColumnModified(".$this->getPeerClassname()."::CUSTOM_DATA))
 			{
-				if (!is_null(\$this->custom_data) && !\$this->oldCustomDataValueWasNull)
+				if (!is_null(\$this->custom_data_md5))
 					\$criteria->add(".$this->getPeerClassname()."::CUSTOM_DATA, \"MD5(cast(\" . ".$this->getPeerClassname()."::CUSTOM_DATA . \" as char character set latin1)) = '\$this->custom_data_md5'\", Criteria::CUSTOM);
 					//casting to latin char set to avoid mysql and php md5 difference
 				else 

--- a/alpha/lib/model/om/BasePartner.php
+++ b/alpha/lib/model/om/BasePartner.php
@@ -1434,9 +1434,7 @@ abstract class BasePartner extends BaseObject  implements Persistent {
 	 */
 	public function setCustomData($v)
 	{
-		if (is_null($this->custom_data))
-			$this->oldCustomDataValueWasNull = true;
-			
+
 		if ($v !== null) {
 			$v = (string) $v;
 		}
@@ -2296,7 +2294,6 @@ abstract class BasePartner extends BaseObject  implements Persistent {
 		kEventsManager::raiseEvent(new kObjectSavedEvent($this));
 		$this->oldColumnsValues = array();
 		$this->oldCustomDataValues = array();
-		$this->oldCustomDataValueWasNull = false; 
     	 
 		parent::postSave($con);
 	}
@@ -2992,7 +2989,7 @@ abstract class BasePartner extends BaseObject  implements Persistent {
 		{
 			if ($this->isColumnModified(PartnerPeer::CUSTOM_DATA))
 			{
-				if (!is_null($this->custom_data) && !$this->oldCustomDataValueWasNull)
+				if (!is_null($this->custom_data_md5)) 
 					$criteria->add(PartnerPeer::CUSTOM_DATA, "MD5(cast(" . PartnerPeer::CUSTOM_DATA . " as char character set latin1)) = '$this->custom_data_md5'", Criteria::CUSTOM);
 					//casting to latin char set to avoid mysql and php md5 difference
 				else 
@@ -3278,12 +3275,6 @@ abstract class BasePartner extends BaseObject  implements Persistent {
 	protected $oldCustomDataValues = array();
 	
 	/**
-	 * Flag to indicate if old custom_data value was null
-	 * @var 	   boolean
-	 */
-	protected $oldCustomDataValueWasNull = false;
-	
-	/**
 	 * @return array
 	 */
 	public function getCustomDataOldValues()
@@ -3390,7 +3381,7 @@ abstract class BasePartner extends BaseObject  implements Persistent {
 	{
 		if ( $this->m_custom_data != null )
 		{
-			$this->custom_data_md5 = md5($this->custom_data);
+			$this->custom_data_md5 = is_null($this->custom_data) ? null : md5($this->custom_data);
 			$this->setCustomData( $this->m_custom_data->toString() );
 		}
 	}


### PR DESCRIPTION
Resolved 2 bugs 
1.  Base classes which doesn’t have custom_data field still tried to buildPkCriteria with the Custom_data md5 (and Fatal-ed out)
2.  When a partner had custom_data = NULL query failed (it md5(null) instead of going to the ‘else’ part)
