### PR TITLE
generic hls / cookie token fixes

### DIFF
--- a/alpha/apps/kaltura/lib/request/infraRequestUtils.class.php
+++ b/alpha/apps/kaltura/lib/request/infraRequestUtils.class.php
@@ -116,8 +116,9 @@ class infraRequestUtils
 		}
 		else
 		{
-			header("Cache-Control:");
 			header("Expires: Sun, 19 Nov 2000 08:52:00 GMT");
+			header("Cache-Control: no-store, no-cache, must-revalidate, post-check=0, pre-check=0");
+			header("Pragma: no-cache" );
 		}
 	}
 	

--- a/alpha/apps/kaltura/lib/storage/urlTokenizers/kAkamaiSecureHDUrlTokenizer.php
+++ b/alpha/apps/kaltura/lib/storage/urlTokenizers/kAkamaiSecureHDUrlTokenizer.php
@@ -304,6 +304,11 @@ class kAkamaiSecureHDUrlTokenizer extends kUrlTokenizer
 	 */
 	public function tokenizeSingleUrl($url)
 	{
+		if ($this->useCookieHosts && !in_array($_SERVER['HTTP_HOST'], explode(',', $this->useCookieHosts)))
+		{
+			return $url;
+		}
+		
 		if ($this->rootDir)
 			$url = rtrim($this->rootDir, '/') . '/' . ltrim($url, '/');
 		
@@ -315,10 +320,9 @@ class kAkamaiSecureHDUrlTokenizer extends kUrlTokenizer
 		
 		if ($this->useCookieHosts)
 		{
-			if (in_array($_SERVER['HTTP_HOST'], explode(',', $this->useCookieHosts)))
-			{
-				setcookie($this->paramName, $token);
-			}
+			$slashPos = strrpos($acl, '/');
+			$path = $slashPos !== false ? substr($acl, 0, $slashPos + 1) : '/';
+			setrawcookie($this->paramName, $token, time() + $this->window, $path);
 			return $url;
 		}
 		
@@ -331,6 +335,11 @@ class kAkamaiSecureHDUrlTokenizer extends kUrlTokenizer
 	
 	public function tokenizeMultiUrls(&$baseUrl, &$flavors)
 	{
+		if ($this->useCookieHosts && !in_array($_SERVER['HTTP_HOST'], explode(',', $this->useCookieHosts)))
+		{
+			return;
+		}
+		
 		$urls = array();
 		foreach($flavors as &$flavor)
 		{
@@ -347,10 +356,9 @@ class kAkamaiSecureHDUrlTokenizer extends kUrlTokenizer
 		
 		if ($this->useCookieHosts)
 		{
-			if (in_array($_SERVER['HTTP_HOST'], explode(',', $this->useCookieHosts)))
-			{
-				setcookie($this->paramName, $token);
-			}
+			$slashPos = strrpos($acl, '/');
+			$path = $slashPos !== false ? substr($acl, 0, $slashPos + 1) : '/';
+			setrawcookie($this->paramName, $token, time() + $this->window, $path);
 			return;
 		}
 		

--- a/alpha/lib/model/DeliveryProfileGenericAppleHttp.php
+++ b/alpha/lib/model/DeliveryProfileGenericAppleHttp.php
@@ -54,7 +54,10 @@ class DeliveryProfileGenericAppleHttp extends DeliveryProfileAppleHttp {
 		if ($this->getManifestRedirect() && $this->getHostName() != $_SERVER['HTTP_HOST'])
 		{
 			kApiCache::setConditionalCacheExpiry(600);		// the result contains a KS so we shouldn't cache it for a long time
-			$flavor = array('urlPrefix' => $this->getUrl(), 'url' => $_SERVER["REQUEST_URI"]);
+			$parsedUrl = parse_url($this->getUrl());
+			$flavor = array(
+				'urlPrefix' => $parsedUrl['scheme'] . '://' . $parsedUrl['host'], 
+				'url' => $_SERVER["REQUEST_URI"]);
 			return new kRedirectManifestRenderer(array($flavor), $this->params->getEntryId());
 		}
 		


### PR DESCRIPTION
- need to return cache-control no-store for akamai to proxy the cookie
- need to use setrawcookie
- limit the cookie path and expiry according to the token
- add the token rootDir to the URL only when tokenizing it
- in manifest redirect, ignore the delivery url path
