### PR TITLE
httpss issue in email notification

### DIFF
--- a/alpha/lib/model/UserLoginDataPeer.php
+++ b/alpha/lib/model/UserLoginDataPeer.php
@@ -327,7 +327,7 @@ class UserLoginDataPeer extends BaseUserLoginDataPeer {
 		}
 
 		$httpsEnforcePermission = PermissionPeer::isValidForPartner(PermissionName::FEATURE_KMC_ENFORCE_HTTPS, $partnerId);
-		if($httpsEnforcePermission)
+		if(strpos($resetLinkPrefix, infraRequestUtils::PROTOCOL_HTTPS) === false && $httpsEnforcePermission)
 			$resetLinkPrefix = str_replace(infraRequestUtils::PROTOCOL_HTTP , infraRequestUtils::PROTOCOL_HTTPS , $resetLinkPrefix);
 
 		return $resetLinkPrefix.$hashKey;


### PR DESCRIPTION
Hi,

I'm re-opening https://github.com/kaltura/platform-install-packages/issues/260 here to send a pull request.

We had been struggling from the following wrong service url in resetting password. As you see, we are using https://HOSTNAME:443 as our service url but the link is becoming "httpss" instead of "https".

```
Hello Shoji Kajita,

A new Kaltura Admin Console user account on Kaltura's online video platform has been created for you by Kaltura Administrator.

Your Kaltura Admin Console Login Information:

Login email: xxxx@kyoto-u.ac.jp.
To set your user password go to:

httpss://HOSTNAME:443/index.php/kmc/kmc/setpasshashkey/NHwxNDE0ODEyNzk1fDk5ZjI2ODMwNWE3MmRhOTg5ZDIwN2Y2MDIyZTJlMzlhMDU3YTQ0OGE=

Please note that these credentials (login email and password) will be used when you open a KMC user account
with the same login email address that you are using for the Admin Console.

Your role in the admin console account is : System Administrator.

Once you have set your password you can log into Kaltura's Admin Console at https://HOSTNAME:443 and get started!

Kaltura Customer Service


Please do not reply to this email, however feel free to share any feedback in our forums at http://bit.ly/KalturaForums . 
If you would like to unsubscribe, please click this link: https://HOSTNAME:443/index.php/extwidget/blockMail?e=xxxx@kyoto-u.ac.jp;dcfcf94109869fde54c5b2616838266b4bd8e451
```

This issue occurs when the following setting is used in /opt/kaltura/app/configurations/local.ini

```
[password_reset_links]
default = https://FQDN:443/index.php/kmc/kmc/setpasshashkey/
```

So, the protocol replacement from http to https should be performed when $resetLinkPrefix is NOT https.
