### PR TITLE
changed hls is live validation to fetch 2 bytes instead of 1 byte

### DIFF
--- a/alpha/apps/kaltura/lib/storage/kUrlManager.php
+++ b/alpha/apps/kaltura/lib/storage/kUrlManager.php
@@ -595,7 +595,7 @@ class kUrlManager
 			
 			$tsUrl = $matches[0];
 			$tsUrl = $this->checkIfValidUrl($tsUrl, $url);
-			if ($this->urlExists($tsUrl ,kConf::get("hls_live_stream_content_type"),'0-0') !== false)
+			if ($this->urlExists($tsUrl ,kConf::get("hls_live_stream_content_type"),'0-1') !== false)
 				return true;
 		}
 			


### PR DESCRIPTION
this fixes (or workaround) a bug in wowza returning 0 bytes for 0-0 range (0-0 means from first byte to first byte, which is 1 byte)
