### PR TITLE
fixes for ps2 compatcheck

### DIFF
--- a/alpha/apps/kaltura/modules/extwidget/actions/kwidgetAction.class.php
+++ b/alpha/apps/kaltura/modules/extwidget/actions/kwidgetAction.class.php
@@ -80,6 +80,8 @@ class kwidgetAction extends sfAction
 		{
 			KExternalErrors::dieGracefully();
 		}
+		
+		myPartnerUtils::blockInactivePartner($widget->getPartnerId());
 
 		// because of the routing rule - the entry_id & kmedia_type WILL exist. be sure to ignore them if smaller than 0
 		$kshow_id= $widget->getKshowId();

--- a/alpha/apps/kaltura/modules/partnerservices2/actions/defPartnerservices2baseAction.class.php
+++ b/alpha/apps/kaltura/modules/partnerservices2/actions/defPartnerservices2baseAction.class.php
@@ -104,6 +104,10 @@ class defPartnerservices2baseAction extends kalturaAction
 		unset($params['ks']);
 		unset($params['kalsig']);
 		$params['uri'] = $_SERVER['PATH_INFO'];
+		if (isset($_SERVER['HTTPS']) && $_SERVER['HTTPS'] == 'on')
+			$params['__protocol'] = 'https';
+		else 	
+			$params['__protocol'] = 'http';
 		ksort($params);
 		
 		$keys = array_keys($params);

--- a/alpha/web/index.php
+++ b/alpha/web/index.php
@@ -40,6 +40,10 @@ function checkCache()
 		unset($params['ks']);
 		unset($params['kalsig']);
 		$params['uri'] = $_SERVER['PATH_INFO'];
+		if (isset($_SERVER['HTTPS']) && $_SERVER['HTTPS'] == 'on')
+			$params['__protocol'] = 'https';
+		else 	
+			$params['__protocol'] = 'http';
 		ksort($params);
 
 		$keys = array_keys($params);


### PR DESCRIPTION
- block inactive partners in kwidget
- include the protocol (http/s) in the ps2 cache key
