### PR TITLE
logToCli + compatCheck fix

### DIFF
--- a/alpha/scripts/compatCheck.php
+++ b/alpha/scripts/compatCheck.php
@@ -929,7 +929,10 @@ function generateKalcliCommand($ipAddress, $service, $action, $parsedParams)
 		
 		$curParam = "{$key}={$value}";
 		if (!preg_match('/^[a-zA-Z0-9\:_\-,=\.\/]+$/', $curParam))
-			$kalcliCmd .= " '{$curParam}'";
+			if (strpos($curParam, "'") === false)
+				$kalcliCmd .= " '{$curParam}'";
+			else
+				$kalcliCmd .= " \"{$curParam}\"";
 		else
 			$kalcliCmd .= " {$curParam}";
 	}

--- a/generator/sources/cli/logToCli.php
+++ b/generator/sources/cli/logToCli.php
@@ -133,7 +133,10 @@ function genKalcliCommand($parsedParams)
 	{
 		$curParam = "{$param}={$value}";
 		if (!preg_match('/^[a-zA-Z0-9\:_\-,=\.]+$/', $curParam))
-			$res .= " '{$curParam}'";
+			if (strpos($curParam, "'") === false)
+				$res .= " '{$curParam}'";
+			else
+				$res .= " \"{$curParam}\"";
 		else
 			$res .= " {$curParam}";
 	}


### PR DESCRIPTION
when an argument contains a quote, escape it with double quotes instead
of single quotes
