### PR TITLE
generic rtmp delivery - removed custom kaltura logic

### DIFF
--- a/alpha/lib/model/DeliveryProfileGenericRtmp.php
+++ b/alpha/lib/model/DeliveryProfileGenericRtmp.php
@@ -1,10 +1,9 @@
 <?php
 
 class DeliveryProfileGenericRtmp extends DeliveryProfileRtmp {
-	
-	// Whenever someone wants - you can extract that as parameter.
-	private $removeDefaultPrefix = true;
-	
+
+	protected $REDUNDANT_EXTENSIONS = array();
+
 	public function setPattern($v)
 	{
 		$this->putInCustomData("pattern", $v);
@@ -44,9 +43,6 @@ class DeliveryProfileGenericRtmp extends DeliveryProfileRtmp {
 	}
 	
 	protected function formatByExtension($url) {
-		$url = parent::formatByExtension($url);
-		if($this->removeDefaultPrefix)
-			$url = str_replace("mp4:", '', $url);
 		return $url;
 	}
 }


### PR DESCRIPTION
The generic rtmp delivery is only used by bitgravity integration, we override formatByExtension method and remove the custom kaltura logic. 
In case the generic rtmp delivery profile will require custom logic, it should be added by configurable parameters, but the default behavior should expose the stock kaltura urls.
