### PR TITLE
generic hls - add support for playManifest redirect

### DIFF
--- a/alpha/lib/model/DeliveryProfileGenericAppleHttp.php
+++ b/alpha/lib/model/DeliveryProfileGenericAppleHttp.php
@@ -21,6 +21,16 @@ class DeliveryProfileGenericAppleHttp extends DeliveryProfileAppleHttp {
 		return $this->getFromCustomData("rendererClass", null, $this->DEFAULT_RENDERER_CLASS);
 	}
 	
+	public function setManifestRedirect($v)
+	{
+		$this->putInCustomData("manifestRedirect", $v);
+	}
+	
+	public function getManifestRedirect()
+	{
+		return $this->getFromCustomData("manifestRedirect");
+	}
+	
 	protected function doGetFlavorAssetUrl(flavorAsset $flavorAsset) 
 	{
 		$url = $this->getBaseUrl($flavorAsset);
@@ -37,6 +47,18 @@ class DeliveryProfileGenericAppleHttp extends DeliveryProfileAppleHttp {
 		if(is_null($pattern))
 			$pattern = '/hls-vod/{url}.m3u8';
 		return kDeliveryUtils::formatGenericUrl($url, $pattern, $this->params);
+	}
+	
+	public function serve()
+	{
+		if ($this->getManifestRedirect() && $this->getHostName() != $_SERVER['HTTP_HOST'])
+		{
+			kApiCache::setConditionalCacheExpiry(600);		// the result contains a KS so we shouldn't cache it for a long time
+			$flavor = array('urlPrefix' => $this->getUrl(), 'url' => $_SERVER["REQUEST_URI"]);
+			return new kRedirectManifestRenderer(array($flavor), $this->params->getEntryId());
+		}
+		
+		return parent::serve();
 	}
 }
 

--- a/api_v3/lib/types/delivery/KalturaDeliveryProfileGenericAppleHttp.php
+++ b/api_v3/lib/types/delivery/KalturaDeliveryProfileGenericAppleHttp.php
@@ -16,11 +16,19 @@ class KalturaDeliveryProfileGenericAppleHttp extends KalturaDeliveryProfile {
 	 */
 	public $rendererClass;
 	
+	/**
+	 * Enable to make playManifest redirect to the domain of the delivery profile
+	 *
+	 * @var KalturaNullableBoolean
+	 */
+	public $manifestRedirect;
+	
 	
 	private static $map_between_objects = array
 	(
 			"pattern",
 			"rendererClass",
+			"manifestRedirect",
 	);
 	
 	public function getMapBetweenObjects ( )


### PR DESCRIPTION
the playManifest redirect is in order to make the playManifest request share the same domain with the flavor m3u8s and ts segments for token cookies
