### PR TITLE
fix query to get browser_id instead of os_id

### DIFF
--- a/alpha/apps/kaltura/lib/reports/browsers/browsers_count_by_app.sql
+++ b/alpha/apps/kaltura/lib/reports/browsers/browsers_count_by_app.sql
@@ -3,7 +3,7 @@ SELECT
 FROM (
 	SELECT b.id id
 	FROM 
-		(SELECT os_id
+		(SELECT browser_id
 		FROM dwh_hourly_events_context_app_devices ev, dwh_dim_applications ap
 			WHERE
 				{OBJ_ID_CLAUSE}


### PR DESCRIPTION
This pull request fix PLAT 289 (fix SQL query)
