### PR TITLE
Show HTML5 v2.0.0 Preview Player in KMC Preview & Embed

### DIFF
--- a/alpha/apps/kaltura/modules/kmc/actions/getuiconfsAction.class.php
+++ b/alpha/apps/kaltura/modules/kmc/actions/getuiconfsAction.class.php
@@ -73,7 +73,13 @@ class getuiconfsAction extends kalturaAction
 		$kdp508_uiconfs = array();
 		if($type == 'player' && $this->partner->getEnable508Players())
 		{
-			$kdp508_uiconfs = kmcUtils::getKdp508PlayerUiconfs();
+			$kdp508_uiconfs = kmcUtils::getPlayerUiconfsByTag('kdp508');
+		}
+
+		// Add HTML5 v2.0.0 Preview Player
+		$v2_preview_players = array();
+		if( $type == 'player'&& PermissionPeer::isValidForPartner(PermissionName::FEATURE_HTML5_V2_PLAYER_PREVIEW, $this->partner_id)){
+			$v2_preview_players = kmcUtils::getPlayerUiconfsByTag('html5_v2_preview');
 		}
 		
 		$merged_list = array();
@@ -83,6 +89,9 @@ class getuiconfsAction extends kalturaAction
 		if(count($kdp508_uiconfs))
 			foreach($kdp508_uiconfs as $uiconf)
 				$merged_list[] = $uiconf;
+		if(count($v2_preview_players))
+			foreach($v2_preview_players as $uiconf)
+				$merged_list[] = $uiconf;			
 		if(count($partner_uiconfs_array))
 			foreach($partner_uiconfs_array as $uiconf)
 				$merged_list[] = $uiconf;

--- a/alpha/apps/kaltura/modules/kmc/actions/kmc3Action.class.php
+++ b/alpha/apps/kaltura/modules/kmc/actions/kmc3Action.class.php
@@ -209,7 +209,7 @@ class kmc3Action extends kalturaAction
 		/** 508 uicinfs **/
 		if($partner->getKmcVersion() == self::CURRENT_KMC_VERSION && $partner->getEnable508Players())
 		{
-			$this->kdp508_players = kmcUtils::getKdp508PlayerUiconfs();
+			$this->kdp508_players = kmcUtils::getPlayerUiconfsByTag('kdp508');
 		}
 		
 		/** partner's preview&embed uiconfs **/

--- a/alpha/apps/kaltura/modules/kmc/lib/kmcUtils.class.php
+++ b/alpha/apps/kaltura/modules/kmc/lib/kmcUtils.class.php
@@ -167,22 +167,25 @@ class kmcUtils
 	  }
 	}
 	
-	public static function getKdp508PlayerUiconfs()
+	public static function getPlayerUiconfsByTag( $tag = null )
 	{
-		$confs = array();
+		if( !$tag ){
+			return array();
+		}
+
 		// implement query to get uiconfs from DB
 		$c = new Criteria();
 		$c->addAnd( uiConfPeer::DISPLAY_IN_SEARCH , mySearchUtils::DISPLAY_IN_SEARCH_KALTURA_NETWORK , Criteria::GREATER_EQUAL );
 		$c->addAnd ( uiConfPeer::PARTNER_ID, 0 );
 		$c->addAnd ( uiConfPeer::STATUS , uiConf::UI_CONF_STATUS_READY );
 		$c->addAnd ( uiConfPeer::OBJ_TYPE , uiConf::UI_CONF_TYPE_KDP3);
-		$c->addAnd ( uiConfPeer::TAGS, 'kdp508', Criteria::LIKE);
+		$c->addAnd ( uiConfPeer::TAGS, $tag, Criteria::LIKE);
 		$c->addAscendingOrderByColumn(uiConfPeer::ID);
 
-		$k508Players = uiConfPeer::doSelect($c);
+		$players = uiConfPeer::doSelect($c);
 
 		$conf_players = array();
-		foreach($k508Players as $conf)
+		foreach($players as $conf)
 		{
 			$conf_players[] = array(
 				'id' => $conf->getId(),


### PR DESCRIPTION
This pull request adds support for displaying v2.0.0 player within the preview & embed.
This pull request is depended on #261 so make sure to update `admin.ini` and add the following lines: 

``` ini
moduls.html5PreviewPlayerV2.enabled = true
moduls.html5PreviewPlayerV2.permissionType = 2
moduls.html5PreviewPlayerV2.label = "Enable HTML5 preview player v2.0.0"
moduls.html5PreviewPlayerV2.permissionName = FEATURE_HTML5_V2_PLAYER_PREVIEW
moduls.html5PreviewPlayerV2.basePermissionType = 
moduls.html5PreviewPlayerV2.basePermissionName = 
moduls.html5PreviewPlayerV2.group = GROUP_ENABLE_DISABLE_FEATURES
```

Also you will need to create a new uiConf on partner 0 with the following properties:

```
name: "HTML5 v2.0.0 Preview Player"
partnerId: 0
objType: 8 (KDP3),
width: 640,
height: 360
config: [SEE THE LINK BELOW]
tags: html5_v2_preview
html5Url: "/html5/html5lib/v2.0.0.rc5/mwEmbedLoader.php"
creationMode: 3 
display_in_search: 2 ( not exposed from API )
```

For the actual config file, use this [Gist](https://gist.github.com/ranyefet/6582960)
### QA Instructions
1. Choose random partner and check "Enable HTML5 preview player v2.0.0" feature
2. Open partner's KMC
3. Open Preview & Embed
4. In "Select Player" you should see: "HTML5 v2.0.0 Preview Player"
