### PR TITLE
pathOnly change bug fix

### DIFF
--- a/alpha/apps/kaltura/modules/extwidget/actions/serveFlavorAction.class.php
+++ b/alpha/apps/kaltura/modules/extwidget/actions/serveFlavorAction.class.php
@@ -71,7 +71,7 @@ class serveFlavorAction extends kalturaAction
 		if ($pathOnly && kIpAddressUtils::isInternalIp())
 		{
 			$path = null;
-			list ( $file_sync , $local )= kFileSyncUtils::getReadyFileSyncForKey( $syncKey , false );
+			list ( $file_sync , $local )= kFileSyncUtils::getReadyFileSyncForKey( $syncKey , false, false );
 			if ( $file_sync )
 			{
 				$parent_file_sync = kFileSyncUtils::resolve($file_sync);

--- a/alpha/scripts/compatCheck.php
+++ b/alpha/scripts/compatCheck.php
@@ -33,7 +33,7 @@ $PS2_TESTED_XML_ACTIONS = array(
 		);
 
 $PS2_TESTED_BIN_ACTIONS = array(
-		'extwidget.serveFlavor',
+		'extwidget.serveflavor',
 		'extwidget.kwidget',
 		'extwidget.thumbnail',
 		'extwidget.download',


### PR DESCRIPTION
should pass strict=false to getReadyFileSyncForKey so that if the file sync is not found locally an empty path will be returned instead of error 500
