### PR TITLE
objective c client fixes

### DIFF
--- a/api_v3/lib/types/fileAsset/filters/KalturaFileAssetFilter.php
+++ b/api_v3/lib/types/fileAsset/filters/KalturaFileAssetFilter.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * @package plugins.metadata
+ * @package api
  * @subpackage api.filters
  */
 class KalturaFileAssetFilter extends KalturaFileAssetBaseFilter

--- a/configurations/generator.ini
+++ b/configurations/generator.ini
@@ -115,6 +115,7 @@ generator = JsClientGenerator
 generator = PythonClientGenerator
 
 [objc : public]
+exclude = batch.*, batchcontrol.*, jobs.*, media.addfrombulk, document.*, categoryentry.addfrombulkupload
 generator = ObjCClientGenerator
 linkhref = https://github.com/kaltura/IOSReferenceApp
 linktext = "Sample app on GitHub"


### PR DESCRIPTION
- KalturaFileAssetFilter was generated under the metadata plugin instead of core
- need to exclude the core document service since it uses objects defined in a plugin
- need to exclude categoryEntry.addFromBulkUpload from the same reason
