### PR TITLE
PLAT-495

### DIFF
--- a/api_v3/lib/KalturaErrors.php
+++ b/api_v3/lib/KalturaErrors.php
@@ -126,6 +126,8 @@ class KalturaErrors extends APIErrors
 
 	const RECORDED_WEBCAM_FILE_NOT_FOUND = "RECORDED_WEBCAM_FILE_NOT_FOUND;;The recorded webcam file was not found by the given token id, or was already used";
 
+	const INVALID_WEBCAM_TOKEN_ID = "INVALID_WEBCAM_TOKEN_ID;;Invalid webcam token id";
+	
 	const PERMISSION_DENIED_TO_UPDATE_ENTRY = "PERMISSION_DENIED_TO_UPDATE_ENTRY;;User can update only the entries he own, otherwise an admin session must be used";
 
 	const INVALID_RANK_VALUE = "INVALID_RANK_VALUE;;Invalid rank value, rank should be between 1 and 5";

--- a/api_v3/services/MediaService.php
+++ b/api_v3/services/MediaService.php
@@ -392,7 +392,16 @@ class MediaService extends KalturaEntryService
 		try
 		{
 		    // check that the uploaded file exists
-			    $entryFullPath = kUploadTokenMgr::getFullPathByUploadTokenId($uploadTokenId);
+		    $entryFullPath = kUploadTokenMgr::getFullPathByUploadTokenId($uploadTokenId);
+		    
+		    // Make sure that the uploads path is not modified by $uploadTokenId (with the value of "../" for example )
+		    $entryRootDir = realpath( dirname( $entryFullPath ) );
+			$uploadPathBase = realpath( myContentStorage::getFSUploadsPath() );
+			if ( strpos( $entryRootDir, $uploadPathBase ) !== 0 ) // Composed path doesn't begin with $uploadPathBase?  
+			{
+				KalturaLog::err( "uploadTokenId [$uploadTokenId] points outside of uploads directory" );
+				throw new KalturaAPIException( KalturaErrors::INVALID_UPLOAD_TOKEN_ID );			
+			}
 		}
 		catch(kCoreException $ex)
 		{
@@ -473,7 +482,18 @@ class MediaService extends KalturaEntryService
 
 	    // check that the webcam file exists
 	    $content = myContentStorage::getFSContentRootPath();
-	    $webcamBasePath = $content."/content/webcam/".$webcamTokenId; // filesync ok
+	    $webcamContentRootDir = $content . "/content/webcam/";
+	    $webcamBasePath = $webcamContentRootDir . $webcamTokenId;
+
+	    // Make sure that the root path of the webcam content is not modified by $webcamTokenId (with the value of "../" for example )
+	    $webcamContentRootDir = realpath( $webcamContentRootDir );
+	    $webcamBaseRootDir = realpath( dirname( $webcamBasePath ) ); // Get realpath of target directory 
+	    if ( strpos( $webcamBaseRootDir, $webcamContentRootDir ) !== 0 ) // The uploaded file's path is different from the content path?    
+	    {
+			KalturaLog::err( "webcamTokenId [$webcamTokenId] points outside of webcam content directory" );
+	    	throw new KalturaAPIException( KalturaErrors::INVALID_WEBCAM_TOKEN_ID );
+	    }
+	     
 		if (!file_exists("$webcamBasePath.flv") && !file_exists("$webcamBasePath.f4v"))
 		{
 			if (kDataCenterMgr::dcExists(1 - kDataCenterMgr::getCurrentDcId()))


### PR DESCRIPTION
1. Failing addFromUploadedFileAction() and addFromRecordedWebcamAction() if the
   given path is above the content's root directory (blocking ../ for example)
2. Added INVALID_WEBCAM_TOKEN_ID to KalturaErrors
   PLAT-495 #time 5h
