### PR TITLE
prevent problems caused by large sphinx sqls

### DIFF
--- a/plugins/sphinx_search/lib/kSphinxSearchManager.php
+++ b/plugins/sphinx_search/lib/kSphinxSearchManager.php
@@ -385,6 +385,21 @@ class kSphinxSearchManager implements kObjectUpdatedEventConsumer, kObjectAddedE
 	 */
 	public function execSphinx($sql, IIndexable $object)
 	{
+		// limit the number of large sphinx SQLs to 1/min per object, since they load the sphinx database
+		// and sphinx servers. the upper limit of 'slightly less than 1MB' is because of the max_allowed_packet 
+		// limit in mysql (by default 1MB). the upper limit is here to prevent the addition of too many category 
+		// users (for example), that will render the category un-indexable 
+		if (strlen($sql) > 128 * 1024 && strlen($sql) < 1000000)
+		{
+			$lockKey = 'large_sql_lock_' . get_class($object) . '_' . $object->getId();
+			$cache = kCacheManager::getSingleLayerCache(kCacheManager::CACHE_TYPE_SPHINX_STICKY_SESSIONS);
+			if ($cache && !$cache->add($lockKey, true, 60))
+			{
+				KalturaLog::log('skipping sql for key ' . $lockKey);
+				return;
+			}
+		}
+		
 		KalturaLog::debug($sql);
 				
 		$sphinxLog = new SphinxLog();

--- a/plugins/sphinx_search/scripts/populateFromLog.php
+++ b/plugins/sphinx_search/scripts/populateFromLog.php
@@ -57,8 +57,8 @@ $dbConf = kConf::getDB();
 DbManager::setConfig($dbConf);
 DbManager::initialize();
 
-$limit = 2000; 	// The number of sphinxLog records we want to query
-$gap = 1000;	// The gap from 'getLastLogId' we want to query
+$limit = 1000; 	// The number of sphinxLog records we want to query
+$gap = 500;	// The gap from 'getLastLogId' we want to query
 
 $serverLastLogs = SphinxLogServerPeer::retrieveByServer($sphinxServer);
 $lastLogs = array();


### PR DESCRIPTION
- avoid updating the same object more than once per minute
- fetch less objects at once in populate to prevent it from going out of memory
