### PR TITLE
- support files with pattern /^\d+\.\w+?\.?\w+\.ini$/ 

### DIFF
--- a/deployment/base/scripts/insertDefaults.php
+++ b/deployment/base/scripts/insertDefaults.php
@@ -37,8 +37,9 @@ function handleDirectory($dirName)
 	while (false !== ($fileName = $dir->read()))
 	{
 		$filePath = realpath("$dirName/$fileName");
-		if($fileName[0] == '.' || is_dir($filePath) || !preg_match('/^\d+\.\w+\.ini$/', $fileName))
+		if($fileName[0] == '.' || is_dir($filePath)|| !preg_match('/^\d+\.\w+?\.?\w+\.ini$/', $fileName) || preg_match('/.*\.template\.ini$/',$fileName)){
 			continue;
+		}
 	
 		KalturaLog::debug("Validate file [$filePath]");
 		$objectConfigurations = parse_ini_file($filePath, true);
@@ -49,9 +50,7 @@ function handleDirectory($dirName)
 		if(preg_match_all('/@[A-Z_0-9]+@/', file_get_contents($filePath), $matches) > 0)
 			$errors[] = "Content file [$filePath] contains place holders: " . implode("\n\t", $matches[0]);
 	
-		list($order, $objectType, $fileExtension) = explode('.', $fileName, 3);
-		if($fileExtension == 'ini')
-			$fileNames[] = $fileName;
+		$fileNames[] = $fileName;
 	}
 	$dir->close();
 	if(count($errors))


### PR DESCRIPTION
which is a must for Eran's

https://github.com/kaltura/nginx-vod-module/blob/master/conf/01.DeliveryProfile.VodPackager.template.ini
- remove additional check that file extension is 'ini' since the first
regex test already checks that.