### PR TITLE
Playlist update was updating user related in the wrong matter.

### DIFF
--- a/api_v3/services/PlaylistService.php
+++ b/api_v3/services/PlaylistService.php
@@ -152,7 +152,7 @@ class PlaylistService extends KalturaEntryService
 		$playlistUpdate = null;
 		$playlistUpdate = $playlist->toObject($playlistUpdate);
 		
-		$this->checkAndSetValidUserUpdate($playlist, $playlistUpdate);
+		$this->checkAndSetValidUserUpdate($playlist, $dbPlaylist);
 		$this->checkAdminOnlyUpdateProperties($playlist);
 		$this->validateAccessControlId($playlist);
 		$this->validateEntryScheduleDates($playlist, $dbPlaylist);


### PR DESCRIPTION
This bug caused the indexing of the playlist entries to be done with
wrong values which affected the playlist list requests when sending user
id in its filter.
