### PR TITLE
Ix 9.2.0 kwidget support head

### DIFF
--- a/alpha/apps/kaltura/modules/extwidget/actions/kwidgetAction.class.php
+++ b/alpha/apps/kaltura/modules/extwidget/actions/kwidgetAction.class.php
@@ -411,7 +411,11 @@ class kwidgetAction extends sfAction
 					KalturaLog::log('Patching took '. (microtime(true) - $startTime));
 						
 					requestUtils::sendCdnHeaders("swf", strlen($wrapper_data), $allowCache ? 60 * 10 : 0, null, true, time());
-					echo $wrapper_data;
+					
+					if ($_SERVER["REQUEST_METHOD"] == "HEAD")
+						header('Content-Length: '.strlen($wrapper_data));
+					else
+						echo $wrapper_data;
 					
 					if ($allowCache)
 					{


### PR DESCRIPTION
add explicit support for HEAD in kwidget

Some browsers seem to send a HEAD request before the GET request. The lack of explicit support for HEAD prevents the terminateDispatch log from appearing and the cache from being populated
