### PR TITLE
Tokenizers should require dependencies

### DIFF
--- a/alpha/apps/kaltura/lib/storage/urlTokenizers/kAkamaiHttpUrlTokenizer.php
+++ b/alpha/apps/kaltura/lib/storage/urlTokenizers/kAkamaiHttpUrlTokenizer.php
@@ -1,4 +1,7 @@
 <?php
+
+require_once(dirname(__FILE__).'/../../kDeliveryUtils.php');
+
 class kAkamaiHttpUrlTokenizer extends kUrlTokenizer
 {
 	/**

--- a/alpha/apps/kaltura/lib/storage/urlTokenizers/kLevel3UrlTokenizer.php
+++ b/alpha/apps/kaltura/lib/storage/urlTokenizers/kLevel3UrlTokenizer.php
@@ -1,4 +1,7 @@
 <?php
+
+require_once(dirname(__FILE__).'/../../kDeliveryUtils.php');
+
 class kLevel3UrlTokenizer extends kUrlTokenizer
 {
 	/**


### PR DESCRIPTION
The include is required since tokenizers should require any depenedencies and not relay on the autoloader
