### PR TITLE
PLAT-2041 - Use example.com instead of real domain test.com

### DIFF
--- a/tests/sanity/01.partnerRegistration.php
+++ b/tests/sanity/01.partnerRegistration.php
@@ -8,9 +8,9 @@ require_once __DIR__ . '/lib/init.php';
 
 $partner = new KalturaPartner();
 $partner->name = 'sanity-test';
-$partner->website = 'sanity.test.com';
+$partner->website = 'sanity.example.com';
 $partner->adminName = 'sanity-test';
-$partner->adminEmail = uniqid('sanity.') . '@test.com';
+$partner->adminEmail = uniqid('sanity.') . '@example.com';
 $partner->description = 'sanity-test';
 $cmsPassword = uniqid('pW@4');
 $registeredPartner = $client->partner->register($partner, $cmsPassword);


### PR DESCRIPTION
Currently sanity check uses test.com which is a real domain. We do not want to send credential mails to test.com, so please use the specially reserved example.com see: https://tools.ietf.org/html/rfc6761
