### PR TITLE
Ix 9.2.0 autoloader lock noapc

### DIFF
--- a/infra/KAutoloader.php
+++ b/infra/KAutoloader.php
@@ -272,13 +272,11 @@ class KAutoloader
 			return;
 
 		require_once(__DIR__ . '/general/kLockBase.php');
-		require_once(__DIR__ . '/cache/kApcCacheWrapper.php');
 		
-		$lock = new kLockBase(new kApcCacheWrapper(null), 'KAutoloader');
-		$lock->lock();
+		$lock = kLockBase::grabLocalLock('KAutoloader');
 		
 		// try loading again - some other instance may have created the cache while we waited for the lock
-		if (self::loadClassMapFromCache())
+		if ($lock && self::loadClassMapFromCache())
 		{
 			$lock->unlock();
 			return;
@@ -327,7 +325,8 @@ class KAutoloader
 			}
 		}
 		
-		$lock->unlock();
+		if ($lock)
+			$lock->unlock();
 	}
 
 	public static function loadClassMapFromCache()

--- a/infra/general/kLockBase.php
+++ b/infra/general/kLockBase.php
@@ -71,4 +71,22 @@ class kLockBase
 		if (class_exists('KalturaLog'))
 			KalturaLog::log($msg);
 	}
+
+	/**
+	 * @param string $key
+	 * @return kLockBase
+	 */
+	static public function grabLocalLock($key)
+	{ 
+		if (!function_exists('apc_add'))
+			return null;
+		
+		require_once(__DIR__ . '/../cache/kApcCacheWrapper.php');		// can be called before autoloader
+		
+		$lock = new kLockBase(new kApcCacheWrapper(), $key);
+		if (!$lock->lock())
+			return null;
+		
+		return $lock;
+	}
 }


### PR DESCRIPTION
add support for environments that don't have APC enabled in the autoloader lock
