### PR TITLE
make the secrets cache multi-layered

### DIFF
--- a/alpha/apps/kaltura/lib/cache/kCacheManager.php
+++ b/alpha/apps/kaltura/lib/cache/kCacheManager.php
@@ -21,6 +21,7 @@ class kCacheManager
 	const CACHE_TYPE_LOCK_KEYS = 'lockKeys';
 	const CACHE_TYPE_API_WARMUP = 'apiWarmup';
 	const CACHE_TYPE_KWIDGET_SWF = 'kwidgetSwf';
+	const CACHE_TYPE_PARTNER_SECRETS = 'partnerSecrets';
 	
 	protected static $caches = array();
 	

--- a/alpha/apps/kaltura/lib/webservices/kSessionUtils.class.php
+++ b/alpha/apps/kaltura/lib/webservices/kSessionUtils.class.php
@@ -683,8 +683,15 @@ class ks extends kSessionBase
 
 		$ksVersion = $partner->getKSVersion();
 
-		if (function_exists('apc_store'))
-			apc_store(self::SECRETS_CACHE_PREFIX . $partnerId, array($partner->getAdminSecret(), $partner->getSecret(), $ksVersion));
+		$cacheSections = kCacheManager::getCacheSectionNames(kCacheManager::CACHE_TYPE_PARTNER_SECRETS);
+		foreach ($cacheSections as $cacheSection)
+		{
+			$cacheStore = kCacheManager::getCache($cacheSection);
+			if (!$cacheStore)
+				continue;
+			
+			$cacheStore->set(self::SECRETS_CACHE_PREFIX . $partnerId, array($partner->getAdminSecret(), $partner->getSecret(), $ksVersion));
+		}
 		
 		return array($ksVersion, $partner->getAdminSecret());
 	}

--- a/configurations/cache.ini
+++ b/configurations/cache.ini
@@ -41,3 +41,4 @@ apiV3Feed = filesystemApiV3Feed
 apiExtraFieldsCache = apc
 apiWarmup = apc
 kwidgetSwf = memcacheLocal
+partnerSecrets = apc 


### PR DESCRIPTION
Keeps the API cache functional even when APC runs out of space.

Deployment instructions:
Edit cache.ini and add the following:
- QA - partnerSecrets = apc
- PROD - partnerSecrets = apc,memcacheData (already committed)
