### PR TITLE
Fix cue point list flow

### DIFF
--- a/alpha/lib/model/entryPeer.php
+++ b/alpha/lib/model/entryPeer.php
@@ -753,9 +753,13 @@ class entryPeer extends BaseentryPeer
 		
 		$c = KalturaCriteria::create(entryPeer::OM_CLASS);
 		$c->addAnd(entryPeer::ID, $entryIds, Criteria::IN);
-		$criterionPartnerOrKn = $c->getNewCriterion(entryPeer::PARTNER_ID, $partnerId);
-		$criterionPartnerOrKn->addOr($c->getNewCriterion(entryPeer::DISPLAY_IN_SEARCH, mySearchUtils::DISPLAY_IN_SEARCH_KALTURA_NETWORK));
-		$c->addAnd($criterionPartnerOrKn);
+		
+		if($partnerId >= 0)
+		{
+			$criterionPartnerOrKn = $c->getNewCriterion(entryPeer::PARTNER_ID, $partnerId);
+			$criterionPartnerOrKn->addOr($c->getNewCriterion(entryPeer::DISPLAY_IN_SEARCH, mySearchUtils::DISPLAY_IN_SEARCH_KALTURA_NETWORK));
+			$c->addAnd($criterionPartnerOrKn);
+		}
 
 		$dbEntries = self::doSelect($c);
 


### PR DESCRIPTION
When cue points list request is issued by one of Kaltura's internal
users, skip filtering by partner id
