### PR TITLE
When Akamai delivery type is not set on the account first check ...

### DIFF
--- a/alpha/apps/kaltura/lib/kContextDataHelper.php
+++ b/alpha/apps/kaltura/lib/kContextDataHelper.php
@@ -399,11 +399,15 @@ class kContextDataHelper
 			reset($enabledDeliveryTypes);
 			$deliveryTypeName = key($enabledDeliveryTypes);
 			foreach ($deliveryTypeKeys as $deliveryTypeKey){
-				$deliveryTypeToValidate = kConf::get($deliveryTypeKey);
-	            if (isset ($enabledDeliveryTypes[$deliveryTypeToValidate]))
-	            {
-	             	$deliveryTypeName = $deliveryTypeToValidate;
-	                break;
+				$deliveryTypesToValidate = kConf::get($deliveryTypeKey);
+				$deliveryTypesToValidate = explode(',', $deliveryTypesToValidate);
+				foreach ($deliveryTypesToValidate as $deliveryTypeToValidate)
+				{
+		            if (isset ($enabledDeliveryTypes[$deliveryTypeToValidate]))
+		            {
+		             	$deliveryTypeName = $deliveryTypeToValidate;
+		                break;
+					}
 				}
 			}		
 			$deliveryType = $enabledDeliveryTypes[$deliveryTypeName];	

--- a/configurations/base.ini
+++ b/configurations/base.ini
@@ -197,7 +197,7 @@ default_live_stream_entry_source_type = EntrySourceType::AKAMAI_LIVE
 short_entries_max_duration = 300
 short_entries_default_delivery_type = http
 secured_default_delivery_type = hds
-default_delivery_type = akamai
+default_delivery_type = akamai,hds
 
 template_partner_custom_data_exclude_fields[] = defConversionProfileType
 template_partner_custom_data_exclude_fields[] = defaultAccessControlId


### PR DESCRIPTION
When Akamai delivery type is not set on the account first check if hds
is allowed before falling back to HTTP
