### PR TITLE
SUP-1046 #comment Remove redundant "/" when playing via rtmp

### DIFF
--- a/alpha/apps/kaltura/lib/storage/kUrlManager.php
+++ b/alpha/apps/kaltura/lib/storage/kUrlManager.php
@@ -254,7 +254,7 @@ class kUrlManager
 			}
 			if (($this->extention && strtolower($this->extention) != 'flv' ||
 				$this->containerFormat && strtolower($this->containerFormat) != 'flash video'))
-				$url = "mp4:$url";
+				$url = "mp4:".ltrim($url,'/');
 				
 			// when serving files directly via RTMP fms doesnt expect to get the file extension
 			$url = str_replace('.mp4', '', str_replace('.flv','',$url));
@@ -360,7 +360,7 @@ class kUrlManager
 			if ($this->extention && strtolower($this->extention) != 'flv' ||
                         	$this->containerFormat && strtolower($this->containerFormat) != 'flash video')
 			{
-				$url = "mp4:$url/name/a.mp4";
+				$url = "mp4:".ltrim($url,'/')."/name/a.mp4";
 			}
 			else
 			{


### PR DESCRIPTION
This fix comes to solve Flash exception thrown due to the extra slash
