### PR TITLE
SUP-520 #comment Fix Categories saved with spaces in the beginning

### DIFF
--- a/api_v3/lib/types/KalturaCategory.php
+++ b/api_v3/lib/types/KalturaCategory.php
@@ -540,4 +540,13 @@ class KalturaCategory extends KalturaObject implements IFilterable
 		return parent::toInsertableObject($object_to_fill, $props_to_skip);
 	}
 	
+ 	/* (non-PHPdoc)
+	 * @see KalturaObject::toObject($object_to_fill, $props_to_skip)
+	 */
+	public function toObject($object_to_fill = null, $props_to_skip = array())
+	{
+		$this->trimStringProperties(array("name"));
+		
+		return parent::toObject($object_to_fill, $props_to_skip);
+	}	
 }


### PR DESCRIPTION
Added toObject func to trim the name property and only than continue
to the parent toObject
