### PR TITLE
The place to set the notification URL is within the Admin Console

### DIFF
--- a/plugins/event_notification/providers/http/example/webService/README.txt
+++ b/plugins/event_notification/providers/http/example/webService/README.txt
@@ -23,5 +23,5 @@
 5. Deploy on tomcat:
 	- Extract a WAR file and put it under <TOMCAT>/webapps
 
-6. On KMC, set the notification URL to be http://<your tomcat server path>/<war name>/HttpNotificationHandler.jsp
+6. Contact your project manager to set the notification URL to be http://<your tomcat server path>/<war name>/HttpNotificationHandler.jsp
 	


### PR DESCRIPTION
At the event notification template settings : Notification Handler
Service Details Which cannot be set by the partner itself.
