### PR TITLE
Whitelabel KMC ( login page )

### DIFF
--- a/alpha/apps/kaltura/modules/kmc/actions/kmc4Action.class.php
+++ b/alpha/apps/kaltura/modules/kmc/actions/kmc4Action.class.php
@@ -194,45 +194,11 @@ class kmc4Action extends kalturaAction
 			'logoutUrl'					=> $logoutUrl,
 			'allowFrame'				=> (bool) $allowFrame,
 			'akamaiEdgeServerIpURL'		=> $akamaiEdgeServerIpURL,
-			'logoUrl' 					=> $this->getWhitelabelData('logo_url'),
-			'supportUrl' 				=> $this->getWhitelabelData('support_url'),
+			'logoUrl' 					=> kmcUtils::getWhitelabelData( $partner, 'logo_url'),
+			'supportUrl' 				=> kmcUtils::getWhitelabelData( $partner, 'support_url'),
 		);
 		
 		$this->kmcVars = $kmcVars;
-	}
-
-	private function getWhitelabelData( $param = null )
-	{
-		// no param, return null
-		if( !$param ){
-			return null;
-		}
-
-		if (kConf::hasMap("whitelabel"))
-		{
-			$whitelabel = kConf::getMap("whitelabel");
-			$params = array();
-
-			// Search for partner Id
-			if (array_key_exists($this->partner_id, $whitelabel))
-			{
-				$params = $whitelabel[$this->partner_id];			
-			} 
-			// Search for parent partner id
-			else if (array_key_exists($this->partner->getPartnerParentId(), $whitelabel))
-			{
-				$params = $whitelabel[$this->partner->getPartnerParentId()];
-			}
-
-			// If we have params, find out param
-			if( is_array($params) && array_key_exists($param, $params) )
-			{
-				return $params[ $param ];
-			}
-
-			return null;
-		}
-		return null;
 	}
 
 	private function stripProtocol( $url )

--- a/alpha/apps/kaltura/modules/kmc/actions/kmcAction.class.php
+++ b/alpha/apps/kaltura/modules/kmc/actions/kmcAction.class.php
@@ -23,6 +23,15 @@ class kmcAction extends kalturaAction
 		$swfUrl .= $this->www_host . myContentStorage::getFSFlashRootPath ();
 		$swfUrl .= '/kmc/login/' . kConf::get('kmc_login_version') . '/login.swf';
 		$this->swfUrl = $swfUrl;
+
+		$this->partner_id = $this->getRequestParameter( "partner_id" );
+		$this->logoUrl = null;
+		if ( $this->partner_id ) {
+			$partner = PartnerPeer::retrieveByPK($partnerId);
+			if( $partner ){
+				$this->logoUrl = kmcUtils::getWhitelabelData( $partner, 'logo_url' );
+			}
+		}
 		
 		$this->beta = $this->getRequestParameter( "beta" );
 		$this->setPassHashKey = $this->getRequestParameter( "setpasshashkey" );

--- a/alpha/apps/kaltura/modules/kmc/lib/kmcUtils.class.php
+++ b/alpha/apps/kaltura/modules/kmc/lib/kmcUtils.class.php
@@ -256,4 +256,38 @@ class kmcUtils
 	    return $arr;
 	}
 
+	public static function getWhitelabelData( Partner $partner,  $param = null )
+	{
+		// no param, return null
+		if( !$param ){
+			return null;
+		}
+
+		if (kConf::hasMap("whitelabel"))
+		{
+			$whitelabel = kConf::getMap("whitelabel");
+			$params = array();
+
+			// Search for partner Id
+			if (array_key_exists($partner->getId(), $whitelabel))
+			{
+				$params = $whitelabel[$partner->getId()];			
+			} 
+			// Search for parent partner id
+			else if (array_key_exists($partner->getPartnerParentId(), $whitelabel))
+			{
+				$params = $whitelabel[$partner->getPartnerParentId()];
+			}
+
+			// If we have params, find out param
+			if( is_array($params) && array_key_exists($param, $params) )
+			{
+				return $params[ $param ];
+			}
+
+			return null;
+		}
+		return null;
+	}
+
 }

--- a/alpha/apps/kaltura/modules/kmc/templates/kmcSuccess.php
+++ b/alpha/apps/kaltura/modules/kmc/templates/kmcSuccess.php
@@ -4,7 +4,11 @@ div#login { width:500px; margin: 0 auto; text-align:center;}
 </style>
 
 <div id="kmcHeader">
+	<?php if( $logoUrl ) { ?>
+	<img src="<?php echo $logoUrl; ?>" />
+	<?php } else { ?>
 	<img src="/lib/images/kmc/logo_kmc.png" alt="Kaltura CMS" />
+	<?php } ?>
 	<div id="user_links">
     	<a href="/content/docs/pdf/KMC_User_Manual.pdf" target="_blank">User Manual</a>
 	</div> 


### PR DESCRIPTION
Improvement to #127 
Support for custom logo in login page.

In order for the logo to shown you need to pass "/partner_id/{partner_id}" to login page.
i.e: 

```
http://kmc.kaltura.com/index.php/kmc/kmc/partner_id/111
```
