### PR TITLE
Sphinx Json: Json fields aren't mandatory

### DIFF
--- a/plugins/metadata/lib/kMetadataManager.php
+++ b/plugins/metadata/lib/kMetadataManager.php
@@ -233,7 +233,6 @@ class kMetadataManager
 		$dataFieldName = MetadataPlugin::getSphinxFieldName(MetadataPlugin::SPHINX_EXPANDER_FIELD_DATA);
 		
 		$searchValues = array();
-		$searchValues[MetadataPlugin::SPHINX_DYNAMIC_ATTRIBUTES] = array();
 		
 		foreach($metadatas as $metadata)
 			$searchValues = self::getDataSearchValues($metadata, $searchValues);


### PR DESCRIPTION
Therefore, if not specified can be null and not [].
