### PR TITLE
1. Enabling setting the recognizer to null

### DIFF
--- a/alpha/lib/model/DeliveryProfile.php
+++ b/alpha/lib/model/DeliveryProfile.php
@@ -85,7 +85,10 @@ abstract class DeliveryProfile extends BaseDeliveryProfile {
 	 */
 	public function setRecognizer($newObject)
 	{
-		if ($newObject instanceof kUrlRecognizer)
+		if(is_null($newObject)) {
+			parent::setRecognizer(null);
+		} 
+		else if ($newObject instanceof kUrlRecognizer)
 		{
 			$serializedObject = serialize($newObject);
 			parent::setRecognizer($serializedObject);

--- a/alpha/lib/model/FileSync.php
+++ b/alpha/lib/model/FileSync.php
@@ -70,6 +70,9 @@ class FileSync extends BaseFileSync
 			return kDataCenterMgr::getInternalRemoteUrl($this);
 			
 		$urlManager = DeliveryProfilePeer::getRemoteDeliveryByStorageId($this->getDc(), $entryId);
+		if(is_null($urlManager))
+			return null;
+		
 		$url = $urlManager->getFileSyncUrl($this);
 		$baseUrl = $urlManager->getUrl();
 		

--- a/alpha/lib/model/asset.php
+++ b/alpha/lib/model/asset.php
@@ -485,7 +485,9 @@ class asset extends Baseasset implements ISyncableFile
 			return null;
 			
 		$urlManager = DeliveryProfilePeer::getRemoteDeliveryByStorageId($fileSync->getDc(), $this->getEntryId(), PlaybackProtocol::HTTP, null, $fileSync, $this);
-		
+		if(is_null($urlManager)) 
+			return null;
+			
 		$url = rtrim($urlManager->getUrl(), "/") . "/". ltrim($urlManager->getFileSyncUrl($fileSync), "/");
 		return $url;
 	}


### PR DESCRIPTION
1. When someone forgets to set the delivery profile on the storage
   profile, no null pointer exception should occur.
