### PR TITLE
PLAT-390 #comment Fix is live returning false on valid stream

### DIFF
--- a/api_v3/services/LiveStreamService.php
+++ b/api_v3/services/LiveStreamService.php
@@ -340,10 +340,15 @@ class LiveStreamService extends KalturaEntryService
 	    $data = curl_exec($ch);  
 	    $httpcode = curl_getinfo($ch, CURLINFO_HTTP_CODE);  
 	    $contentType = curl_getinfo($ch, CURLINFO_CONTENT_TYPE);
-	    curl_close($ch);  
+	    curl_close($ch);
+
+	    $contentTypeToCheck = strstr($contentType, ";", true);
+	    if(!$contentTypeToCheck)
+	    	$contentTypeToCheck = $contentType;
+	    
 	    if($data && $httpcode>=200 && $httpcode<300)
 	    {
-	        return in_array($contentType, $contentTypeToReturn) ? $data : true;
+	        return in_array(trim($contentTypeToCheck), $contentTypeToReturn) ? $data : true;
 	    }  
 	    else 
 	        return false;  
@@ -397,6 +402,7 @@ class LiveStreamService extends KalturaEntryService
 	 */
 	private function checkIfValidUrl($urlToCheck, $parentURL)
 	{
+		$urlToCheck = trim($urlToCheck);
 		if(!filter_var($urlToCheck, FILTER_VALIDATE_URL, FILTER_FLAG_PATH_REQUIRED))
 		{
 			$urlToCheck = dirname($parentURL) . DIRECTORY_SEPARATOR . $urlToCheck;

--- a/configurations/base.ini
+++ b/configurations/base.ini
@@ -259,6 +259,7 @@ audio_file_ext[]=amr
 
 hls_live_stream_content_type[]=application/vnd.apple.mpegurl 
 hls_live_stream_content_type[]=application/x-mpegURL
+hls_live_stream_content_type[]=audio/x-mpegURL
 
 kmc_chunked_category_load_threshold = 1000
 


### PR DESCRIPTION
Added support for new hls live stream content type "audio/x-mpegURL" and
strip invalid chars from stream url
