### PR TITLE
Correcting string replacement algorithm

### DIFF
--- a/plugins/content_distribution/lib/kContentDistributionManager.php
+++ b/plugins/content_distribution/lib/kContentDistributionManager.php
@@ -34,7 +34,7 @@ class kContentDistributionManager
 		KalturaLog::debug("Importing asset [" . $asset->getId() . "] from dc [$dc] with URL [$entryUrl]");
 		
 		$entryUrl = str_replace('//', '/', $entryUrl);
-		$entryUrl = preg_replace('/^((https?)|(ftp)|(scp)|(sftp)):\//', '$1://', $entryUrl);
+		$entryUrl = preg_replace('/^((https?)|(ftp)|(scp)|(sftp)):\/', '$1://', $entryUrl);
 	
 		$jobData = new kImportJobData();
 		$jobData->setCacheOnly(true);


### PR DESCRIPTION
String replacement to correct additional '/' introduced in the url is not working correctly. 
Since "//" is being replaced in the previous line, the line 37 never executes leaving the / in front of http. 
My quick and simple suggestion is to remove one of the / in the patterns. It works fine with that.
Otherwise there is a malformed url error.
