### PR TITLE
Correction in string replacement algorithm

### DIFF
--- a/alpha/apps/kaltura/lib/batch2/kJobsManager.php
+++ b/alpha/apps/kaltura/lib/batch2/kJobsManager.php
@@ -918,7 +918,7 @@ class kJobsManager
 	public static function addImportJob(BatchJob $parentJob = null, $entryId, $partnerId, $entryUrl, asset $asset = null, $subType = null, kImportJobData $jobData = null, $keepCurrentVersion = false)
 	{
 		$entryUrl = str_replace('//', '/', $entryUrl);
-		$entryUrl = preg_replace('/^((https?)|(ftp)|(scp)|(sftp)):\//', '$1://', $entryUrl);
+		$entryUrl = preg_replace('/^((https?)|(ftp)|(scp)|(sftp)):\/', '$1://', $entryUrl);
 		
 		if (is_null($subType)) 
 		{


### PR DESCRIPTION
String replacement to correct additional '/' introduced in the url is not working correctly. 
Since "//" is being replaced in the previous line, the line 921 never executes leaving the / in front of http. 
My quick and simple suggestion is to remove one of the / in the patterns. It works fine with that.
