### PR TITLE
UI-Conf view - filtering

### DIFF
--- a/admin_console/controllers/WidgetController.php
+++ b/admin_console/controllers/WidgetController.php
@@ -226,6 +226,10 @@ class WidgetController extends Zend_Controller_Action
 						$partnerIds[] = $partner->id;
 					$uiConfFilter->partnerIdIn = implode(',', $partnerIds);
 				}
+				break;
+			default:
+				// We don't want to query all ui-confs.
+				$uiConfFilter->partnerIdIn = 0;
 		}
 		
 		return $uiConfFilter;


### PR DESCRIPTION
In case an empty ui-conf filter is used, filter at least by the partner id.
# PLAT-681 #time 2h
