### PR TITLE
Plat 226: Enabling of proxy connection with credentials

### DIFF
--- a/generator/sources/csharp/KalturaClient/KalturaClientBase.cs
+++ b/generator/sources/csharp/KalturaClient/KalturaClientBase.cs
@@ -190,9 +190,7 @@ namespace Kaltura
             request.Headers = _Config.RequestHeaders;
 			
 			// Add proxy information if required
-			if( !_Config.ProxyAddress.Equals( "" ) && !_Config.ProxyAddress.Equals( null ) ) {
-				request.Proxy = new WebProxy( _Config.ProxyAddress );
-			}
+            createProxy(request, _Config);
             			
             if (kfiles.Count > 0)
             {
@@ -236,6 +234,21 @@ namespace Kaltura
             this.ThrowExceptionOnAPIError(result);
 
             return result;
+        }
+        private void createProxy(HttpWebRequest request, KalturaConfiguration _Config)
+        {
+            if (String.IsNullOrEmpty(_Config.ProxyAddress))
+                return;
+            Console.WriteLine("Create proxy");
+            if (!(String.IsNullOrEmpty(_Config.ProxyUser) || String.IsNullOrEmpty(_Config.ProxyPassword)))
+            {
+                ICredentials credentials = new NetworkCredential(_Config.ProxyUser, _Config.ProxyPassword);
+                request.Proxy = new WebProxy(_Config.ProxyAddress, false, null, credentials);
+            }
+            else
+            {
+                request.Proxy = new WebProxy(_Config.ProxyAddress);
+            }
         }
 
         public void StartMultiRequest()

--- a/generator/sources/csharp/KalturaClient/KalturaConfiguration.cs
+++ b/generator/sources/csharp/KalturaClient/KalturaConfiguration.cs
@@ -42,6 +42,8 @@ namespace Kaltura
         private int _Timeout = 120000;
         private string _ClientTag = "dotnet:@DATE@";
 		private string _ProxyAddress = "";
+		private string _ProxyUser = null;
+        private string _ProxyPassword = null;
         private WebHeaderCollection _RequestHeaders; 
 
         #endregion
@@ -89,6 +91,16 @@ namespace Kaltura
 			get { return _ProxyAddress; }
 		}
 
+        public string ProxyUser
+        {
+            set { _ProxyUser = value; }
+            get { return _ProxyUser; }
+        }
+        public string ProxyPassword
+        {
+            set { _ProxyPassword = value; }
+            get { return _ProxyPassword; }
+        }
         public WebHeaderCollection RequestHeaders
         {
             set { _RequestHeaders = value; }


### PR DESCRIPTION
One can now configure the proxy user and proxy password in the kaltura configuration and the client will use it when creating the proxy.
