### PR TITLE
Added loading of mod_ssl

### DIFF
--- a/configurations/apache/kaltura.ssl.conf.template
+++ b/configurations/apache/kaltura.ssl.conf.template
@@ -2,7 +2,7 @@
 	LoadModule ssl_module modules/mod_ssl.so
 </IfModule>
 
-Listen 443
+Listen @KALTURA_VIRTUAL_HOST_PORT@
 
 SSLPassPhraseDialog  builtin
 SSLSessionCache         shmcb:/var/cache/mod_ssl/scache(512000)


### PR DESCRIPTION
Reference to: 
http://forum.kaltura.org/t/upgrade-from-9-18-x-to-9-19-x-latest-release-as-on-date-caused-ssl-to-break/662/2?u=shaktidhar1 

Conditional loading of mod_ssl in case not being addressed in httpd/conf/ssl.conf
