### PR TITLE
lowercase all invalidation key params

### DIFF
--- a/alpha/apps/kaltura/lib/cache/kApiCache.php
+++ b/alpha/apps/kaltura/lib/cache/kApiCache.php
@@ -23,7 +23,7 @@ class kApiCache extends kApiCacheBase
 	const SUFFIX_RULES = '.rules';
 	const SUFFIX_LOG = '.log';
 
-	const CACHE_VERSION = '4';
+	const CACHE_VERSION = '5';
 
 	// cache modes
 	const CACHE_MODE_ANONYMOUS = 1;				// anonymous caching should be performed - the cached response will not be associated with any conditions

--- a/alpha/apps/kaltura/lib/cache/kQueryCache.php
+++ b/alpha/apps/kaltura/lib/cache/kQueryCache.php
@@ -62,7 +62,7 @@ class kQueryCache
 	const QUERY_DB_MASTER = 1;
 	const QUERY_DB_SLAVE = 2;
 	
-	const CACHE_VERSION = '1';
+	const CACHE_VERSION = '2';
 	
 	protected static $s_memcacheKeys = null;
 	protected static $s_memcacheQueries = null;
@@ -171,7 +171,8 @@ class kQueryCache
 				{
 					foreach ($values as $value)
 					{
-						$newInvalidationKeys[] = self::replaceVariable($invalidationKey, str_replace(' ', '_', $value));
+						$value = strtolower(str_replace(' ', '_', $value));
+						$newInvalidationKeys[] = self::replaceVariable($invalidationKey, $value);
 					}
 				}
 				$invalidationKeys = $newInvalidationKeys;

--- a/alpha/lib/model/FileSync.php
+++ b/alpha/lib/model/FileSync.php
@@ -122,7 +122,7 @@ class FileSync extends BaseFileSync
 
 	public function getCacheInvalidationKeys()
 	{
-		return array("fileSync:id=".$this->getId(), "fileSync:objectId=".$this->getObjectId());
+		return array("fileSync:id=".strtolower($this->getId()), "fileSync:objectId=".strtolower($this->getObjectId()));
 	}
 	
 	/* (non-PHPdoc)

--- a/alpha/lib/model/KuserToUserRole.php
+++ b/alpha/lib/model/KuserToUserRole.php
@@ -17,7 +17,7 @@ class KuserToUserRole extends BaseKuserToUserRole {
 
 	public function getCacheInvalidationKeys()
 	{
-		return array("kuserToUserRole:kuserId=".$this->getKuserId());
+		return array("kuserToUserRole:kuserId=".strtolower($this->getKuserId()));
 	}
 	
 } // KuserToUserRole

--- a/alpha/lib/model/Partner.php
+++ b/alpha/lib/model/Partner.php
@@ -1395,7 +1395,7 @@ class Partner extends BasePartner
 	
 	public function getCacheInvalidationKeys()
 	{
-		return array("partner:id=".$this->getId());
+		return array("partner:id=".strtolower($this->getId()));
 	}	
 	
 	public function getWidgetSessionRoleId() {

--- a/alpha/lib/model/Permission.php
+++ b/alpha/lib/model/Permission.php
@@ -209,6 +209,6 @@ class Permission extends BasePermission
 	
 	public function getCacheInvalidationKeys()
 	{
-		return array("permission:partnerId=".$this->getPartnerId());
+		return array("permission:partnerId=".strtolower($this->getPartnerId()));
 	}
 } // Permission

--- a/alpha/lib/model/PermissionPeer.php
+++ b/alpha/lib/model/PermissionPeer.php
@@ -336,7 +336,7 @@ class PermissionPeer extends BasePermissionPeer
 	
 	public static function getCacheInvalidationKeys()
 	{
-		return array(array("permission:partnerId=%s", self::PARTNER_ID));
+		return array(array("permission:partnerId=%s", self::PARTNER_ID));		
 	}
 } // PermissionPeer
 

--- a/alpha/lib/model/PermissionToPermissionItem.php
+++ b/alpha/lib/model/PermissionToPermissionItem.php
@@ -17,6 +17,6 @@ class PermissionToPermissionItem extends BasePermissionToPermissionItem {
 
 	public function getCacheInvalidationKeys()
 	{
-		return array("permissionToPermissionItem:permissionId=".$this->getPermissionId());
+		return array("permissionToPermissionItem:permissionId=".strtolower($this->getPermissionId()));
 	}
 } // PermissionToPermissionItem

--- a/alpha/lib/model/StorageProfile.php
+++ b/alpha/lib/model/StorageProfile.php
@@ -171,7 +171,7 @@ class StorageProfile extends BaseStorageProfile
 	
 	public function getCacheInvalidationKeys()
 	{
-		return array("storageProfile:id=".$this->getId(), "storageProfile:partnerId=".$this->getPartnerId());
+		return array("storageProfile:id=".strtolower($this->getId()), "storageProfile:partnerId=".strtolower($this->getPartnerId()));
 	}
 	
 	/**

--- a/alpha/lib/model/UploadToken.php
+++ b/alpha/lib/model/UploadToken.php
@@ -92,6 +92,6 @@ class UploadToken extends BaseUploadToken
 	}
 	public function getCacheInvalidationKeys()
 	{
-		return array("uploadToken:id=".$this->getId());
+		return array("uploadToken:id=".strtolower($this->getId()));
 	}
 }

--- a/alpha/lib/model/UserRole.php
+++ b/alpha/lib/model/UserRole.php
@@ -98,6 +98,6 @@ class UserRole extends BaseUserRole
 	
 	public function getCacheInvalidationKeys()
 	{
-		return array("userRole:id=".$this->getId());
+		return array("userRole:id=".strtolower($this->getId()));
 	}
 } // UserRole

--- a/alpha/lib/model/accessControl.php
+++ b/alpha/lib/model/accessControl.php
@@ -258,6 +258,6 @@ class accessControl extends BaseaccessControl
 	
 	public function getCacheInvalidationKeys()
 	{
-		return array("accessControl:id=".$this->getId());
+		return array("accessControl:id=".strtolower($this->getId()));
 	}
 }

--- a/alpha/lib/model/asset.php
+++ b/alpha/lib/model/asset.php
@@ -557,7 +557,7 @@ class asset extends Baseasset implements ISyncableFile
 
 	public function getCacheInvalidationKeys()
 	{
-		return array("flavorAsset:id=".$this->getId(), "flavorAsset:entryId=".$this->getEntryId());
+		return array("flavorAsset:id=".strtolower($this->getId()), "flavorAsset:entryId=".strtolower($this->getEntryId()));
 	}
 	
 	public function getPartnerDescription()			{return $this->getFromCustomData(self::CUSTOM_DATA_FIELD_PARTNER_DESCRIPTION);}

--- a/alpha/lib/model/assetParams.php
+++ b/alpha/lib/model/assetParams.php
@@ -197,7 +197,7 @@ class assetParams extends BaseassetParams
 	}
 	public function getCacheInvalidationKeys()
 	{
-		return array("flavorParams:id=".$this->getId(), "flavorParams:partnerId=".$this->getPartnerId());
+		return array("flavorParams:id=".strtolower($this->getId()), "flavorParams:partnerId=".strtolower($this->getPartnerId()));
 	}
 	
 	public function setSourceAssetParamsIds($sourceAssetParamsIds)

--- a/alpha/lib/model/assetParamsOutput.php
+++ b/alpha/lib/model/assetParamsOutput.php
@@ -132,7 +132,7 @@ class assetParamsOutput extends BaseassetParamsOutput
 	}
 	public function getCacheInvalidationKeys()
 	{
-		return array("flavorParamsOutput:id=".$this->getId(), "flavorParamsOutput:flavorAssetId=".$this->getFlavorAssetId());
+		return array("flavorParamsOutput:id=".strtolower($this->getId()), "flavorParamsOutput:flavorAssetId=".strtolower($this->getFlavorAssetId()));
 	}
 	
 	public function setSourceAssetParamsIds($sourceAssetParamsIds)

--- a/alpha/lib/model/category.php
+++ b/alpha/lib/model/category.php
@@ -762,7 +762,7 @@ class category extends Basecategory implements IIndexable
 
 	public function getCacheInvalidationKeys()
 	{
-		return array("category:id=".$this->getId(), "category:partnerId=".$this->getPartnerId());
+		return array("category:id=".strtolower($this->getId()), "category:partnerId=".strtolower($this->getPartnerId()));
 	}
 	
 	/**

--- a/alpha/lib/model/categoryEntry.php
+++ b/alpha/lib/model/categoryEntry.php
@@ -176,6 +176,6 @@ class categoryEntry extends BasecategoryEntry {
 	
 	public function getCacheInvalidationKeys()
 	{
-		return array("categoryEntry:entryId=".$this->getEntryId());
+		return array("categoryEntry:entryId=".strtolower($this->getEntryId()));
 	}
 } // categoryEntry

--- a/alpha/lib/model/conversionProfile2.php
+++ b/alpha/lib/model/conversionProfile2.php
@@ -250,6 +250,6 @@ class conversionProfile2 extends BaseconversionProfile2 implements ISyncableFile
 	}
 	public function getCacheInvalidationKeys()
 	{
-		return array("conversionProfile2:partnerId=".$this->getPartnerId());
+		return array("conversionProfile2:partnerId=".strtolower($this->getPartnerId()));
 	}
 }

--- a/alpha/lib/model/entry.php
+++ b/alpha/lib/model/entry.php
@@ -2852,7 +2852,7 @@ class entry extends Baseentry implements ISyncableFile, IIndexable, IOwnable
 	
 	public function getCacheInvalidationKeys()
 	{
-		return array("entry:id=".$this->getId(), "entry:partnerId=".$this->getPartnerId());
+		return array("entry:id=".strtolower($this->getId()), "entry:partnerId=".strtolower($this->getPartnerId()));
 	}
 	
 	/**

--- a/alpha/lib/model/entryPeer.php
+++ b/alpha/lib/model/entryPeer.php
@@ -627,7 +627,7 @@ class entryPeer extends BaseentryPeer
 
 	public static function getCacheInvalidationKeys()
 	{
-		return array(array("entry:id=%s", self::ID), array("entry:partnerId=%s", self::PARTNER_ID));
+		return array(array("entry:id=%s", self::ID), array("entry:partnerId=%s", self::PARTNER_ID));		
 	}
 
 	/* (non-PHPdoc)

--- a/alpha/lib/model/flavorParamsConversionProfile.php
+++ b/alpha/lib/model/flavorParamsConversionProfile.php
@@ -36,6 +36,6 @@ class flavorParamsConversionProfile extends BaseflavorParamsConversionProfile
 	
 	public function getCacheInvalidationKeys()
 	{
-		return array("flavorParamsConversionProfile:flavorParamsId=".$this->getFlavorParamsId().",conversionProfileId=".$this->getConversionProfileId(), "flavorParamsConversionProfile:conversionProfileId=".$this->getConversionProfileId());
+		return array("flavorParamsConversionProfile:flavorParamsId=".strtolower($this->getFlavorParamsId()).",conversionProfileId=".strtolower($this->getConversionProfileId()), "flavorParamsConversionProfile:conversionProfileId=".strtolower($this->getConversionProfileId()));
 	}
 }

--- a/alpha/lib/model/invalidSession.php
+++ b/alpha/lib/model/invalidSession.php
@@ -17,6 +17,6 @@ class invalidSession extends BaseinvalidSession {
 
 	public function getCacheInvalidationKeys()
 	{
-		return array("invalidSession:ks=".$this->getKs());
+		return array("invalidSession:ks=".strtolower($this->getKs()));
 	}
 } // invalidSession

--- a/alpha/lib/model/kuser.php
+++ b/alpha/lib/model/kuser.php
@@ -1098,7 +1098,7 @@ class kuser extends Basekuser implements IIndexable
 
 	public function getCacheInvalidationKeys()
 	{
-		return array("kuser:id=".$this->getId(), "kuser:partnerId=".$this->getPartnerId().",puserid=".$this->getPuserId());
+		return array("kuser:id=".strtolower($this->getId()), "kuser:partnerId=".strtolower($this->getPartnerId()).",puserid=".strtolower($this->getPuserId()));
 	}
 	
 	/* (non-PHPdoc)

--- a/alpha/lib/model/mediaInfo.php
+++ b/alpha/lib/model/mediaInfo.php
@@ -15,6 +15,6 @@ class mediaInfo extends BasemediaInfo
 	 
 	public function getCacheInvalidationKeys()
 	{
-		return array("mediaInfo:flavorAssetId=".$this->getFlavorAssetId());
+		return array("mediaInfo:flavorAssetId=".strtolower($this->getFlavorAssetId()));
 	}
 }

--- a/alpha/lib/model/uiConf.php
+++ b/alpha/lib/model/uiConf.php
@@ -681,7 +681,7 @@ class uiConf extends BaseuiConf implements ISyncableFile
 
 	public function getCacheInvalidationKeys()
 	{
-		return array("uiConf:id=".$this->getId(), "uiConf:partnerId=".$this->getPartnerId());
+		return array("uiConf:id=".strtolower($this->getId()), "uiConf:partnerId=".strtolower($this->getPartnerId()));
 	}
 	
 	private function shouldSetContent()

--- a/alpha/lib/model/widget.php
+++ b/alpha/lib/model/widget.php
@@ -262,7 +262,7 @@ class widget extends Basewidget
 
 	public function getCacheInvalidationKeys()
 	{
-		return array("widget:id=".$this->getId());
+		return array("widget:id=".strtolower($this->getId()));
 	}
 	
 	public function setPrivacyContext ( $v )	{		$this->putInCustomData ( "privacyContext" , $v );	}

--- a/deployment/base/scripts/createQueryCacheTriggers.php
+++ b/deployment/base/scripts/createQueryCacheTriggers.php
@@ -61,7 +61,7 @@ function generateInvalidationKeyCode($invalidationKey)
 				$peerArrayElems[0] .= "%s";
 				$peerArrayElems[] = "self::" . strtoupper($curStr);
 				$curStrUpperCamel = str_replace(' ', '', ucwords(str_replace('_', ' ', $curStr)));
-				$objArrayElems[] = '$this->get' . $curStrUpperCamel . '()';
+				$objArrayElems[] = 'strtolower($this->get' . $curStrUpperCamel . '())';
 			}
 		}
 		
@@ -90,7 +90,7 @@ function generateInvalidationKeyCode($invalidationKey)
 		return array($peerKeys);		
 	}";
 	
-	return array($objFunc, $peerFunc);
+	return array(str_replace("\n", PHP_EOL, $objFunc), str_replace("\n", PHP_EOL, $peerFunc));
 }
 
 function getFuncEnd($fileData, $funcPos)
@@ -206,7 +206,7 @@ function buildTriggerBody($invalidationKey, $triggerType)
 				$curKey[] = $curStr;
 			else 
 			{
-				$curStrValue = "REPLACE($curStr,' ','_')";
+				$curStrValue = "LOWER(REPLACE($curStr,' ','_'))";
 				$curKey[] = "IF($curStr IS NULL,'',$curStrValue)";
 				$keyChangeCondition[] = str_replace('@OBJ@', 'OLD', $curStr) . ' <> ' . str_replace('@OBJ@', 'NEW', $curStr);
 			}

--- a/plugins/content_distribution/lib/model/DistributionProfile.php
+++ b/plugins/content_distribution/lib/model/DistributionProfile.php
@@ -445,6 +445,6 @@ abstract class DistributionProfile extends BaseDistributionProfile implements IS
 	
 	public function getCacheInvalidationKeys()
 	{
-		return array("distributionProfile:id=".$this->getId());
+		return array("distributionProfile:id=".strtolower($this->getId()));
 	}
 } // DistributionProfile

--- a/plugins/content_distribution/lib/model/EntryDistribution.php
+++ b/plugins/content_distribution/lib/model/EntryDistribution.php
@@ -483,7 +483,7 @@ class EntryDistribution extends BaseEntryDistribution implements IIndexable, ISy
 	}
 	public function getCacheInvalidationKeys()
 	{
-		return array("entryDistribution:entryId=".$this->getEntryId());
+		return array("entryDistribution:entryId=".strtolower($this->getEntryId()));
 	}
 	
 	public function getSearchIndexFieldsEscapeType($fieldName)

--- a/plugins/cue_points/base/lib/model/CuePoint.php
+++ b/plugins/cue_points/base/lib/model/CuePoint.php
@@ -322,7 +322,7 @@ abstract class CuePoint extends BaseCuePoint implements IIndexable
 	
 	public function getCacheInvalidationKeys()
 	{
-		return array("cuePoint:id=".$this->getId(), "cuePoint:entryId=".$this->getEntryId());
+		return array("cuePoint:id=".strtolower($this->getId()), "cuePoint:entryId=".strtolower($this->getEntryId()));
 	}
 	
 	public function getSearchIndexFieldsEscapeType($fieldName)

--- a/plugins/drop_folder/lib/model/DropFolder.php
+++ b/plugins/drop_folder/lib/model/DropFolder.php
@@ -216,7 +216,7 @@ class DropFolder extends BaseDropFolder
 	
 	public function getCacheInvalidationKeys()
 	{
-		return array("dropFolder:id=".$this->getId(), "dropFolder:dc=".$this->getDc());
+		return array("dropFolder:id=".strtolower($this->getId()), "dropFolder:dc=".strtolower($this->getDc()));
 	}
 	
 	/**

--- a/plugins/drop_folder/lib/model/DropFolderFile.php
+++ b/plugins/drop_folder/lib/model/DropFolderFile.php
@@ -57,7 +57,7 @@ class DropFolderFile extends BaseDropFolderFile
 		
 	public function getCacheInvalidationKeys()
 	{
-		return array("dropFolderFile:id=".$this->getId(), "dropFolderFile:fileName=".$this->getFileName(), "dropFolderFile:dropFolderId=".$this->getDropFolderId());
+		return array("dropFolderFile:id=".strtolower($this->getId()), "dropFolderFile:fileName=".strtolower($this->getFileName()), "dropFolderFile:dropFolderId=".strtolower($this->getDropFolderId()));
 	}
 	
 	public function setStatus($v)

--- a/plugins/metadata/lib/model/Metadata.php
+++ b/plugins/metadata/lib/model/Metadata.php
@@ -157,6 +157,6 @@ class Metadata extends BaseMetadata implements ISyncableFile
 
 	public function getCacheInvalidationKeys()
 	{
-		return array("metadata:objectId=".$this->getObjectId());
+		return array("metadata:objectId=".strtolower($this->getObjectId()));
 	}
 } // Metadata

--- a/plugins/metadata/lib/model/MetadataProfile.php
+++ b/plugins/metadata/lib/model/MetadataProfile.php
@@ -190,6 +190,6 @@ class MetadataProfile extends BaseMetadataProfile implements ISyncableFile
 	
 	public function getCacheInvalidationKeys()
 	{
-		return array("metadataProfile:id=".$this->getId(), "metadataProfile:partnerId=".$this->getPartnerId());
+		return array("metadataProfile:id=".strtolower($this->getId()), "metadataProfile:partnerId=".strtolower($this->getPartnerId()));
 	}
 } // MetadataProfile

--- a/plugins/metadata/lib/model/MetadataProfileField.php
+++ b/plugins/metadata/lib/model/MetadataProfileField.php
@@ -21,6 +21,6 @@ class MetadataProfileField extends BaseMetadataProfileField {
 	
 	public function getCacheInvalidationKeys()
 	{
-		return array("metadataProfileField:metadataProfileId=".$this->getMetadataProfileId());
+		return array("metadataProfileField:metadataProfileId=".strtolower($this->getMetadataProfileId()));
 	}
 } // MetadataProfileField


### PR DESCRIPTION
required since memcache cache are case-sensitive while the database is
not. this has no effect for most peers since the ids are integers, but
it's a must for peers such as kuser & drop folder file
