### PR TITLE
Flavor size : Get the size in bytes and not in Kb.

### DIFF
--- a/alpha/apps/kaltura/lib/batch2/bcdl/kBusinessPostConvertDL.php
+++ b/alpha/apps/kaltura/lib/batch2/bcdl/kBusinessPostConvertDL.php
@@ -136,7 +136,8 @@ class kBusinessPostConvertDL
 		
 		$flavorSize = $currentFlavorAsset->getSize();
 		if($dbBatchJob) {
-			$dbBatchJob->putInCustomData("flavor_size", $flavorSize);
+			// Multiply by 1024 to get the file size in bytes.
+			$dbBatchJob->putInCustomData("flavor_size", $flavorSize * 1024);
 			$dbBatchJob->save();
 		}
 				


### PR DESCRIPTION
Multiply the size by 1024 to get the flavor size in bytes. Was made in order to unify the measuring units we use according to Eran's request.
