### PR TITLE
support sending extra arguments on serveFlavor URLs

### DIFF
--- a/alpha/apps/kaltura/lib/storage/kUrlManager.php
+++ b/alpha/apps/kaltura/lib/storage/kUrlManager.php
@@ -66,7 +66,7 @@ class kUrlManager
 		if(isset($urlManagers[$cdnHost]))
 		{
 			$class = $urlManagers[$cdnHost]["class"];
-			$params = isset($urlManagers[$cdnHost]["params"]) ? $urlManagers[$cdnHost]["params"] : null;
+			$params = isset($urlManagers[$cdnHost]["params"]) ? $urlManagers[$cdnHost]["params"] : array();
 			$entry = entryPeer::retrieveByPK($entryId);
 			$urlManagersMap = kConf::getMap('url_managers');
 			if ($entry && isset($urlManagersMap["override"]))
@@ -286,6 +286,16 @@ class kUrlManager
 		{
 			$baseUrl = preg_replace('/^rtmp:\/\//', 'rtmpe://', $baseUrl);
 			$baseUrl = preg_replace('/^rtmpt:\/\//', 'rtmpte://', $baseUrl);
+		}
+
+		if (isset($this->params['extra_params']) && $this->params['extra_params'] && !$flavorsUrls)
+		{
+			$parsedUrl = parse_url($baseUrl);
+			if (isset($parsedUrl['query']) && strlen($parsedUrl['query']) > 0)
+				$baseUrl .= '&';
+			else
+				$baseUrl .= '?';
+			$baseUrl .= $this->params['extra_params'];
 		}
 	}
 

--- a/alpha/apps/kaltura/modules/extwidget/actions/playManifestAction.class.php
+++ b/alpha/apps/kaltura/modules/extwidget/actions/playManifestAction.class.php
@@ -1338,6 +1338,9 @@ class playManifestAction extends kalturaAction
 				break;
 			
 			case PlaybackProtocol::APPLE_HTTP:
+				$flavors = array();
+				$this->urlManager->finalizeUrls($baseUrl, $flavors);
+				
 				$flavor = $this->getFlavorAssetInfo('', $baseUrl);		// passing the url as urlPrefix so that only the path will be tokenized
 				$renderer = new kRedirectManifestRenderer();
 				$renderer->flavor = $flavor;


### PR DESCRIPTION
required in order to send attributes=off to disable the CODECS and
RESOLUTION tags in m3u8s generated by akamai
