### PR TITLE
Skipping linux current and parent folder

### DIFF
--- a/plugins/drop_folder/batch/Engine/KDropFolderFileTransferEngine.php
+++ b/plugins/drop_folder/batch/Engine/KDropFolderFileTransferEngine.php
@@ -213,7 +213,12 @@ class KDropFolderFileTransferEngine extends KDropFolderEngine
 		try 
 		{
 			$fullPath = $this->dropFolder->path.'/'.$physicalFile;
-			if (empty($physicalFile) || $physicalFile === '.' || $physicalFile === '..')
+			if ($physicalFile === '.' || $physicalFile === '..')
+			{
+				KalturaLog::debug("Skipping linux current and parent folder indicators");
+				$isValid = false;
+			}
+			else if (empty($physicalFile)) 
 			{
 				KalturaLog::err("File name is not set");
 				$isValid = false;


### PR DESCRIPTION
Prevent log pollution, only output them to debug as these two entries will always be there, and are not an error as incorrectly suggested originally. This decreases every Drop Folder log with 4 lines of log output (multiplied by the amount of dropfolders)
