### PR TITLE
Return un-cached context data result in some cases

### DIFF
--- a/alpha/apps/kaltura/lib/kContextDataHelper.php
+++ b/alpha/apps/kaltura/lib/kContextDataHelper.php
@@ -161,7 +161,8 @@ class kContextDataHelper
 				if (array_key_exists($partnerId, $optimizedPlayback))
 				{
 					$params = $optimizedPlayback[$partnerId];
-					if (array_key_exists('cache_kdp_access_control', $params) && $params['cache_kdp_access_control'])
+					if (array_key_exists('cache_kdp_access_control', $params) && $params['cache_kdp_access_control'] &&
+					 	(strpos(strtolower(kCurrentContext::$client_lang), "kdp") !== false || strpos(strtolower(kCurrentContext::$client_lang), "html") !== false ))
 						return;
 				}
 			}		


### PR DESCRIPTION
when the request arrives from outside of the player we want to return a
none cached context data response
