### PR TITLE
while the returncode is what determines the monitor's result, it is

### DIFF
--- a/plugins/monitor/nagios/exec.php
+++ b/plugins/monitor/nagios/exec.php
@@ -116,25 +116,25 @@ if($monitorResult->errors)
 
 if(!is_null($errorThresholdMax) && $monitorResult->value > $errorThresholdMax)
 {
-	echo "Threshold crossed - $monitorResult->description";
+	echo "CRITICAL: Threshold crossed - $monitorResult->description";
 	exit(NAGIOS_CODE_CRITICAL);
 }
 
 if(!is_null($warningThresholdMax) && $monitorResult->value > $warningThresholdMax)
 {
-	echo "Threshold crossed - $monitorResult->description";
+    echo "WARNING: Threshold crossed - $monitorResult->description";
 	exit(NAGIOS_CODE_WARNING);
 }
 
 if(!is_null($errorThresholdMin) && $monitorResult->value < $errorThresholdMin)
 {
-	echo "Threshold crossed - $monitorResult->description";
+	echo "CRITICAL: Threshold crossed - $monitorResult->description";
 	exit(NAGIOS_CODE_CRITICAL);
 }
 
 if(!is_null($warningThresholdMin) && $monitorResult->value < $warningThresholdMin)
 {
-	echo "Threshold crossed - $monitorResult->description";
+        echo "WARNING: Threshold crossed - $monitorResult->description";
 	exit(NAGIOS_CODE_WARNING);
 }
 


### PR DESCRIPTION
also customary to reflect the status in the output.
good for say, getting it by mail, or when running from CLI or when you
are color blind looking at the Nagios I/F :)
