### PR TITLE
SUP-987 #comment Redirect to https instead of just dying

### DIFF
--- a/alpha/apps/kaltura/modules/kmc/actions/kmc4Action.class.php
+++ b/alpha/apps/kaltura/modules/kmc/actions/kmc4Action.class.php
@@ -42,7 +42,7 @@ class kmc4Action extends kalturaAction
 		// Check for forced HTTPS
 		$force_ssl = PermissionPeer::isValidForPartner(PermissionName::FEATURE_KMC_ENFORCE_HTTPS, $this->partner_id);
 		if( $force_ssl && (!isset($_SERVER['HTTPS']) || $_SERVER['HTTPS'] != 'on') ) {
-			$this->redirect( infraRequestUtils::PROTOCOL_HTTPS . "://" . $_SERVER['SERVER_NAME'] . $_SERVER["REQUEST_URI"]);
+			header( "Location: " . infraRequestUtils::PROTOCOL_HTTPS . "://" . $_SERVER['SERVER_NAME'] . $_SERVER["REQUEST_URI"] );
 			die();
 		}
 		/** END - check parameters and verify user is logged-in **/


### PR DESCRIPTION
When account is configured with https access only redirect to https url
instead of dying.
