### PR TITLE
Conversion profile updated_at is not updated to the last change.

### DIFF
--- a/alpha/lib/model/flavorParamsConversionProfile.php
+++ b/alpha/lib/model/flavorParamsConversionProfile.php
@@ -38,4 +38,27 @@ class flavorParamsConversionProfile extends BaseflavorParamsConversionProfile
 	{
 		return array("flavorParamsConversionProfile:flavorParamsId=".strtolower($this->getFlavorParamsId()).",conversionProfileId=".strtolower($this->getConversionProfileId()), "flavorParamsConversionProfile:conversionProfileId=".strtolower($this->getConversionProfileId()));
 	}
+	
+	public function postSave(PropelPDO $con = null) 
+	{
+		$this->updateConversionProfileLastModified();
+		parent::postSave($con);
+	}
+	
+	public function postDelete(PropelPDO $con = null)
+	{
+		$this->updateConversionProfileLastModified();
+		parent::postDelete($con);
+	}
+	
+	private function updateConversionProfileLastModified()
+	{
+		$conversionProfile = $this->getconversionProfile2();
+		
+		if($conversionProfile)
+		{
+			$conversionProfile->setUpdatedAt(time());
+			$conversionProfile->save();
+		}
+	}
 }


### PR DESCRIPTION
When adding or removing flavor params from conversion profile the
updated at of the conversion profile is not getting updated.
