### PR TITLE
Related playlist (_KDP_CTXPL) is missing on CE/OnPrem

### DIFF
--- a/deployment/base/scripts/init_data/04.entry.ini
+++ b/deployment/base/scripts/init_data/04.entry.ini
@@ -144,3 +144,13 @@ id=_KMCSPL2
 data=100000.txt
 name=PlaylistDemo2
 
+[_KDP_CTXPL]
+partnerId=0
+status=2
+type=5
+mediaType=10
+moderationStatus=6
+displayInSearch=2
+
+id=_KDP_CTXPL
+dataContent=@playlist/_KDP_CTXPL.xml

--- a/deployment/base/scripts/init_data/playlist/_KDP_CTXPL.xml
+++ b/deployment/base/scripts/init_data/playlist/_KDP_CTXPL.xml
@@ -1,0 +1,1 @@
+<?xml version="1.0"?><playlist><total_results>13</total_results><filters><filter><in_status>2,1</in_status><in_type>1,2,7</in_type><in_moderation_status>2,5,6,1</in_moderation_status><free_text dynamic="1">context::entry::tags</free_text><limit>13</limit></filter></filters></playlist>


### PR DESCRIPTION
Added data for related playlist _KDP_CTXPL which is required for the related player plugin to work.

@erankor please approve
@hilak @jessp01 FYI
