### PR TITLE
Set user email for every kuser we unable login for

### DIFF
--- a/alpha/lib/model/kuser.php
+++ b/alpha/lib/model/kuser.php
@@ -986,7 +986,13 @@ class kuser extends Basekuser implements IIndexable
 		}
 		
 		$this->setLoginDataId($loginData->getId());
-				
+
+		//Email notification on user creation is sent while using kuser email so make sure this field is set before enabling login
+		//if not than set the email to be the $loginId provided to this action (we now know this is a valid email since "addLoginData" verifies this)
+		if(!$this->getEmail()) {
+			$this->setEmail($loginId);
+		}
+		
 		if ($sendEmail)
 		{
 			if ($loginDataExisted) {


### PR DESCRIPTION
SUP-1372 #time 15m If no email is set on kuser during the enable login
action we set the email of the kuser to be identical to the one provided
in the login data
