### PR TITLE
make the admin console block configurable

### DIFF
--- a/alpha/apps/kaltura/lib/kPermissionManager.php
+++ b/alpha/apps/kaltura/lib/kPermissionManager.php
@@ -460,8 +460,10 @@ class kPermissionManager implements kObjectCreatedEventConsumer, kObjectChangedE
 		// copy kCurrentContext parameters (kCurrentContext::init should have been executed before)
 		self::$requestedPartnerId = !self::isEmpty(kCurrentContext::$partner_id) ? kCurrentContext::$partner_id : null;
 		self::$ksPartnerId = !self::isEmpty(kCurrentContext::$ks_partner_id) ? kCurrentContext::$ks_partner_id : null;
-		if (self::$ksPartnerId == Partner::ADMIN_CONSOLE_PARTNER_ID && $_SERVER['REMOTE_ADDR'] != '127.0.0.1') {
-			throw new kCoreException("Admin console partner cannot be used outside the server", kCoreException::PARTNER_BLOCKED);
+		if (self::$ksPartnerId == Partner::ADMIN_CONSOLE_PARTNER_ID && 
+			kConf::hasParam('admin_console_partner_allowed_ips') &&
+			!kIpAddressUtils::isIpInRange($_SERVER['REMOTE_ADDR'], kConf::get('admin_console_partner_allowed_ips'))) {
+			throw new kCoreException("Admin console partner used from an unallowed address", kCoreException::PARTNER_BLOCKED);
 		}
 		self::$ksUserId = !self::isEmpty(kCurrentContext::$ks_uid) ? kCurrentContext::$ks_uid : null;
 		if (self::$ksPartnerId != Partner::BATCH_PARTNER_ID)


### PR DESCRIPTION
to support on prems that don't run the admin console on the same machine
as the api
