### PR TITLE
SUP-730 #comment preventing empty string in file_ext in setContent

### DIFF
--- a/plugins/content/caption/base/services/CaptionAssetService.php
+++ b/plugins/content/caption/base/services/CaptionAssetService.php
@@ -177,7 +177,8 @@ class CaptionAssetService extends KalturaAssetService
 		$ext = pathinfo($fullPath, PATHINFO_EXTENSION);
 		
 		$captionAsset->incrementVersion();
-		$captionAsset->setFileExt($ext);
+		if ($ext)
+			$captionAsset->setFileExt($ext);
 		$captionAsset->setSize(filesize($fullPath));
 		$captionAsset->save();
 		


### PR DESCRIPTION
if new captionAsset file has no extension, the current extension will
not be overridden.
