### PR TITLE
SUP-730 #comment preventing empty string in file_ext in setContent.

### DIFF
--- a/alpha/apps/kaltura/lib/kUploadTokenMgr.php
+++ b/alpha/apps/kaltura/lib/kUploadTokenMgr.php
@@ -1,6 +1,7 @@
 <?php
 class kUploadTokenMgr
 {
+	const NO_EXTENSION_IDENTIFIER = 'noext';
 	/**
 	 * @var UploadToken
 	 */
@@ -168,7 +169,7 @@ class kUploadTokenMgr
 	protected function getUploadPath($uploadTokenId, $extension = '')
 	{
 		if (!$extension)
-			$extension = 'noext';
+			$extension = self::NO_EXTENSION_IDENTIFIER;
 			
 		return myContentStorage::getFSUploadsPath().$uploadTokenId.'.'.$extension;
 	}

--- a/plugins/content/caption/base/services/CaptionAssetService.php
+++ b/plugins/content/caption/base/services/CaptionAssetService.php
@@ -177,7 +177,9 @@ class CaptionAssetService extends KalturaAssetService
 		$ext = pathinfo($fullPath, PATHINFO_EXTENSION);
 		
 		$captionAsset->incrementVersion();
-		$captionAsset->setFileExt($ext);
+		if($ext && $ext != kUploadTokenMgr::NO_EXTENSION_IDENTIFIER)
+ +      	$captionAsset->setFileExt($ext);
+		
 		$captionAsset->setSize(filesize($fullPath));
 		$captionAsset->save();
 		


### PR DESCRIPTION
if new captionAsset file has no extension, the current extension will
not be overridden.
