### PR TITLE
New partner permissions fixing PLAT-1320

### DIFF
--- a/alpha/scripts/utils/setAlwaysAllowedPermissions.php
+++ b/alpha/scripts/utils/setAlwaysAllowedPermissions.php
@@ -1,0 +1,17 @@
+<?php
+require_once(dirname(__FILE__).'/../bootstrap.php');
+
+if ($argc < 3)
+	die ("Script usage: php setAlwaysAllowedPartnerPermissions.php <partnerId> <comma-separated permission names list>");
+
+$partnerId = $argv[1];
+$permissionNames = $argv[2];
+
+$partner = PartnerPeer::retrieveByPK($partnerId);
+if (!$partner)
+{
+	die ("Partner with id [$partnerId] not found");
+}
+
+$partner->setAlwaysAllowedPermissionNames($permissionNames);
+$partner->save();

--- a/deployment/permissions/partner.0.ini
+++ b/deployment/permissions/partner.0.ini
@@ -1249,3 +1249,12 @@ permission193.type = 1
 permission193.name = LIVE_STREAM_CREATE_SYNC_POINTS
 permission193.friendlyName = "Create live stream sync-points"
 permission193.description = "Create live stream sync-points"
+
+permission194.partnerId = 0
+permission194.type = 1
+permission194.name = ALWAYS_ALLOWED_PERMISSION_HYBRID_ECDN
+permission194.friendlyName = "Media Server partner-level permission"
+permission194.description = "Media Server partner-level permission"
+permission194.dependsOnPermissionNames = FEATURE_HYBRID_ECDN
+permission194.tags = 
+permission194.partnerGroup =

--- a/deployment/permissions/service.wowza.liveconversionprofile.ini
+++ b/deployment/permissions/service.wowza.liveconversionprofile.ini
@@ -6,5 +6,5 @@ permissionItem1.param3 =
 permissionItem1.param4 = 
 permissionItem1.param5 = 
 permissionItem1.tags = 
-permissionItem1.permissions = ALWAYS_ALLOWED_FROM_INTERNAL_IP_ACTIONS
+permissionItem1.permissions = ALWAYS_ALLOWED_FROM_INTERNAL_IP_ACTIONS,ALWAYS_ALLOWED_PERMISSION_HYBRID_ECDN
 

--- a/deployment/updates/scripts/add_permissions/2014_05_07_add_always_allowed_hybrid_ecdn.php
+++ b/deployment/updates/scripts/add_permissions/2014_05_07_add_always_allowed_hybrid_ecdn.php
@@ -1,0 +1,13 @@
+<?php
+/**
+ * @package deployment
+ * @subpackage gemini.roles_and_permissions
+ *
+ * Adds userId parameter permissions
+ *
+ * No need to re-run after server code deploy
+ */
+
+$script = realpath(dirname(__FILE__) . '/../../../../') . '/alpha/scripts/utils/permissions/addPermissionsAndItems.php';
+$config = realpath(dirname(__FILE__) . '/../../../') . '/permissions/partner.0.ini';
+passthru("php $script $config");

--- a/deployment/updates/scripts/add_permissions/2014_05_07_live_conversionprofile_hybrid_ecdn.php
+++ b/deployment/updates/scripts/add_permissions/2014_05_07_live_conversionprofile_hybrid_ecdn.php
@@ -1,0 +1,11 @@
+<?php
+/**
+ * @package deployment
+ * @subpackage falcon.roles_and_permissions
+ * 
+ * Add permissions to caption asset
+ */
+
+$script = realpath(dirname(__FILE__) . '/../../../../') . '/alpha/scripts/utils/permissions/addPermissionsAndItems.php';
+$config = realpath(dirname(__FILE__)) . '/../../../permissions/service.wowza.liveconversionprofile.ini';
+passthru("php $script $config");


### PR DESCRIPTION
Hybrid eCDN partner has no permissions to use the liveConversionProfile->serve action
