### PR TITLE
ImageMagick is not part of the installation

### DIFF
--- a/configurations/batch/batch.ini.template
+++ b/configurations/batch/batch.ini.template
@@ -210,7 +210,7 @@ params.fastStartCmd									= @BIN_DIR@/qt-faststart
 params.avidemuxCmd									= @BIN_DIR@/avidemux2_cli
 params.segmenterCmd									= @BIN_DIR@/segmenter
 params.pdf2SwfCmd									= @BIN_DIR@/pdf2swf
-params.ImageMagickCmd								= @BIN_DIR@/convert
+params.ImageMagickCmd								= convert
 params.ismIndexCmd									= @BIN_DIR@/ismIndex
 
 params.EncodingComUserId							= should-fail


### PR DESCRIPTION
ImageMagick is a prerequisite for the installation. It will not be in the @BIN_DIR@ location
