### PR TITLE
changes for nginx-vod-module integration with CE

### DIFF
--- a/configurations/apache/conf.d/enabled.kaltura.conf.template
+++ b/configurations/apache/conf.d/enabled.kaltura.conf.template
@@ -93,31 +93,29 @@ Alias /sf "/usr/share/pear/data/symfony/web/sf/"
 	
 	RewriteRule ^p/[-0-9]+/sp/[-0-9]+/flv/(.*)$ /index.php/flv/$1 [L]
 	RewriteRule ^p/[-0-9]+/flv/(.*)$ /index.php/flv/$1 [L]
-	
+		
 	RewriteRule ^p/[-0-9]+/sp/[-0-9]+/playManifest/(.*)$ /index.php/extwidget/playManifest/$1 [L]
-	RewriteRule ^p/[-0-9]+/sp/[-0-9]+/serveFlavor/(.*)$ /index.php/extwidget/serveFlavor/$1 [L]
 	RewriteRule ^p/[-0-9]+/sp/[-0-9]+/serveIsm/(.*)$ /index.php/extwidget/serveIsm/$1 [L]
 	RewriteRule ^p/[-0-9]+/sp/[-0-9]+/serveManifest/(.*)$ /index.php/extwidget/serveManifest/$1 [L]
 	RewriteRule ^p/[-0-9]+/sp/[-0-9]+/embedIframe/(.*)$ /index.php/extwidget/embedIframe/$1 [L]
 	RewriteRule ^p/[-0-9]+/sp/[-0-9]+/embedIframeJs/(.*)$ /index.php/extwidget/embedIframeJs/$1 [L]
 	
 	RewriteRule ^s/p/[-0-9]+/sp/[-0-9]+/playManifest/(.*)$ /index.php/extwidget/playManifest/$1 [L]
-	RewriteRule ^s/p/[-0-9]+/sp/[-0-9]+/serveFlavor/(.*)$ /index.php/extwidget/serveFlavor/$1 [L]
 	RewriteRule ^s/p/[-0-9]+/sp/[-0-9]+/serveManifest/(.*)$ /index.php/extwidget/serveManifest/$1 [L]
 	RewriteRule ^s/p/[-0-9]+/sp/[-0-9]+/embedIframe/(.*)$ /index.php/extwidget/embedIframe/$1 [L]
 	RewriteRule ^s/p/[-0-9]+/sp/[-0-9]+/embedIframeJs/(.*)$ /index.php/extwidget/embedIframeJs/$1 [L]
 	
 	RewriteRule ^p/[-0-9]+/playManifest/(.*)$ /index.php/extwidget/playManifest/$1 [L]
-	RewriteRule ^p/[-0-9]+/serveFlavor/(.*)$ /index.php/extwidget/serveFlavor/$1 [L]
 	RewriteRule ^p/[-0-9]+/serveManifest/(.*)$ /index.php/extwidget/serveManifest/$1 [L]
 	RewriteRule ^p/[-0-9]+/embedIframe/(.*)$ /index.php/extwidget/embedIframe/$1 [L]
 	RewriteRule ^p/[-0-9]+/embedIframeJs/(.*)$ /index.php/extwidget/embedIframeJs/$1 [L]
 	
 	RewriteRule ^s/p/[-0-9]+/playManifest/(.*)$ /index.php/extwidget/playManifest/$1 [L]
-	RewriteRule ^s/p/[-0-9]+/serveFlavor/(.*)$ /index.php/extwidget/serveFlavor/$1 [L]
 	RewriteRule ^s/p/[-0-9]+/serveManifest/(.*)$ /index.php/extwidget/serveManifest/$1 [L]
 	RewriteRule ^s/p/[-0-9]+/embedIframe/(.*)$ /index.php/extwidget/embedIframe/$1 [L]
 	RewriteRule ^s/p/[-0-9]+/embedIframeJs/(.*)$ /index.php/extwidget/embedIframeJs/$1 [L]
+	
+	RewriteRule (?<!extwidget)/serveFlavor/(.*)$ /index.php/extwidget/serveFlavor/$1 [L]
 	
 	RewriteRule ^p/[-0-9]+/sp/[-0-9]+/kpreloader/(.*)$ /index.php/extwidget/kpreloader/$1 [L]
 	RewriteRule ^p/[-0-9]+/kpreloader/(.*)$ /index.php/extwidget/kpreloader/$1 [L]

--- a/configurations/local.template.ini
+++ b/configurations/local.template.ini
@@ -124,7 +124,7 @@ metadata_sphinx_num_of_int_fields = 10
 ;range of ip addresses belonging to internal kaltura servers
 ;the range is used when checking service actions permissions and allowing to access certain 
 ;services without KS from the internal servers
-;internal_ip_range = @IP_RANGE@
+internal_ip_range = @IP_RANGE@
 
 ; dwh settings
 plays_limit = 100000


### PR DESCRIPTION
- serveFlavor URLs should not be limited /p/[0-9]+/sp/[0-9]+
- internal_ip_range is required so that serveFlavor will support the pathOnly parameter