### PR TITLE
Support Wowza webcam recording with mp4 extension

### DIFF
--- a/alpha/apps/kaltura/lib/myInsertEntryHelper.class.php
+++ b/alpha/apps/kaltura/lib/myInsertEntryHelper.class.php
@@ -136,6 +136,7 @@ class myInsertEntryHelper
 			$webcam_basePath = $content.'/content/webcam/'.($webcam_suffix ? $webcam_suffix : 'my_recorded_stream_'.$kuser_id);
 			$entry_fullPath = $webcam_basePath.'.flv';
 			$entry_fullPathF4v = $webcam_basePath.'.f4v';
+			$entry_fullPathMp4 = $webcam_basePath.'.f4v.mp4';
 			if(file_exists($entry_fullPath))
 			{
 				// webcam should be preconvert until REALLY ready
@@ -168,6 +169,15 @@ class myInsertEntryHelper
 				$entry_status = entryStatus::PRECONVERT;
 				$ext = 'f4v';
 				$entry_fullPath = $entry_fullPathF4v;
+				// continue tracking the webcam
+				$te->setParam3Str( $entry_fullPath );
+				$te->setDescription(  __METHOD__ . ":" . __LINE__ . "::ENTRY_MEDIA_SOURCE_WEBCAM" );
+			}
+			else if (file_exists($entry_fullPathMp4))
+			{
+				$entry_status = entryStatus::PRECONVERT;
+				$ext = 'mp4';
+				$entry_fullPath = $entry_fullPathMp4;
 				// continue tracking the webcam
 				$te->setParam3Str( $entry_fullPath );
 				$te->setDescription(  __METHOD__ . ":" . __LINE__ . "::ENTRY_MEDIA_SOURCE_WEBCAM" );

--- a/api_v3/lib/types/resource/KalturaWebcamTokenResource.php
+++ b/api_v3/lib/types/resource/KalturaWebcamTokenResource.php
@@ -16,10 +16,15 @@ class KalturaWebcamTokenResource extends KalturaDataCenterContentResource
 	public function getDc()
 	{
 	    $content = myContentStorage::getFSContentRootPath();
-	    $entryFullPath = "{$content}/content/webcam/{$this->token}.flv";
+	    $entryFullPaths = array(
+	    	"{$content}/content/webcam/{$this->token}.flv",
+	    	"{$content}/content/webcam/{$this->token}.f4v",
+	    	"{$content}/content/webcam/{$this->token}.f4v.mp4",
+	    );
 	    
-		if(file_exists($entryFullPath))
-			return kDataCenterMgr::getCurrentDcId();
+	    foreach($entryFullPaths as $entryFullPath)
+			if(file_exists($entryFullPath))
+				return kDataCenterMgr::getCurrentDcId();
 			
 		return (1 - kDataCenterMgr::getCurrentDcId()); // other dc
 	}
@@ -74,25 +79,37 @@ class KalturaWebcamTokenResource extends KalturaDataCenterContentResource
 			$object_to_fill = new kLocalFileResource();
 			
 	    $content = myContentStorage::getFSContentRootPath();
-	    $entryFullPath = "{$content}/content/webcam/{$this->token}.flv";
+	    $entryFullPaths = array(
+	    	'flv' => "{$content}/content/webcam/{$this->token}.flv",
+	    	'f4v' => "{$content}/content/webcam/{$this->token}.f4v",
+	    	'mp4' => "{$content}/content/webcam/{$this->token}.f4v.mp4",
+	    );
 	    
-		if(!file_exists($entryFullPath))
-			throw new KalturaAPIException(KalturaErrors::RECORDED_WEBCAM_FILE_NOT_FOUND);
-					
-		$entryFixedFullPath = $entryFullPath . '.fixed.flv';
- 		KalturaLog::debug("Fix webcam full path from [$entryFullPath] to [$entryFixedFullPath]");
-		myFlvStaticHandler::fixRed5WebcamFlv($entryFullPath, $entryFixedFullPath);
-				
-		$entryNewFullPath = $entryFullPath . '.clipped.flv';
- 		KalturaLog::debug("Clip webcam full path from [$entryFixedFullPath] to [$entryNewFullPath]");
-		myFlvStaticHandler::clipToNewFile($entryFixedFullPath, $entryNewFullPath, 0, 0);
-		$entryFullPath = $entryNewFullPath ;
-				
-		if(!file_exists($entryFullPath))
-			throw new KalturaAPIException(KalturaErrors::RECORDED_WEBCAM_FILE_NOT_FOUND);
-					
-		$object_to_fill->setSourceType(KalturaSourceType::WEBCAM);
-		$object_to_fill->setLocalFilePath($entryFullPath);
-		return $object_to_fill;
+	    foreach($entryFullPaths as $type => $entryFullPath)
+	    {
+			if(file_exists($entryFullPath))
+			{
+				if($type == 'flv')
+				{
+					$entryFixedFullPath = $entryFullPath . '.fixed.flv';
+			 		KalturaLog::debug("Fix webcam full path from [$entryFullPath] to [$entryFixedFullPath]");
+					myFlvStaticHandler::fixRed5WebcamFlv($entryFullPath, $entryFixedFullPath);
+							
+					$entryNewFullPath = $entryFullPath . '.clipped.flv';
+			 		KalturaLog::debug("Clip webcam full path from [$entryFixedFullPath] to [$entryNewFullPath]");
+					myFlvStaticHandler::clipToNewFile($entryFixedFullPath, $entryNewFullPath, 0, 0);
+					$entryFullPath = $entryNewFullPath ;
+							
+					if(!file_exists($entryFullPath))
+						throw new KalturaAPIException(KalturaErrors::RECORDED_WEBCAM_FILE_NOT_FOUND);
+				}
+							
+				$object_to_fill->setSourceType(KalturaSourceType::WEBCAM);
+				$object_to_fill->setLocalFilePath($entryFullPath);
+				return $object_to_fill;
+			}
+	    }
+		
+		throw new KalturaAPIException(KalturaErrors::RECORDED_WEBCAM_FILE_NOT_FOUND);
 	}
 }

--- a/api_v3/services/MediaService.php
+++ b/api_v3/services/MediaService.php
@@ -477,7 +477,7 @@ class MediaService extends KalturaEntryService
 	    // check that the webcam file exists
 	    $content = myContentStorage::getFSContentRootPath();
 	    $webcamBasePath = $content."/content/webcam/".$webcamTokenId; // filesync ok
-		if (!file_exists("$webcamBasePath.flv") && !file_exists("$webcamBasePath.f4v"))
+		if (!file_exists("$webcamBasePath.flv") && !file_exists("$webcamBasePath.f4v") && !file_exists("$webcamBasePath.f4v.mp4"))
 		{
 			if (kDataCenterMgr::dcExists(1 - kDataCenterMgr::getCurrentDcId()))
 				kFileUtils::dumpApiRequest ( kDataCenterMgr::getRemoteDcExternalUrlByDcId ( 1 - kDataCenterMgr::getCurrentDcId () ) );


### PR DESCRIPTION
In order to support webcam recording with Wowza:
- Create oflaDemo application in your Wowza server.
  - Create @WOWZA_DIR@/applications/oflaDemo directory
  - Create @WOWZA_DIR@/conf/oflaDemo directory
  - Copy @WOWZA_DIR@/conf/Application.xml to @WOWZA_DIR@/conf/oflaDemo/Application.xml.
- Configure @WOWZA_DIR@/conf/oflaDemo/Application.xml
  - /Root/Streams/StreamType - live-record
  - /Root/Streams/StorageDir - @WEB_DIR@/content/webcam
  - /Root/Transcoder/LiveStreamTranscoder - transcoder
  - /Root/Transcoder/Templates - hdfvr.xml
- Create @WOWZA_DIR@/transcoder/templates/hdfvr.xml template:

> ```
> <Root>
>   <Transcode>
>       <Encodes>
>           <!-- Example Encode block for source, not required unless Member of StreamNameGroup. -->
>           <Encode>
>               <Enable>true</Enable>
>               <Name>aac</Name>
>               <StreamName>mp4:${SourceStreamName}</StreamName>
>               <Video>
>                   <!-- H.264, PassThru, Disable -->
>                   <Codec>PassThru</Codec>
>                   <Bitrate>${SourceVideoBitrate}</Bitrate>
>                   <Parameters>
>                   </Parameters>
>               </Video>
>               <Audio>
>                   <!-- AAC, PassThru, Disable -->
>                   <Codec>AAC</Codec>
>                   <Bitrate>48000</Bitrate>
>               </Audio>
>               <Properties>
>               </Properties>
>           </Encode>
>       </Encodes>
>       <Decode>
>       </Decode>
>       <StreamNameGroups>
>       </StreamNameGroups>
>       <Properties>
>       </Properties>
>   </Transcode>
> </Root>
> ```
- Make sure that @WEB_DIR@/content/webcam group is kaltura or apache
- Define permissions stickiness on the group:
  - chmod +t @WEB_DIR@/content/webcam
  - chmod g+s @WEB_DIR@/content/webcam
- Restart Wowza.
