### PR TITLE
Generate thumbnail for LOCAL Remote Storages

### DIFF
--- a/alpha/apps/kaltura/lib/batch2/bcdl/kBusinessPreConvertDL.php
+++ b/alpha/apps/kaltura/lib/batch2/bcdl/kBusinessPreConvertDL.php
@@ -279,11 +279,18 @@ class kBusinessPreConvertDL
 		
 		if(!$fileSync || $fileSync->getFileType() == FileSync::FILE_SYNC_FILE_TYPE_URL)
 		{
-			$errDescription = 'Source asset could has no valid file sync';
-			return false;
+			$dcId = $fileSync->getDc();
+			$storageProfile = StorageProfilePeer::retrieveByPK($dcId);
+			if(!is_null($storageProfile) && $storageProfile->getProtocol() == StorageProfile::STORAGE_PROTOCOL_LOCAL)
+				$srcPath = $storageProfile->getStorageBaseDir() . "/" . $fileSync->getFilePath();
+			else{
+				$errDescription = 'Source asset could has no valid file sync';
+				return false;
+                        }
 		}
+		else
+			$srcPath = $fileSync->getFullPath();
 		
-		$srcPath = $fileSync->getFullPath();
 		$uniqid = uniqid('thumb_');
 		$tempDir = kConf::get('cache_root_path') . DIRECTORY_SEPARATOR . 'thumb';
 		if(!file_exists($tempDir))

--- a/alpha/lib/model/StorageProfile.php
+++ b/alpha/lib/model/StorageProfile.php
@@ -24,6 +24,7 @@ class StorageProfile extends BaseStorageProfile
 	const STORAGE_PROTOCOL_SCP = 2;
 	const STORAGE_PROTOCOL_SFTP = 3;
 	const STORAGE_PROTOCOL_S3 = 6;
+	const STORAGE_PROTOCOL_LOCAL = 7;
 	
 	const STORAGE_DEFAULT_KALTURA_PATH_MANAGER = 'kPathManager';
 	const STORAGE_DEFAULT_EXTERNAL_PATH_MANAGER = 'kExternalPathManager';

--- a/api_v3/services/ThumbAssetService.php
+++ b/api_v3/services/ThumbAssetService.php
@@ -652,7 +652,13 @@ class ThumbAssetService extends KalturaAssetService
 		
 		if($fileSync->getFileType() == FileSync::FILE_SYNC_FILE_TYPE_URL)
 		{
-			throw new KalturaAPIException(KalturaErrors::SOURCE_FILE_REMOTE);
+			$dcId = $fileSync->getDc();
+			$storageProfile = StorageProfilePeer::retrieveByPK($dcId);
+			//We are using a remote storage, but it is LOCAL
+			if(!is_null($storageProfile) && $storageProfile->getProtocol() == StorageProfile::STORAGE_PROTOCOL_LOCAL)
+				$local = true;
+			else
+				throw new KalturaAPIException(KalturaErrors::SOURCE_FILE_REMOTE);
 		}
 		
 		if(!$local)


### PR DESCRIPTION
As it is now, Kaltura can only generate thumbnails for entries which are in the main DC, i.e. using the default storage space that comes with kaltura (/web/content/entry/data...).
In order to generate thumbnails for entries which are stored in a remote storage, there has to be a flavor that remains in that main DC.
Nevertheless, if you are using a Remote Storage configured as LOCAL, you can access locally to it, so I've made this modification which checks if this is the case, and then builds the source path for the video to generate correctly the thumbnail.