### PR TITLE
For reasons of backward compatibility, id property should be skipped in ...

### DIFF
--- a/api_v3/lib/types/entry/KalturaLiveStreamEntry.php
+++ b/api_v3/lib/types/entry/KalturaLiveStreamEntry.php
@@ -147,7 +147,10 @@ class KalturaLiveStreamEntry extends KalturaLiveEntry
 	public function toInsertableObject ( $dbObject = null , $props_to_skip = array() )
 	{
 		/* @var $dbObject LiveStreamEntry */
-		
+		if (!count ($props_to_skip))
+		{
+			$props_to_skip = array("id");
+		}	
 		// if the given password is empty, generate a random 8-character string as the new password
 		if(($this->streamPassword == null) || (strlen(trim($this->streamPassword)) <= 0))
 		{
@@ -178,6 +181,11 @@ class KalturaLiveStreamEntry extends KalturaLiveEntry
 	 */
 	public function validateForInsert($propertiesToSkip = array())
 	{
+		if (!count ($propertiesToSkip))
+		{
+			$propertiesToSkip = array("id");
+		}
+		
 		$this->validatePropertyNotNull("mediaType");
 		$this->validatePropertyNotNull("sourceType");
 		$this->validatePropertyNotNull("streamPassword");


### PR DESCRIPTION
...the toInsertableObject flow
