### PR TITLE
Supports concurrent nbrplayer sessions

### DIFF
--- a/plugins/transcoding/webex_nbrplayer/lib/KOperationEngineWebexNbrplayer.php
+++ b/plugins/transcoding/webex_nbrplayer/lib/KOperationEngineWebexNbrplayer.php
@@ -102,6 +102,61 @@ public function buildCfgFile($inputFile, $outputFile, $format=null,
 		parent::configure($data, $job);
 		KalturaLog::info("taskConfig-->".print_r(KBatchBase::$taskConfig,true)."\ndata->".print_r($data,true));
 	}
+	
+	public function operate(kOperator $operator = null, $inFilePath, $configFilePath = null)
+	{
+			/*
+			 * Creating unique output folder for nbrPlay/Webex sessions.
+			 * This is required in order to support concurrent conversion sessions,
+			 * because the nbrPlay tool generates temp files with the same name.
+			 * Upon completion move the generated file into the 'regular' outFilePath
+			 */
+		$saveOutPath = $this->outFilePath;	
+		
+		$path_parts = pathinfo($this->outFilePath);
+		$outDir = realpath($path_parts['dirname']);
+			/*
+			 * The temp folder name
+			 */
+		$tempFolder = "$outDir/".$path_parts['basename'].".webex_temp_folder";
+		$tempOutPath = "$tempFolder/".$path_parts['basename'];
+		if(!file_exists($tempFolder)){
+			$oldUmask = umask(00);
+			$result = @mkdir($tempFolder, 0777, true);
+			umask($oldUmask);
+		}
+			/*
+			 * Switch to temp forlder
+			 */
+		$this->outFilePath = $tempOutPath;
+		$rv = parent::operate($operator, $inFilePath, $configFilePath);
+		
+			/*
+			 * Restore the original
+			 */
+		if(file_exists($tempOutPath)){
+			$outFilelist = kFile::dirList($tempFolder);
+			if(isset($outFilelist) && count($outFilelist)>0){
+				foreach ($outFilelist as $fileName){
+					for($tries=0; $tries<5; $tries++){
+						$toFile = "$outDir/".pathinfo($fileName, PATHINFO_BASENAME);
+						$rv = kFile::moveFile($fileName, $toFile);
+						if(!file_exists($fileName)){
+							break;
+						}
+						KalturaLog::err("Failed to move ($fileName) to ($toFile)");
+						Sleep(60);
+					}
+					Sleep(60);
+				}
+				rmdir($tempFolder);
+			}
+		}
+		$this->outFilePath = $saveOutPath;
+		
+		return $rv;
+	}
+		
 }
 
 		


### PR DESCRIPTION
Uses python script to overcome webex/nbrplay restriction to run just a single nbrplay instance. The script uses Windows ability to create number of desktop objects, each desktop can run a single nbrplay instance.

Additional required updates:
- runUniqueDesktop.py - python script
- windows.workers.ini - to change the params.webexNbrplayerCmd assignment to:
  params.webexNbrplayerCmd                            = "c:\Python27\python.exe c:\opt\kaltura\runUniqueDesktop.py C:\ProgramData\webex\WebEx\500\nbrplay.exe"

Test notes;
- Sanity run on all windows transcoding flows:
  -- Webex
  -- SmoothStreaming
  -- WMV
