### PR TITLE
Set curl options CURLOPT_SSL_VERIFYHOST to use value 1 instead of 2

### DIFF
--- a/infra/general/KCurlWrapper.class.php
+++ b/infra/general/KCurlWrapper.class.php
@@ -160,7 +160,7 @@ class KCurlWrapper
 		if(!$params || !isset($params->curlVerifySSL) || !$params->curlVerifySSL)
 		{
 			curl_setopt($this->ch, CURLOPT_SSL_VERIFYPEER, false);
-			curl_setopt($this->ch, CURLOPT_SSL_VERIFYHOST, 2);
+			curl_setopt($this->ch, CURLOPT_SSL_VERIFYHOST, 1);
 		}
 	}
 


### PR DESCRIPTION
Explanation:1 to check the existence of a common name in the SSL peer
certificate. 2 to check the existence of a common name and also verify
that it matches the host name provided.
