### PR TITLE
reduce the caching time for kaltura live streams

### DIFF
--- a/alpha/apps/kaltura/modules/extwidget/actions/playManifestAction.class.php
+++ b/alpha/apps/kaltura/modules/extwidget/actions/playManifestAction.class.php
@@ -1428,8 +1428,13 @@ class playManifestAction extends kalturaAction
 	
 	private function serveLiveEntry()
 	{		
-		if (($this->entry->getSource() == EntrySourceType::LIVE_STREAM || $this->entry->getSource() == EntrySourceType::LIVE_CHANNEL) && !$this->entry->hasMediaServer())
-			KExternalErrors::dieError(KExternalErrors::ENTRY_NOT_LIVE, "Entry [$this->entryId] is not broadcasting");
+		if ($this->entry->getSource() == EntrySourceType::LIVE_STREAM || $this->entry->getSource() == EntrySourceType::LIVE_CHANNEL)
+		{
+			if (!$this->entry->hasMediaServer())
+				KExternalErrors::dieError(KExternalErrors::ENTRY_NOT_LIVE, "Entry [$this->entryId] is not broadcasting");
+			
+			kApiCache::setExpiry(120);
+		}
 		
 		$baseUrl = $this->getLiveEntryBaseUrl();
 			


### PR DESCRIPTION
we need a shorter cache in case the stream has to move to a different wowza server
