### PR TITLE
PLAT-2289 Live to VOD offset fix

### DIFF
--- a/alpha/lib/data/live/kLiveRecordingSegmentInfo.php
+++ b/alpha/lib/data/live/kLiveRecordingSegmentInfo.php
@@ -1,0 +1,38 @@
+<?php
+
+/**
+ * Map duration and offset of a live and its associated VOD entries
+ * 
+ * @package Core
+ * @subpackage model
+ *
+ */
+class kLiveRecordingSegmentInfo
+{
+	/**
+	 * Live stream relative start time in msec.
+	 * @var int
+	 */
+	protected $liveStreamStartTime = 0;
+
+	/**
+	 * VOD entry relative end time in msec.
+	 * @var int
+	 */
+	protected $vodEntryEndTime = 0;
+
+	/**
+	 * The diff between VOD end time and live stream end time in msec
+	 * @var int
+	 */
+	protected $vodToLiveDeltaTime = 0;
+
+	public function setLiveStreamStartTime( $liveStreamStartTime ) { $this->liveStreamStartTime = $liveStreamStartTime; }
+	public function getLiveStreamStartTime() { return $this->liveStreamStartTime; }
+	
+	public function setVodEntryEndTime( $vodEntryEndTime ) { $this->vodEntryEndTime = $vodEntryEndTime; }
+	public function getVodEntryEndTime() { return $this->vodEntryEndTime; }
+	
+	public function setVodToLiveDeltaTime( $vodToLiveDeltaTime ) { $this->vodToLiveDeltaTime = $vodToLiveDeltaTime; }
+	public function getVodToLiveDeltaTime() { return $this->vodToLiveDeltaTime; }
+}

--- a/alpha/lib/model/LiveEntry.php
+++ b/alpha/lib/model/LiveEntry.php
@@ -229,11 +229,8 @@ abstract class LiveEntry extends entry
 		$this->putInCustomData("dvr_window", $v);
 	}
 	
-	public function getLastElapsedRecordingTime()		{ return $this->getLastElapsedLiveDuration(); } // Left for backward compatibility
-	public function setLastElapsedRecordingTime( $v )	{ $this->setLastElapsedLiveDuration( $v ); }	// Left for backward compatibility
-
-	public function getLastElapsedLiveDuration()		{ return $this->getFromCustomData( "lastElapsedLiveDuration", null, 0 ); }
-	public function setLastElapsedLiveDuration( $v )	{ $this->putInCustomData( "lastElapsedLiveDuration" , $v ); }
+	public function getLastElapsedRecordingTime()		{ return $this->getFromCustomData( "lastElapsedRecordingTime", null, 0 ); }
+	public function setLastElapsedRecordingTime( $v )	{ $this->putInCustomData( "lastElapsedRecordingTime" , $v ); }
 
 	public function getRecordedLengthInMsec()			{ return $this->getFromCustomData( "recordedLengthInMsec", null, 0 ); }
 	public function setRecordedLengthInMsec( $v )		{ $this->putInCustomData( "recordedLengthInMsec" , $v ); }

--- a/alpha/lib/model/LiveEntry.php
+++ b/alpha/lib/model/LiveEntry.php
@@ -229,8 +229,17 @@ abstract class LiveEntry extends entry
 		$this->putInCustomData("dvr_window", $v);
 	}
 	
-	public function getLastElapsedRecordingTime()		{ return $this->getFromCustomData( "lastElapsedRecordingTime", null, 0 ); }
-	public function setLastElapsedRecordingTime( $v )	{ $this->putInCustomData( "lastElapsedRecordingTime" , $v ); }
+	public function getLastElapsedRecordingTime()		{ return $this->getLastElapsedLiveDuration(); } // Left for backward compatibility
+	public function setLastElapsedRecordingTime( $v )	{ $this->setLastElapsedLiveDuration( $v ); }	// Left for backward compatibility
+
+	public function getLastElapsedLiveDuration()		{ return $this->getFromCustomData( "lastElapsedLiveDuration", null, 0 ); }
+	public function setLastElapsedLiveDuration( $v )	{ $this->putInCustomData( "lastElapsedLiveDuration" , $v ); }
+
+	public function getRecordedLengthInMsec()			{ return $this->getFromCustomData( "recordedLengthInMsec", null, 0 ); }
+	public function setRecordedLengthInMsec( $v )		{ $this->putInCustomData( "recordedLengthInMsec" , $v ); }
+
+	public function setLiveRecordingSegmentInfoArray( $v )	{ $this->putInCustomData('live_recording_segment_info_array', $v); }
+	public function getLiveRecordingSegmentInfoArray()		{ return $this->getFromCustomData('live_recording_segment_info_array',null, array()); }
 
 	public function setStreamName ( $v )	{	$this->putInCustomData ( "streamName" , $v );	}
 	public function getStreamName (  )	{	return $this->getFromCustomData( "streamName", null, $this->getId() . '_%i' );	}

--- a/api_v3/lib/KalturaLiveEntryService.php
+++ b/api_v3/lib/KalturaLiveEntryService.php
@@ -93,7 +93,7 @@ class KalturaLiveEntryService extends KalturaEntryService
 			if ( $isLastChunk )
 			{
 				$liveRecordingSegmentInfo = new kLiveRecordingSegmentInfo();
-				$liveRecordingSegmentInfo->setLiveStreamStartTime( $dbEntry->getLastElapsedLiveDuration() );
+				$liveRecordingSegmentInfo->setLiveStreamStartTime( $dbEntry->getLastElapsedRecordingTime() );
 				$liveRecordingSegmentInfo->setVodEntryEndTime( $recordedLengthInMsec );
 				$liveRecordingSegmentInfo->setVodToLiveDeltaTime( $currentDuration - $recordedLengthInMsec );
 

--- a/api_v3/lib/KalturaLiveEntryService.php
+++ b/api_v3/lib/KalturaLiveEntryService.php
@@ -61,19 +61,6 @@ class KalturaLiveEntryService extends KalturaEntryService
 			$currentDuration = 0;
 		$currentDuration += (int)($duration * 1000);
 		
-		if($dbAsset->hasTag(assetParams::TAG_RECORDING_ANCHOR) && $mediaServerIndex == KalturaMediaServerIndex::PRIMARY)
-		{
-			$dbEntry->setLengthInMsecs($currentDuration);
-
-			if ( $isLastChunk )
-			{
-				// Save last elapsed recording time
-				$dbEntry->setLastElapsedRecordingTime( $currentDuration );
-			}
-
-			$dbEntry->save();
-		}
-	
 		$maxRecordingDuration = (kConf::get('max_live_recording_duration_hours') + 1) * 60 * 60 * 1000;
 		if($currentDuration > $maxRecordingDuration)
 		{
@@ -90,6 +77,37 @@ class KalturaLiveEntryService extends KalturaEntryService
 			chgrp($filename, kConf::get('content_group'));
 			chmod($filename, 0640);
 		}
+
+		if($dbAsset->hasTag(assetParams::TAG_RECORDING_ANCHOR) && $mediaServerIndex == KalturaMediaServerIndex::PRIMARY)
+		{
+			$dbEntry->setLengthInMsecs($currentDuration);
+
+			// Extract the exact video segment duration from the recorded file
+			$mediaInfoParser = new KMediaInfoMediaParser($filename, kConf::get('bin_path_mediainfo'));
+			$recordedSegmentDurationInMsec = $mediaInfoParser->getMediaInfo()->videoDuration;
+
+			// Set the total recorded time
+			$recordedLengthInMsec = $dbEntry->getRecordedLengthInMsec() + $recordedSegmentDurationInMsec;
+			$dbEntry->setRecordedLengthInMsec( $recordedLengthInMsec );
+
+			if ( $isLastChunk )
+			{
+				$liveRecordingSegmentInfo = new kLiveRecordingSegmentInfo();
+				$liveRecordingSegmentInfo->setLiveStreamStartTime( $dbEntry->getLastElapsedLiveDuration() );
+				$liveRecordingSegmentInfo->setVodEntryEndTime( $recordedLengthInMsec );
+				$liveRecordingSegmentInfo->setVodToLiveDeltaTime( $currentDuration - $recordedLengthInMsec );
+
+				$liveRecordingSegmentInfoArray = $dbEntry->getLiveRecordingSegmentInfoArray();
+				$liveRecordingSegmentInfoArray[] = $liveRecordingSegmentInfo;
+				$dbEntry->setLiveRecordingSegmentInfoArray( $liveRecordingSegmentInfoArray );
+
+				// Save last elapsed recording time
+				$dbEntry->setLastElapsedRecordingTime( $currentDuration );
+			}
+
+			$dbEntry->save();
+		}
+
 		kJobsManager::addConvertLiveSegmentJob(null, $dbAsset, $mediaServerIndex, $filename, $currentDuration);
 		
 		if($mediaServerIndex == KalturaMediaServerIndex::PRIMARY)

--- a/api_v3/lib/types/entry/KalturaLiveEntry.php
+++ b/api_v3/lib/types/entry/KalturaLiveEntry.php
@@ -36,15 +36,8 @@ abstract class KalturaLiveEntry extends KalturaMediaEntry
 	/**
 	 * Elapsed recording time (in msec) up to the point where the live stream was last stopped (unpublished).
 	 * @var int
-	 * @deprecated
 	 */
 	public $lastElapsedRecordingTime;
-
-	/**
-	 * Elapsed live streaming time (in msec) up to the point where the live stream was last stopped (unpublished).
-	 * @var int
-	 */
-	public $lastElapsedLiveDuration;
 
 	/**
 	 * Array of key value protocol->live stream url objects

--- a/api_v3/lib/types/entry/KalturaLiveEntry.php
+++ b/api_v3/lib/types/entry/KalturaLiveEntry.php
@@ -36,8 +36,15 @@ abstract class KalturaLiveEntry extends KalturaMediaEntry
 	/**
 	 * Elapsed recording time (in msec) up to the point where the live stream was last stopped (unpublished).
 	 * @var int
+	 * @deprecated
 	 */
 	public $lastElapsedRecordingTime;
+
+	/**
+	 * Elapsed live streaming time (in msec) up to the point where the live stream was last stopped (unpublished).
+	 * @var int
+	 */
+	public $lastElapsedLiveDuration;
 
 	/**
 	 * Array of key value protocol->live stream url objects

--- a/plugins/cue_points/base/lib/model/CuePoint.php
+++ b/plugins/cue_points/base/lib/model/CuePoint.php
@@ -385,7 +385,7 @@ abstract class CuePoint extends BaseCuePoint implements IIndexable
 		return null;
 	}
 
-	public function copyFromLiveToVodEntry( $liveEntry, $vodEntry, $liveDurationOffsetFromVodInMsec )
+	public function copyFromLiveToVodEntry( $liveEntry, $vodEntry, array $liveRecordingSegmentInfoArray )
 	{
 	}
 } // CuePoint

--- a/plugins/cue_points/base/lib/model/CuePoint.php
+++ b/plugins/cue_points/base/lib/model/CuePoint.php
@@ -384,4 +384,8 @@ abstract class CuePoint extends BaseCuePoint implements IIndexable
 	{
 		return null;
 	}
+
+	public function copyFromLiveToVodEntry( $liveEntry, $vodEntry, $liveDurationOffsetFromVodInMsec )
+	{
+	}
 } // CuePoint


### PR DESCRIPTION
1. Added code to copy cuepoints from live to VOD within the barriers of the VOD duration.
2. Changed lastElapsedRecordingTime to lastElapsedLiveDuration and made lastElapsedRecordingTime deprecated.
3. Accumulating recorded entry duration in appendRecording via recordedLengthInMsec
4. Added kLiveRecordingSegmentInfo
5. Setting cuepoint status to HANDLED immediately if recording is disabled, otherwise, after copying cuepoints to VOD entry.
6. Copying only cuepoints with READY state (skipping already HANDLED cuepoints), which replaces the maxCopiedVodCuePointStartTime condition.
