### PR TITLE
feed bug fixes

### DIFF
--- a/plugins/content_distribution/providers/ContentDistributionServiceBase.php
+++ b/plugins/content_distribution/providers/ContentDistributionServiceBase.php
@@ -112,7 +112,8 @@ abstract class ContentDistributionServiceBase extends KalturaBaseService {
 	
 	protected function handleEntries($context, $feed, array $entries) {
 		
-		$cachePrefix = "dist_" . ($this->profile->getId()) . "/entry_";
+		$protocol = infraRequestUtils::getProtocol();
+		$cachePrefix = "dist_" . ($this->profile->getId()) . "/{$protocol}/entry_";
 		$profileUpdatedAt = $this->profile->getUpdatedAt(null);
 		
 		$extendItems = $this->profile->getItemXpathsToExtend();


### PR DESCRIPTION
- feed entry cache should take the protocol as part of the cache key
- in KalturaSyndicationFeedRenderer place the criterions directly on the
  criteria object instead of using a filter. in large feeds the filter
  created a criterion of status = 2 and status 2 and ... this happened
  because the even though the criteria is clone on every cycle, clone
  performs a shallow copy, the criterions are not cloned, and the filter
  is applied over and over on the same criterion.
