### PR TITLE
Event consumers 

### DIFF
--- a/alpha/apps/kaltura/lib/events/kEventsManager.php
+++ b/alpha/apps/kaltura/lib/events/kEventsManager.php
@@ -83,8 +83,10 @@ class kEventsManager
 			$a = $priorities[$consumerA];
 		if(isset($priorities[$consumerB]))
 			$b = $priorities[$consumerB];
-			
-		return ($a == $b ? 0 : ($a < $b ? 1 : -1)); 
+		
+		if($a == $b)
+			return strcmp($consumerA, $consumerB);
+		return ($a < $b ? 1 : -1);
 	}
 	
 	protected static function getConsumers($interfaceType)


### PR DESCRIPTION
Change the order of the event consumers to be deterministic. 
Unless described otherwise, the events will be handled alphabetically. 
One can set the priority manually by configuring the events consumers priority.
# PLAT-526 #time 0.5h
