### PR TITLE
SUP-801 #comment Save caption asset item after striping invalid chars

### DIFF
--- a/plugins/content/caption/search/services/CaptionAssetItemService.php
+++ b/plugins/content/caption/search/services/CaptionAssetItemService.php
@@ -76,6 +76,11 @@ class CaptionAssetItemService extends KalturaBaseService
     		$content = '';
     		foreach ($itemData['content'] as $curChunk)
     			$content .= $curChunk['text'];
+    			
+    		//Make sure there are no invalid chars in the caption asset items to avoid braking the search request by providing invalid XML
+    		$content = kString::stripUtf8InvalidChars($content);
+    		$content = kXml::stripXMLInvalidChars($content);
+    		
     		$item->setContent($content);
     		$item->save();
     	}


### PR DESCRIPTION
This was added so the save is done without any illegal characters that
would have caused the captionAssetItem->search() to fail when building
the XML response
