### PR TITLE
p-166004 recalculate likes script

### DIFF
--- a/alpha/scripts/utils/recalculateLikesForPartnerEntries.php
+++ b/alpha/scripts/utils/recalculateLikesForPartnerEntries.php
@@ -30,6 +30,7 @@ class LikesReCalculator
 	{
 		$entryCriteria = new Criteria();
 		$entryCriteria->add(entryPeer::PARTNER_ID, $this->_partner->getId());
+		$entryCriteria->addDescendingOrderByColumn(entryPeer::INT_ID);
 
 		$entriesCount = entryPeer::doCount($entryCriteria);
 		$this->writeLine('--------------------------------');


### PR DESCRIPTION
The script will go over all partner entries and will re calculate the number of likes.
The script ignores old ranks (the 5 star rank that used anonymousRank API)
