### PR TITLE
Return the requested version in serveFlavor

### DIFF
--- a/alpha/apps/kaltura/lib/storage/kUrlManager.php
+++ b/alpha/apps/kaltura/lib/storage/kUrlManager.php
@@ -327,7 +327,7 @@ class kUrlManager
 		$partnerFlavorVersion = $partner->getCacheFlavorVersion();
 		$entryFlavorVersion = $entry->getCacheFlavorVersion();
 
-		return (!$flavorAssetVersion || $flavorAssetVersion == 1 ? '' : "/v/$flavorAssetVersion").
+		return (!$flavorAssetVersion ? '' : "/v/$flavorAssetVersion").
 			($partnerFlavorVersion ? "/pv/$partnerFlavorVersion" : '') .
 			($entryFlavorVersion ? "/ev/$entryFlavorVersion" : '');
 	}

--- a/alpha/apps/kaltura/modules/extwidget/actions/serveFlavorAction.class.php
+++ b/alpha/apps/kaltura/modules/extwidget/actions/serveFlavorAction.class.php
@@ -45,7 +45,11 @@ class serveFlavorAction extends kalturaAction
 		myPartnerUtils::blockInactivePartner($flavorAsset->getPartnerId());
 		myPartnerUtils::enforceDelivery($flavorAsset->getPartnerId());
 		
-		$syncKey = $flavorAsset->getSyncKey(flavorAsset::FILE_SYNC_FLAVOR_ASSET_SUB_TYPE_ASSET);
+		$version = $this->getRequestParameter( "v" );
+		if (!$version)
+			$version = $flavorAsset->getVersion();
+		
+		$syncKey = $flavorAsset->getSyncKey(flavorAsset::FILE_SYNC_FLAVOR_ASSET_SUB_TYPE_ASSET, $version);
 		if (!kFileSyncUtils::file_exists($syncKey, false))
 		{
 			list($fileSync, $local) = kFileSyncUtils::getReadyFileSyncForKey($syncKey, true, false);
@@ -94,7 +98,7 @@ class serveFlavorAction extends kalturaAction
 					PermissionPeer::isValidForPartner(PermissionName::FEATURE_ACCURATE_SERVE_CLIPPING, $flavorAsset->getPartnerId()))
 				{
 					$contentPath = myContentStorage::getFSContentRootPath();
-					$tempClipName = $flavorAsset->getVersion() . '_' . $clipTo . '.mp4';
+					$tempClipName = $version . '_' . $clipTo . '.mp4';
 					$tempClipPath = $contentPath . myContentStorage::getGeneralEntityPath("entry/tempclip", $flavorAsset->getIntId(), $flavorAsset->getId(), $tempClipName);
 					if (!file_exists($tempClipPath))
 					{


### PR DESCRIPTION
Instead of always returning the latest version. This fixes a problem where the content-length of the URL changes while the CDN is pulling the file, causing the CDN to return error 404
