### PR TITLE
There is no reference sign on a function call - only on function definitions

### DIFF
--- a/batch/batches/PostConvert/KAsyncPostConvert.class.php
+++ b/batch/batches/PostConvert/KAsyncPostConvert.class.php
@@ -109,7 +109,7 @@ class KAsyncPostConvert extends KJobHandlerWorker
 		$detectMsg = null;
 		if(isset($data->flavorParamsOutput) && isset($data->flavorParamsOutput->operators)
 		&& strstr($data->flavorParamsOutput->operators, "webexNbrplayer.WebexNbrplayer")!=false) {
-			$rv = $this->checkForValidityOfWebexProduct($data, realpath($mediaFile), $mediaInfo, &$detectMsg);
+			$rv = $this->checkForValidityOfWebexProduct($data, realpath($mediaFile), $mediaInfo, $detectMsg);
 			if($rv==false){
 				return $this->closeJob($job, KalturaBatchJobErrorTypes::APP, KalturaBatchJobAppErrors::BLACK_OR_SILENT_CONTENT, $detectMsg, KalturaBatchJobStatus::FAILED);
 			}


### PR DESCRIPTION
Function definitions alone are enough to correctly pass the
argument by reference. As of PHP 5.3.0, you will get a warning saying
that "call-time pass-by-reference" is deprecated when you use & in
foo(&$a);. And as of PHP 5.4.0, call-time pass-by-reference was removed,
so using it will raise a fatal error.
