### PR TITLE
Feeds: instead of echo & die, we return kRendererString and populate it

### DIFF
--- a/plugins/content_distribution/providers/ContentDistributionServiceBase.php
+++ b/plugins/content_distribution/providers/ContentDistributionServiceBase.php
@@ -21,7 +21,7 @@ abstract class ContentDistributionServiceBase extends KalturaBaseService {
 		$entries = $this->getEntries($context, null, null);
 		$feed = $this->createFeedGenerator($context);
 		$this->handleEntries($context, $feed, $entries);
-		$this->doneFeedGeneration($context, $feed);
+		return $this->doneFeedGeneration($context, $feed);
 	}
 
 	/**
@@ -171,9 +171,7 @@ abstract class ContentDistributionServiceBase extends KalturaBaseService {
 	 * @param $feed
 	 */
 	protected function doneFeedGeneration ($context, $feed) {
-		header('Content-Type: text/xml');
-		echo $feed->getXml();
-		die;
+		return new kRendererString($feed->getXml(), 'text/xml');
 	}
 }
 

--- a/plugins/content_distribution/providers/att_uverse/services/AttUverseService.php
+++ b/plugins/content_distribution/providers/att_uverse/services/AttUverseService.php
@@ -17,7 +17,7 @@ class AttUverseService extends ContentDistributionServiceBase
 	 * @return file
 	 */
 	public function getFeedAction($distributionProfileId, $hash) {
-		$this->generateFeed(new ContentDistributionServiceContext(), $distributionProfileId, $hash);
+		return $this->generateFeed(new ContentDistributionServiceContext(), $distributionProfileId, $hash);
 	}
 	
 	
@@ -52,6 +52,6 @@ class AttUverseService extends ContentDistributionServiceBase
 	protected function doneFeedGeneration ($context, $feed) {
 		$channelTitle = isset($context->channelTitle) ? $context->channelTitle : $this->profile->getChannelTitle();
 		$feed->setChannelTitle($channelTitle);
-		parent::doneFeedGeneration($context, $feed);
+		return parent::doneFeedGeneration($context, $feed);
 	}
 }

--- a/plugins/content_distribution/providers/avn/services/AvnService.php
+++ b/plugins/content_distribution/providers/avn/services/AvnService.php
@@ -17,7 +17,7 @@ class AvnService extends ContentDistributionServiceBase
 	 */
 	public function getFeedAction($distributionProfileId, $hash)
 	{
-		$this->generateFeed(new ContentDistributionServiceContext(), $distributionProfileId, $hash);
+		return $this->generateFeed(new ContentDistributionServiceContext(), $distributionProfileId, $hash);
 	}
 	
 	public function getProfileClass() {

--- a/plugins/content_distribution/providers/comcast_mrss/services/ComcastMrssService.php
+++ b/plugins/content_distribution/providers/comcast_mrss/services/ComcastMrssService.php
@@ -17,7 +17,7 @@ class ComcastMrssService extends ContentDistributionServiceBase
 	 */
 	public function getFeedAction($distributionProfileId, $hash)
 	{
-		$this->generateFeed(new ContentDistributionServiceContext(), $distributionProfileId, $hash);
+		return $this->generateFeed(new ContentDistributionServiceContext(), $distributionProfileId, $hash);
 	}
 	
 	public function getProfileClass() {

--- a/plugins/content_distribution/providers/doubleclick/services/DoubleClickService.php
+++ b/plugins/content_distribution/providers/doubleclick/services/DoubleClickService.php
@@ -23,7 +23,7 @@ class DoubleClickService extends ContentDistributionServiceBase
 	{
 		$context = new DoubleClickServiceContext($hash, $page, $period, $state, $ignoreScheduling);
 		$context->keepScheduling = !$ignoreScheduling;
-		$this->generateFeed($context, $distributionProfileId, $hash);
+		return $this->generateFeed($context, $distributionProfileId, $hash);
 	}
 	
 	public function getProfileClass() {
@@ -148,7 +148,7 @@ class DoubleClickService extends ContentDistributionServiceBase
 		$entries[] = $entry;
 		$context = new DoubleClickServiceContext($hash);
 		$this->handleEntries($context, $feed, $entries);
-		$this->doneFeedGeneration($context, $feed);
+		return $this->doneFeedGeneration($context, $feed);
 		
 	}
 	

--- a/plugins/content_distribution/providers/ndn/services/NdnService.php
+++ b/plugins/content_distribution/providers/ndn/services/NdnService.php
@@ -17,7 +17,7 @@ class NdnService extends ContentDistributionServiceBase
 	 */
 	public function getFeedAction($distributionProfileId, $hash)
 	{
-		$this->generateFeed(new ContentDistributionServiceContext(), $distributionProfileId, $hash);
+		return $this->generateFeed(new ContentDistributionServiceContext(), $distributionProfileId, $hash);
 	}
 	
 	public function getProfileClass() {
@@ -49,6 +49,6 @@ class NdnService extends ContentDistributionServiceBase
 	
 	protected function doneFeedGeneration ($context, $feed) {
 		$feed->setChannelLastBuildDate($context->lastBuildDate);
-		parent::doneFeedGeneration($context, $feed);
+		return parent::doneFeedGeneration($context, $feed);
 	}
 }

--- a/plugins/content_distribution/providers/synacor_hbo/services/SynacorHboService.php
+++ b/plugins/content_distribution/providers/synacor_hbo/services/SynacorHboService.php
@@ -17,7 +17,7 @@ class SynacorHboService extends ContentDistributionServiceBase
 	 */
 	public function getFeedAction($distributionProfileId, $hash)
 	{
-		$this->generateFeed(new ContentDistributionServiceContext(), $distributionProfileId, $hash); 
+		return $this->generateFeed(new ContentDistributionServiceContext(), $distributionProfileId, $hash); 
 	}
 	
 	public function getProfileClass() {

--- a/plugins/content_distribution/providers/time_warner/services/TimeWarnerService.php
+++ b/plugins/content_distribution/providers/time_warner/services/TimeWarnerService.php
@@ -18,7 +18,7 @@ class TimeWarnerService extends ContentDistributionServiceBase
 	 */
 	public function getFeedAction($distributionProfileId, $hash)
 	{
-		$this->generateFeed(new ContentDistributionServiceContext(), $distributionProfileId, $hash);
+		return $this->generateFeed(new ContentDistributionServiceContext(), $distributionProfileId, $hash);
 	}
 	
 	public function getProfileClass() {

--- a/plugins/content_distribution/providers/tvcom/services/TVComService.php
+++ b/plugins/content_distribution/providers/tvcom/services/TVComService.php
@@ -16,7 +16,7 @@ class TVComService extends ContentDistributionServiceBase
 	 */
 	public function getFeedAction($distributionProfileId, $hash)
 	{
-		$this->generateFeed(new ContentDistributionServiceContext(), $distributionProfileId, $hash);
+		return $this->generateFeed(new ContentDistributionServiceContext(), $distributionProfileId, $hash);
 	}
 	
 	public function getProfileClass() {

--- a/plugins/content_distribution/providers/uverse/services/UverseService.php
+++ b/plugins/content_distribution/providers/uverse/services/UverseService.php
@@ -17,7 +17,7 @@ class UverseService extends ContentDistributionServiceBase
 	 */
 	public function getFeedAction($distributionProfileId, $hash)
 	{
-		$this->generateFeed(new ContentDistributionServiceContext(), $distributionProfileId, $hash);
+		return $this->generateFeed(new ContentDistributionServiceContext(), $distributionProfileId, $hash);
 	}
 	
 	public function getProfileClass() {
@@ -71,6 +71,6 @@ class UverseService extends ContentDistributionServiceBase
 	
 	protected function doneFeedGeneration ($context, $feed) {
 		$feed->setChannelLastBuildDate($context->lastBuildDate);
-		parent::doneFeedGeneration($context, $feed);
+		return parent::doneFeedGeneration($context, $feed);
 	}
 }

--- a/plugins/content_distribution/providers/uverse_click_to_order/services/UverseClickToOrderService.php
+++ b/plugins/content_distribution/providers/uverse_click_to_order/services/UverseClickToOrderService.php
@@ -17,7 +17,7 @@ class UverseClickToOrderService extends ContentDistributionServiceBase
 	 */
 	public function getFeedAction($distributionProfileId, $hash)
 	{
-		$this->generateFeed(new ContentDistributionServiceContext(), $distributionProfileId, $hash);
+		return $this->generateFeed(new ContentDistributionServiceContext(), $distributionProfileId, $hash);
 	}
 	
 	public function getProfileClass() {


### PR DESCRIPTION
up to the API action. This will enable us to return the whole feed from
cache in case nothing changes.
PLAT-295 #time 5h
