### PR TITLE
Removed default threading and added threads param to the batch worker

### DIFF
--- a/batch/batches/Convert/Engines/KConversionEngineFfmpeg.class.php
+++ b/batch/batches/Convert/Engines/KConversionEngineFfmpeg.class.php
@@ -19,7 +19,8 @@ class KConversionEngineFfmpeg  extends KJobConversionEngine
 	
 	public function getCmd ()
 	{
-		return KBatchBase::$taskConfig->params->ffmpegCmd;
+		$threads = isset( KBatchBase::$taskConfig->params->threads ) ? KBatchBase::$taskConfig->params->threads : 4;
+		return KBatchBase::$taskConfig->params->ffmpegCmd . ' -threads '. $threads;
 	}
 	
 	/**
@@ -56,7 +57,7 @@ class KConversionEngineFfmpeg  extends KJobConversionEngine
 				KBatchBase::impersonate($data->flavorParamsOutput->partnerId); 
 				
 				$wmCmdLine = self::buildWatermarkedCommandLine($wmData, $data->destFileSyncLocalPath, $exec_cmd, 
-									KBatchBase::$taskConfig->params->ffmpegCmd, KBatchBase::$taskConfig->params->mediaInfoCmd);
+									$this->getCmd(), KBatchBase::$taskConfig->params->mediaInfoCmd);
 				// un-impersonite
 				KBatchBase::unimpersonate();
 			}

--- a/batch/batches/Convert/OperationEngines/KOperationEngineFfmpeg.php
+++ b/batch/batches/Convert/OperationEngines/KOperationEngineFfmpeg.php
@@ -33,8 +33,12 @@ class KOperationEngineFfmpeg  extends KSingleOutputOperationEngine
 		// impersonite
 		KBatchBase::impersonate($this->data->flavorParamsOutput->partnerId); // !!!!!!!!!!!$this->job->partnerId);
 
+		// Apply theads configuration parameter, or default to 4
+		$threads = isset( KBatchBase::$taskConfig->params->threads ) ? KBatchBase::$taskConfig->params->threads : 4;
+		$ffmpegCmd = KBatchBase::$taskConfig->params->ffmpegCmd . ' -threads '. $threads;
+
 		$wmCmdLine = KConversionEngineFfmpeg::buildWatermarkedCommandLine($wmData, $this->data->destFileSyncLocalPath, $cmdLine,
-						KBatchBase::$taskConfig->params->ffmpegCmd, KBatchBase::$taskConfig->params->mediaInfoCmd);
+			$ffmpegCmd, KBatchBase::$taskConfig->params->mediaInfoCmd);
 		// un-impersonite
 		KBatchBase::unimpersonate();
 

--- a/configurations/batch/batch.ini.template
+++ b/configurations/batch/batch.ini.template
@@ -220,6 +220,8 @@ params.EncodingComUrl								= http://manage.encoding.com/index.php
 params.isRemoteInput								= 0
 params.isRemoteOutput								= 0
 
+params.threads                      = 4
+
 ;The path for local temporary generated product
 params.localTempPath 								= @TMP_DIR@/convert
 

--- a/deployment/base/scripts/init_data/04.flavorParams.ini
+++ b/deployment/base/scripts/init_data/04.flavorParams.ini
@@ -129,7 +129,7 @@ frameRate=0
 gopSize=0
 twoPass=0
 conversionEngines="2,99,3"
-conversionEnginesExtraParams="-flags +loop+mv4 -cmp 256 -partitions +parti4x4+partp8x8+partb8x8 -trellis 1 -refs 1 -me_range 16 -keyint_min 20 -sc_threshold 40 -i_qfactor 0.71 -bt 100k -maxrate 400k -bufsize 1200k -rc_eq 'blurCplx^(1-qComp)' -level 30 -async 2  -vsync 1 -threads 4 | -flags +loop+mv4 -cmp 256 -partitions +parti4x4+partp8x8+partb8x8 -trellis 1 -refs 1 -me_range 16 -keyint_min 20 -sc_threshold 40 -i_qfactor 0.71 -bt 100k -maxrate 400k -bufsize 1200k -rc_eq 'blurCplx^(1-qComp)' -level 30 -async 2 -vsync 1 | -x264encopts qcomp=0.6:qpmin=10:qpmax=50:qpstep=4:frameref=1:bframes=0:threads=auto:level_idc=30:global_header:partitions=i4x4+p8x8+b8x8:trellis=1:me_range=16:keyint_min=20:scenecut=40:ipratio=0.71:ratetol=20:vbv-maxrate=400:vbv-bufsize=1200"
+conversionEnginesExtraParams="-flags +loop+mv4 -cmp 256 -partitions +parti4x4+partp8x8+partb8x8 -trellis 1 -refs 1 -me_range 16 -keyint_min 20 -sc_threshold 40 -i_qfactor 0.71 -bt 100k -maxrate 400k -bufsize 1200k -rc_eq 'blurCplx^(1-qComp)' -level 30 -async 2  -vsync 1  | -flags +loop+mv4 -cmp 256 -partitions +parti4x4+partp8x8+partb8x8 -trellis 1 -refs 1 -me_range 16 -keyint_min 20 -sc_threshold 40 -i_qfactor 0.71 -bt 100k -maxrate 400k -bufsize 1200k -rc_eq 'blurCplx^(1-qComp)' -level 30 -async 2 -vsync 1 | -x264encopts qcomp=0.6:qpmin=10:qpmax=50:qpstep=4:frameref=1:bframes=0:level_idc=30:global_header:partitions=i4x4+p8x8+b8x8:trellis=1:me_range=16:keyint_min=20:scenecut=40:ipratio=0.71:ratetol=20:vbv-maxrate=400:vbv-bufsize=1200"
 aspectRatioProcessingMode=0
 isGopInSec=0
 forceFrameToMultiplication16=1
@@ -164,7 +164,7 @@ frameRate=0
 gopSize=0
 twoPass=0
 conversionEngines="2,99,3"
-conversionEnginesExtraParams="-flags +loop+mv4 -cmp 256 -partitions +parti4x4+partp8x8+partb8x8 -trellis 1 -refs 1 -me_range 16 -keyint_min 20 -sc_threshold 40 -i_qfactor 0.71 -bt 200k -maxrate 600k -bufsize 1200k -rc_eq 'blurCplx^(1-qComp)' -level 30 -async 2  -vsync 1 -threads 4 | -flags +loop+mv4 -cmp 256 -partitions +parti4x4+partp8x8+partb8x8 -trellis 1 -refs 1 -me_range 16 -keyint_min 20 -sc_threshold 40 -i_qfactor 0.71 -bt 200k -maxrate 600k -bufsize 1200k -rc_eq 'blurCplx^(1-qComp)' -level 30 -async 2 -vsync 1 | -x264encopts qcomp=0.6:qpmin=10:qpmax=50:qpstep=4:frameref=1:bframes=0:threads=auto:level_idc=30:global_header:partitions=i4x4+p8x8+b8x8:trellis=1:me_range=16:keyint_min=20:scenecut=40:ipratio=0.71:ratetol=20:vbv-maxrate=600:vbv-bufsize=1200"
+conversionEnginesExtraParams="-flags +loop+mv4 -cmp 256 -partitions +parti4x4+partp8x8+partb8x8 -trellis 1 -refs 1 -me_range 16 -keyint_min 20 -sc_threshold 40 -i_qfactor 0.71 -bt 200k -maxrate 600k -bufsize 1200k -rc_eq 'blurCplx^(1-qComp)' -level 30 -async 2  -vsync 1  | -flags +loop+mv4 -cmp 256 -partitions +parti4x4+partp8x8+partb8x8 -trellis 1 -refs 1 -me_range 16 -keyint_min 20 -sc_threshold 40 -i_qfactor 0.71 -bt 200k -maxrate 600k -bufsize 1200k -rc_eq 'blurCplx^(1-qComp)' -level 30 -async 2 -vsync 1 | -x264encopts qcomp=0.6:qpmin=10:qpmax=50:qpstep=4:frameref=1:bframes=0:level_idc=30:global_header:partitions=i4x4+p8x8+b8x8:trellis=1:me_range=16:keyint_min=20:scenecut=40:ipratio=0.71:ratetol=20:vbv-maxrate=600:vbv-bufsize=1200"
 aspectRatioProcessingMode=0
 isGopInSec=0
 forceFrameToMultiplication16=1
@@ -199,7 +199,7 @@ frameRate=0
 gopSize=0
 twoPass=0
 conversionEngines="2,99,3"
-conversionEnginesExtraParams="-flags +loop+mv4 -cmp 256 -partitions +parti4x4+partp8x8+partb8x8 -trellis 1 -refs 1 -me_range 16 -keyint_min 20 -sc_threshold 40 -i_qfactor 0.71 -bt 300k -maxrate 900k -bufsize 1200k -rc_eq 'blurCplx^(1-qComp)' -level 31 -async 2  -vsync 1 -threads 4 | -flags +loop+mv4 -cmp 256 -partitions +parti4x4+partp8x8+partb8x8 -trellis 1 -refs 1 -me_range 16 -keyint_min 20 -sc_threshold 40 -i_qfactor 0.71 -bt 300k -maxrate 900k -bufsize 1200k -rc_eq 'blurCplx^(1-qComp)' -level 31 -async 2 -vsync 1 | -x264encopts qcomp=0.6:qpmin=10:qpmax=50:qpstep=4:frameref=1:bframes=0:threads=auto:level_idc=31:global_header:partitions=i4x4+p8x8+b8x8:trellis=1:me_range=16:keyint_min=20:scenecut=40:ipratio=0.71:ratetol=40:vbv-maxrate=900:vbv-bufsize=1200"
+conversionEnginesExtraParams="-flags +loop+mv4 -cmp 256 -partitions +parti4x4+partp8x8+partb8x8 -trellis 1 -refs 1 -me_range 16 -keyint_min 20 -sc_threshold 40 -i_qfactor 0.71 -bt 300k -maxrate 900k -bufsize 1200k -rc_eq 'blurCplx^(1-qComp)' -level 31 -async 2  -vsync 1  | -flags +loop+mv4 -cmp 256 -partitions +parti4x4+partp8x8+partb8x8 -trellis 1 -refs 1 -me_range 16 -keyint_min 20 -sc_threshold 40 -i_qfactor 0.71 -bt 300k -maxrate 900k -bufsize 1200k -rc_eq 'blurCplx^(1-qComp)' -level 31 -async 2 -vsync 1 | -x264encopts qcomp=0.6:qpmin=10:qpmax=50:qpstep=4:frameref=1:bframes=0:level_idc=31:global_header:partitions=i4x4+p8x8+b8x8:trellis=1:me_range=16:keyint_min=20:scenecut=40:ipratio=0.71:ratetol=40:vbv-maxrate=900:vbv-bufsize=1200"
 aspectRatioProcessingMode=0
 isGopInSec=0
 forceFrameToMultiplication16=1
@@ -234,7 +234,7 @@ frameRate=0
 gopSize=0
 twoPass=0
 conversionEngines="2,99,3"
-conversionEnginesExtraParams="-flags +loop+mv4 -cmp 256 -partitions +parti4x4+partp8x8+partb8x8 -trellis 1 -refs 1 -me_range 16 -keyint_min 20 -sc_threshold 40 -i_qfactor 0.71 -bt 400k -maxrate 1500k -bufsize 1200k -rc_eq 'blurCplx^(1-qComp)' -level 31 -async 2  -vsync 1 -threads 4 | -flags +loop+mv4 -cmp 256 -partitions +parti4x4+partp8x8+partb8x8 -trellis 1 -refs 1 -me_range 16 -keyint_min 20 -sc_threshold 40 -i_qfactor 0.71 -bt 400k -maxrate 1500k -bufsize 1200k -rc_eq 'blurCplx^(1-qComp)' -level 31 -async 2 -vsync 1 | -x264encopts qcomp=0.6:qpmin=10:qpmax=50:qpstep=4:frameref=1:bframes=0:threads=auto:level_idc=31:global_header:partitions=i4x4+p8x8+b8x8:trellis=1:me_range=16:keyint_min=20:scenecut=40:ipratio=0.71:ratetol=40:vbv-maxrate=1500:vbv-bufsize=1200"
+conversionEnginesExtraParams="-flags +loop+mv4 -cmp 256 -partitions +parti4x4+partp8x8+partb8x8 -trellis 1 -refs 1 -me_range 16 -keyint_min 20 -sc_threshold 40 -i_qfactor 0.71 -bt 400k -maxrate 1500k -bufsize 1200k -rc_eq 'blurCplx^(1-qComp)' -level 31 -async 2  -vsync 1  | -flags +loop+mv4 -cmp 256 -partitions +parti4x4+partp8x8+partb8x8 -trellis 1 -refs 1 -me_range 16 -keyint_min 20 -sc_threshold 40 -i_qfactor 0.71 -bt 400k -maxrate 1500k -bufsize 1200k -rc_eq 'blurCplx^(1-qComp)' -level 31 -async 2 -vsync 1 | -x264encopts qcomp=0.6:qpmin=10:qpmax=50:qpstep=4:frameref=1:bframes=0:level_idc=31:global_header:partitions=i4x4+p8x8+b8x8:trellis=1:me_range=16:keyint_min=20:scenecut=40:ipratio=0.71:ratetol=40:vbv-maxrate=1500:vbv-bufsize=1200"
 aspectRatioProcessingMode=1
 isGopInSec=0
 forceFrameToMultiplication16=1
@@ -269,7 +269,7 @@ frameRate=0
 gopSize=0
 twoPass=0
 conversionEngines="2,99,3"
-conversionEnginesExtraParams="-flags +loop+mv4 -cmp 256 -partitions +parti4x4+partp8x8+partb8x8 -trellis 1 -refs 6 -me_range 16 -keyint_min 20 -sc_threshold 40 -i_qfactor 0.71 -bt 700k -maxrate 2500k -bufsize 5000k -rc_eq 'blurCplx^(1-qComp)' -async 2  -vsync 1 -threads 4 | -flags +loop+mv4 -cmp 256 -partitions +parti4x4+partp8x8+partb8x8 -trellis 1 -refs 6 -me_range 16 -keyint_min 20 -sc_threshold 40 -i_qfactor 0.71 -bt 700k -maxrate 2500k -bufsize 5000k -rc_eq 'blurCplx^(1-qComp)' -async 2 -vsync 1 | -x264encopts qcomp=0.6:qpmin=10:qpmax=50:qpstep=4:frameref=6:bframes=0:threads=auto:global_header:partitions=i4x4+p8x8+b8x8:trellis=1:me_range=16:keyint_min=20:scenecut=40:ipratio=0.71:ratetol=40:vbv-maxrate=2500:vbv-bufsize=5000"
+conversionEnginesExtraParams="-flags +loop+mv4 -cmp 256 -partitions +parti4x4+partp8x8+partb8x8 -trellis 1 -refs 6 -me_range 16 -keyint_min 20 -sc_threshold 40 -i_qfactor 0.71 -bt 700k -maxrate 2500k -bufsize 5000k -rc_eq 'blurCplx^(1-qComp)' -async 2  -vsync 1  | -flags +loop+mv4 -cmp 256 -partitions +parti4x4+partp8x8+partb8x8 -trellis 1 -refs 6 -me_range 16 -keyint_min 20 -sc_threshold 40 -i_qfactor 0.71 -bt 700k -maxrate 2500k -bufsize 5000k -rc_eq 'blurCplx^(1-qComp)' -async 2 -vsync 1 | -x264encopts qcomp=0.6:qpmin=10:qpmax=50:qpstep=4:frameref=6:bframes=0:global_header:partitions=i4x4+p8x8+b8x8:trellis=1:me_range=16:keyint_min=20:scenecut=40:ipratio=0.71:ratetol=40:vbv-maxrate=2500:vbv-bufsize=5000"
 aspectRatioProcessingMode=0
 isGopInSec=0
 forceFrameToMultiplication16=1
@@ -304,7 +304,7 @@ frameRate=0
 gopSize=0
 twoPass=0
 conversionEngines="2,99,3"
-conversionEnginesExtraParams="-flags +loop+mv4 -cmp 256 -partitions +parti4x4+partp8x8+partb8x8 -trellis 1 -refs 6 -me_range 16 -keyint_min 20 -sc_threshold 40 -i_qfactor 0.71 -bt 1200k -maxrate 4000k -bufsize 8000k -rc_eq 'blurCplx^(1-qComp)' -async 2  -vsync 1 -threads 4 | -flags +loop+mv4 -cmp 256 -partitions +parti4x4+partp8x8+partb8x8 -trellis 1 -refs 6 -me_range 16 -keyint_min 20 -sc_threshold 40 -i_qfactor 0.71 -bt 1200k -maxrate 4000k -bufsize 8000k -rc_eq 'blurCplx^(1-qComp)' -async 2 -vsync 1 | -x264encopts qcomp=0.6:qpmin=10:qpmax=50:qpstep=4:frameref=6:bframes=0:threads=auto:global_header:partitions=i4x4+p8x8+b8x8:trellis=1:me_range=16:keyint_min=20:scenecut=40:ipratio=0.71:ratetol=40:vbv-maxrate=4000:vbv-bufsize=8000"
+conversionEnginesExtraParams="-flags +loop+mv4 -cmp 256 -partitions +parti4x4+partp8x8+partb8x8 -trellis 1 -refs 6 -me_range 16 -keyint_min 20 -sc_threshold 40 -i_qfactor 0.71 -bt 1200k -maxrate 4000k -bufsize 8000k -rc_eq 'blurCplx^(1-qComp)' -async 2  -vsync 1  | -flags +loop+mv4 -cmp 256 -partitions +parti4x4+partp8x8+partb8x8 -trellis 1 -refs 6 -me_range 16 -keyint_min 20 -sc_threshold 40 -i_qfactor 0.71 -bt 1200k -maxrate 4000k -bufsize 8000k -rc_eq 'blurCplx^(1-qComp)' -async 2 -vsync 1 | -x264encopts qcomp=0.6:qpmin=10:qpmax=50:qpstep=4:frameref=6:bframes=0:global_header:partitions=i4x4+p8x8+b8x8:trellis=1:me_range=16:keyint_min=20:scenecut=40:ipratio=0.71:ratetol=40:vbv-maxrate=4000:vbv-bufsize=8000"
 aspectRatioProcessingMode=0
 isGopInSec=0
 forceFrameToMultiplication16=1


### PR DESCRIPTION
After upgrading I noticed that convert jobs were taking up to ~800% CPU load per convert Job instance.

Upon inspection I found out:
- The new ffmpeg has great multithreading support but without -threads it uses as much threads as it can.
- The new default flavors have -threads in the flavor params.
- When multiple -threads parameters are defined in the command, the last one is used.

After talking with @jessp01 we agreed this solution would be best:
- Remove -threads 4 from default flavors
- Add a optional threads option in the batch.ini
- When no threads option is present, it defaults to 4 so installed systems aren't affected.
- Overriding on a per flavor basis, is possible via the extra flavor params.

This brings convert jobs back to at least manageable levels. The only thing I can't seem to figure out, is:
-  flavors with no conversion_engines_extra_params use exactly 1 thread (h264b, AAC)
- flavors with extra conversion_engines_extra_params span more than one thread. How can we affect this behavior further?

Example failing params:
-flags +loop+mv4 -cmp 256 -partitions +parti4x4+partp8x8+partb8x8 -trellis 1 -refs 1 -me_range 16 -keyint_min 20 -sc_threshold 40 -i_qfactor 0.71 -bt 800k -maxrate 1200k -bufsize 1200k -rc_eq 'blurCplx^(1-qComp)' -level 30 -async 2 -vsync 2 | -flags +loop+mv4 -cmp 256 -partitions +parti4x4+partp8x8+partb8x8 -trellis 1 -refs 1 -me_range 16 -keyint_min 20 -sc_threshold 40 -i_qfactor 0.71 -bt 800k -maxrate 1200k -bufsize 1200k -rc_eq 'blurCplx^(1-qComp)' -level 30 -async 2 -vsync 2
