### PR TITLE
When a tag is not resolved to be deleted, its instance count should be c...

### DIFF
--- a/plugins/tag_search/services/TagService.php
+++ b/plugins/tag_search/services/TagService.php
@@ -114,6 +114,12 @@ class TagService extends KalturaBaseService
 	    	$tag->delete();	
 	    	return 1;
 	    }
+		else
+		{
+			$tag->setInstanceCount($count);
+			$tag->save();
+			return 1;		
+		}
 	    
 	    return 0;
 	    
@@ -138,7 +144,13 @@ class TagService extends KalturaBaseService
 	    	$tag->delete();	
 	    	return 1;
 	    }
-	    
+	    else
+		{
+			$tag->setInstanceCount($count);
+			$tag->save();
+			return 1;		
+		}
+		
 	    return 0;
 	}
 	

--- a/plugins/tag_search/sphinx/kTagFlowManager.php
+++ b/plugins/tag_search/sphinx/kTagFlowManager.php
@@ -5,8 +5,8 @@ class kTagFlowManager implements kObjectCreatedEventConsumer, kObjectDeletedEven
     
     const PARTNER_ID_FIELD = "partner_id";
     
-    public static $specialCharacters = array ('!', '*', '"');
-    public static $specialCharactersReplacement = array ('\\!', '\\*', '\\"');
+    public static $specialCharacters = array ('!', '*', '"', '\\');
+    public static $specialCharactersReplacement = array ('\\!', '\\*', '\\"', '\\\\');
     
     const NULL_PC = "NO_PC";
     


### PR DESCRIPTION
...hanged to a non-zero value to avoid running into it again in the tag resolve batch. '\' should be escaped to '\' in the sphinx search query
