### PR TITLE
Remove uiConf type HTML5

### DIFF
--- a/admin_console/configs/lang/en.php
+++ b/admin_console/configs/lang/en.php
@@ -326,7 +326,6 @@ return array(
 	'KalturaUiConfObjType::PLAYER_SL' => 'Player Silverlight',
 	'KalturaUiConfObjType::CLIENTSIDE_ENCODER' => 'Client Side Encoder',
 	'Kaltura_Client_Enum_UiConfObjType::KSR' => 'Kaltura Screen Recorder',
-	'Kaltura_Client_Enum_UiConfObjType::HTML5_PLAYER' => 'HTML5 Player',
 	 
     
 	//batch index

--- a/alpha/lib/model/uiConf.php
+++ b/alpha/lib/model/uiConf.php
@@ -33,7 +33,6 @@ class uiConf extends BaseuiConf implements ISyncableFile
 	const UI_CONF_CLIPPER = 18;
 	const UI_CONF_TYPE_KSR = 19;
 	const UI_CONF_TYPE_KUPLOAD = 20;
-	const UI_CONF_TYPE_HTML5 = 21;
 
 
 	const UI_CONF_CREATION_MODE_MANUAL = 1;
@@ -80,7 +79,6 @@ class uiConf extends BaseuiConf implements ISyncableFile
 										self::UI_CONF_TYPE_KSR => "ScreencastOMaticRun-1.0.32.jar",
 										self::UI_CONF_TYPE_KRECORD => "KRecord.swf",
 										self::UI_CONF_TYPE_KUPLOAD => "KUpload.swf",
-										self::UI_CONF_TYPE_HTML5 => "kdp3.swf",
 									);
 
 	private static $swf_directory_map = array (
@@ -104,7 +102,6 @@ class uiConf extends BaseuiConf implements ISyncableFile
 		self::UI_CONF_TYPE_KSR => "ksr",
 		self::UI_CONF_TYPE_KRECORD => 'krecord',
 		self::UI_CONF_TYPE_KUPLOAD => "kupload",
-		self::UI_CONF_TYPE_HTML5 => "kdp3",
 	);
 
 	public function save(PropelPDO $con = null, $isClone = false)
@@ -223,7 +220,6 @@ class uiConf extends BaseuiConf implements ISyncableFile
 				self::UI_CONF_CLIPPER => "Kaltura Clipper",
 				self::UI_CONF_TYPE_KSR => "Kaltura Screen Recorder",
 				self::UI_CONF_TYPE_KUPLOAD => "Kaltura Simple Uploader",
-				self::UI_CONF_TYPE_HTML5 => "HTML5",
 			);
 		}
 	}
@@ -254,7 +250,6 @@ class uiConf extends BaseuiConf implements ISyncableFile
 				self::UI_CONF_CLIPPER => false,
 				self::UI_CONF_TYPE_KSR => true,
 				self::UI_CONF_TYPE_KUPLOAD => false,
-				self::UI_CONF_TYPE_HTML5 => true,
 			);
 		}
 	}
@@ -685,15 +680,9 @@ class uiConf extends BaseuiConf implements ISyncableFile
 			$version = "_" . ($version ? $version : $this->getVersion());
 		else
 			$version = "";
-
-		// html5 player uses JSON instead of XML
-		$ext = "xml";
-		if( $this->getType() === self::UI_CONF_TYPE_HTML5 ) {
-			$ext = "json";
-		}
-
+		
 		$dir = (intval($this->getId() / 1000000)).'/'.	(intval($this->getId() / 1000) % 1000);
-		$file_name = "/content/generatedUiConf/$dir/ui_conf_{$this->getId()}_{$version}.$ext";
+		$file_name = "/content/generatedUiConf/$dir/ui_conf_{$this->getId()}_{$version}.xml";
 		return $file_name;
 	}
 

--- a/api_v3/lib/types/enums/KalturaUiConfObjType.php
+++ b/api_v3/lib/types/enums/KalturaUiConfObjType.php
@@ -25,5 +25,4 @@ class KalturaUiConfObjType extends KalturaEnum
 	const CLIPPER = 18;
 	const KSR = 19;
 	const KUPLOAD = 20;
-	const HTML5_PLAYER = 21;
 }

--- a/configurations/admin.template.ini
+++ b/configurations/admin.template.ini
@@ -42,7 +42,6 @@ settings.uiConfTypes[] = Kaltura_Client_Enum_UiConfObjType::PLAYER_SL
 settings.uiConfTypes[] = Kaltura_Client_Enum_UiConfObjType::PLAYLIST
 settings.uiConfTypes[] = Kaltura_Client_Enum_UiConfObjType::CLIPPER
 settings.uiConfTypes[] = Kaltura_Client_Enum_UiConfObjType::KSR
-settings.uiConfTypes[] = Kaltura_Client_Enum_UiConfObjType::HTML5_PLAYER
 
 ; disable KCW visual editor for on-prem/ce (editor is enabled if property is true or missing)
 settings.enableKCWVisualEditor = false;


### PR DESCRIPTION
This pull request is to remove the uiConf type for HTML5.
Not needed anymore since we now have new "config" attribute on the uiConf object.

Also need to update `admin.ini` on all environments to remove this line:

```
settings.uiConfTypes[] = Kaltura_Client_Enum_UiConfObjType::HTML5_PLAYER
```

Please review & merge
