### PR TITLE
Save live duration only if the duration reported by primary server

### DIFF
--- a/api_v3/lib/KalturaLiveEntryService.php
+++ b/api_v3/lib/KalturaLiveEntryService.php
@@ -56,8 +56,11 @@ class KalturaLiveEntryService extends KalturaEntryService
 			throw new KalturaAPIException(KalturaErrors::LIVE_STREAM_EXCEEDED_MAX_RECORDED_DURATION, $entryId);
 		}
 		
-		$dbEntry->setLengthInMsecs($currentDuration);
-		$dbEntry->save();
+		if($mediaServerIndex == KalturaMediaServerIndex::PRIMARY)
+		{
+			$dbEntry->setLengthInMsecs($currentDuration);
+			$dbEntry->save();
+		}
 			
 		$kResource = $resource->toObject();
 		$target = $kResource->getLocalFilePath();


### PR DESCRIPTION
PLAT-1311 #time 20m
