### PR TITLE
plat-239: update exclusive - Throw exception if lock object doesn't

### DIFF
--- a/alpha/apps/kaltura/lib/batch2/kBatchExclusiveLock.class.php
+++ b/alpha/apps/kaltura/lib/batch2/kBatchExclusiveLock.class.php
@@ -399,11 +399,7 @@ class kBatchExclusiveLock
 		
 		$db_lock_object = BatchJobLockPeer::doSelectOne($c);
 		if(!$db_lock_object) {
-			// If another lock exists
-			$db_lock_object = BatchJobLockPeer::retrieveByPk ( $id );
-			if($db_lock_object) {
-				throw new APIException ( APIErrors::UPDATE_EXCLUSIVE_JOB_FAILED , $id,$lockKey->getSchedulerId(), $lockKey->getWorkerId(), $lockKey->getBatchIndex(), print_r ( $db_lock_object , true ));
-			}
+			throw new APIException ( APIErrors::UPDATE_EXCLUSIVE_JOB_FAILED , $id,$lockKey->getSchedulerId(), $lockKey->getWorkerId(), $lockKey->getBatchIndex(), print_r ( $db_lock_object , true ));
 		}
 		
 		if($db_lock_object) {


### PR DESCRIPTION
exist

When a call to update exclusive is made and no batch_job_lock object is
locked on that scheduler - throw an exception.
