### PR TITLE
when installing mod_ssl RPM, a file called /etc/httpd/conf.d/ssl.conf is

### DIFF
--- a/configurations/apache/kaltura.ssl.conf.template
+++ b/configurations/apache/kaltura.ssl.conf.template
@@ -2,7 +2,6 @@
 	LoadModule ssl_module modules/mod_ssl.so
 </IfModule>
 
-Listen @KALTURA_VIRTUAL_HOST_PORT@
 
 SSLPassPhraseDialog  builtin
 SSLSessionCache         shmcb:/var/cache/mod_ssl/scache(512000)


### PR DESCRIPTION
placed on disk. This file already has Listen 443 directive and so, if
the user chose port 443 then we will end up with 2:
Listen 443
directives. One in the default ssl.conf file and another in
configurations/apache/kaltura.ssl.conf.
This will cause apache to fail when initing since there will be a double
attempt to open a listener.
