### PR TITLE
directory created by the 'apache' user but job run as kaltura

### DIFF
--- a/configurations/cron/api.template
+++ b/configurations/cron/api.template
@@ -1,1 +1,1 @@
-*/15 * * * * kaltura @APP_DIR@/alpha/crond/kaltura/clear_cache.sh 2>&1 >> @LOG_DIR@/cron.log
+*/15 * * * * apache @APP_DIR@/alpha/crond/kaltura/clear_cache.sh 2>&1 >> @LOG_DIR@/cron.log


### PR DESCRIPTION
[root@kalt-single ~]# ll -d /tmp/cache_v3-600/
drwxr-xr-x 258 apache apache 4096 Aug 11 16:21 /tmp/cache_v3-600/

Running the job as 'kaltura' will fail every time. Creating a bloted mail file under /var/mail/kaltura, not to mention it would not do the job..
