### PR TITLE
IX-9.8.0-PLAT-706 : Reduce live-entry cache timeout

### DIFF
--- a/alpha/apps/kaltura/lib/cache/kApiCache.php
+++ b/alpha/apps/kaltura/lib/cache/kApiCache.php
@@ -32,6 +32,7 @@ class kApiCache extends kApiCacheBase
 	const ANONYMOUS_CACHE_EXPIRY = 600;
 	const CONDITIONAL_CACHE_EXPIRY = 86400;		// 1 day, must not be greater than the expiry of the query cache keys
 	const KALTURA_COMMENT_MARKER = '@KALTURA_COMMENT@';
+	const REDIRECT_ENTRY_CACHE_EXPIRY = 120;
 	
 	const EXPIRY_MARGIN = 300;
 

--- a/plugins/sphinx_search/lib/SphinxEntryCriteria.php
+++ b/plugins/sphinx_search/lib/SphinxEntryCriteria.php
@@ -23,6 +23,13 @@ class SphinxEntryCriteria extends SphinxCriteria
 			
 			if ( ! empty( $origEntry ) )
 			{
+				if ( $origEntry->getType() == entryType::LIVE_STREAM )
+				{
+					// Set a relatively short expiry value in order to reduce the wait-time
+					// until the cache is refreshed and a redirection kicks-in. 
+					kApiCache::setExpiry( kApiCache::REDIRECT_ENTRY_CACHE_EXPIRY );
+				}
+								
 				// Get the id of the entry id that is being redirected from the original entry
 				$redirectEntryId = $origEntry->getRedirectEntryId(); 
 				


### PR DESCRIPTION
Expiring a live-entry cache after a relatively short (2 minutes) timeoue
PLAT-706 #time 0.5d
