### PR TITLE
fix file_ext override after import job

### DIFF
--- a/alpha/apps/kaltura/lib/batch2/kFlowHelper.php
+++ b/alpha/apps/kaltura/lib/batch2/kFlowHelper.php
@@ -167,7 +167,8 @@ class kFlowHelper
 		if(!$flavorAsset->getVersion())
 			$flavorAsset->incrementVersion();
 
-		$flavorAsset->setFileExt($ext);
+		if($ext)
+			$flavorAsset->setFileExt($ext);
 		$flavorAsset->save();
 		$syncKey = $flavorAsset->getSyncKey(flavorAsset::FILE_SYNC_FLAVOR_ASSET_SUB_TYPE_ASSET);
 		kFileSyncUtils::moveFromFile($data->getDestFileLocalPath(), $syncKey, true, false, $data->getCacheOnly());


### PR DESCRIPTION
update file_ext on flavor asset after import is finished only if the
extracted ext is not null
