### PR TITLE
fixed the last modified header returned from cache

### DIFF
--- a/alpha/apps/kaltura/lib/kManifestRenderers.php
+++ b/alpha/apps/kaltura/lib/kManifestRenderers.php
@@ -33,6 +33,11 @@ abstract class kManifestRenderer
 	public $forceCachingHeaders = false;
 	
 	/**
+	 * @var int
+	 */
+	public $lastModified = null;
+	
+	/**
 	 * @var string
 	 */
 	public $deliveryCode = '';
@@ -121,7 +126,7 @@ abstract class kManifestRenderer
 		if (kApiCache::hasExtraFields() && !$this->forceCachingHeaders)
 			$this->cachingHeadersAge = 0;
 		
-		infraRequestUtils::sendCachingHeaders($this->cachingHeadersAge, true);
+		infraRequestUtils::sendCachingHeaders($this->cachingHeadersAge, true, $this->lastModified);
 
 		$header = $this->getManifestHeader();
 		$footer = $this->getManifestFooter();
@@ -137,9 +142,13 @@ abstract class kManifestRenderer
 		$separator = $this->getSeparator();
 		
 		$flavorsString = implode($separator, $flavors);
-		$content .= $separator.$flavorsString;
+		if ($content)
+			$content .= $separator;		
+		$content .= $flavorsString;
 		
-		$content.=$separator.$footer;
+		if ($content)
+			$content .= $separator;		
+		$content .= $footer;
 		echo $content;
 		
 		die;

--- a/alpha/apps/kaltura/modules/extwidget/actions/playManifestAction.class.php
+++ b/alpha/apps/kaltura/modules/extwidget/actions/playManifestAction.class.php
@@ -940,6 +940,7 @@ class playManifestAction extends kalturaAction
 		if ($this->deliveryProfile)
 			$renderer->tokenizer = $this->deliveryProfile->getTokenizer();
 		$renderer->defaultDeliveryCode = $this->entry->getPartner()->getDefaultDeliveryCode();
+		$renderer->lastModified = time();
 		
 		// Handle caching
 		$canCacheAccessControl = false;

--- a/api_v3/lib/KalturaResponseCacher.php
+++ b/api_v3/lib/KalturaResponseCacher.php
@@ -104,7 +104,7 @@ class KalturaResponseCacher extends kApiCache
 		return $ks;
 	}
 
-	protected function sendCachingHeaders($usingCache)
+	protected function sendCachingHeaders($usingCache, $lastModified = null)
 	{
 		header("Access-Control-Allow-Origin:*"); // avoid html5 xss issues
 
@@ -122,7 +122,7 @@ class KalturaResponseCacher extends kApiCache
 			$max_age = $this->_cacheHeadersExpiry;
 			header("Cache-Control: private, max-age=$max_age, max-stale=0");
 			header('Expires: ' . gmdate('D, d M Y H:i:s', time() + $max_age) . 'GMT');
-			header('Last-Modified: ' . gmdate('D, d M Y H:i:s', time()) . 'GMT');
+			header('Last-Modified: ' . gmdate('D, d M Y H:i:s', $lastModified) . 'GMT');
 		}
 		else
 		{
@@ -167,7 +167,7 @@ class KalturaResponseCacher extends kApiCache
 		foreach ($responseMetadata['headers'] as $curHeader)
 			header($curHeader, true);
 		
-		$this->sendCachingHeaders(true);
+		$this->sendCachingHeaders(true, isset($responseMetadata['lastModified']) ? $responseMetadata['lastModified'] : time());
 
 		// for jsonp ignore the callback argument and replace it in result (e.g. callback_4([{...}]);
 		if (@$_REQUEST["format"] == 9)
@@ -214,7 +214,11 @@ class KalturaResponseCacher extends kApiCache
 			
 			$contentHeaders = $this->getContentHeaders();
 			
-			$responseMetadata = array('headers' => $contentHeaders, 'class' => $responseClass);
+			$responseMetadata = array(
+				'lastModified' => time(),
+				'headers' => $contentHeaders, 
+				'class' => $responseClass
+			);
 						
 			$this->storeCache($response, serialize($responseMetadata), $serializeResponse);
 		}


### PR DESCRIPTION
- make the playmanifest cache and api_v3 cache return the caching time as the last modified http header
- in addition, remove the 2 newlines that are returned in manifest redirect responses
