### PR TITLE
Revert the return of last modified in the header

### DIFF
--- a/alpha/apps/kaltura/lib/renderers/kRendererDumpFile.php
+++ b/alpha/apps/kaltura/lib/renderers/kRendererDumpFile.php
@@ -17,16 +17,13 @@ class kRendererDumpFile implements kRendererBase
 	protected $fileData;
 	protected $mimeType;
 	protected $maxAge;
-	protected $lastModified;
 	protected $xSendFileAllowed;
 
 	public function __construct($filePath, $mimeType, $xSendFileAllowed, $maxAge = 8640000, $limitFileSize = 0)
 	{
-		clearstatcache();
 		$this->filePath = $filePath;
 		$this->mimeType = $mimeType;
 		$this->maxAge = $maxAge;
-		$this->lastModified = filemtime($filePath);
 		$this->fileExt = pathinfo($filePath, PATHINFO_EXTENSION);
 		if ($limitFileSize)
 		{
@@ -35,6 +32,7 @@ class kRendererDumpFile implements kRendererBase
 		}
 		else
 		{
+			clearstatcache();
 			$this->fileSize = kFile::fileSize($filePath);
 			$this->xSendFileAllowed = $xSendFileAllowed;
 		}
@@ -59,7 +57,7 @@ class kRendererDumpFile implements kRendererBase
 		else
 			list($rangeFrom, $rangeTo, $rangeLength) = infraRequestUtils::handleRangeRequest($this->fileSize);
 
-		infraRequestUtils::sendCdnHeaders($this->fileExt, $rangeLength, $this->maxAge, $this->mimeType, false, $this->lastModified);
+		infraRequestUtils::sendCdnHeaders($this->fileExt, $rangeLength, $this->maxAge, $this->mimeType);
 
 		// return "Accept-Ranges: bytes" header. Firefox looks for it when playing ogg video files
 		// upon detecting this header it cancels its original request and starts sending byte range requests


### PR DESCRIPTION
This was reverted due to issues we had with Akamai when trying to pull
the content from us
