### PR TITLE
SUP-3485

### DIFF
--- a/alpha/apps/kaltura/modules/extwidget/templates/previewSuccess.php
+++ b/alpha/apps/kaltura/modules/extwidget/templates/previewSuccess.php
@@ -42,7 +42,7 @@
 	<meta property="og:site_name" content="Kaltura" />
 	<?php } ?>
 	<title><?php echo htmlspecialchars($entry_name); ?></title>
-	<link type="text/css" rel="stylesheet" href="/lib/css/kmc.css" />
+	<link type="text/css" rel="stylesheet" href="/lib/css/shortlink.css" />
 	<?php if($framed)  { ?>
 	<style>
 	html, body {margin: 0; padding: 0; width: 100%; height: 100%; } 

--- a/alpha/web/lib/css/shortlink.css
+++ b/alpha/web/lib/css/shortlink.css
@@ -1,0 +1,32 @@
+* { margin:0; padding:0;}
+body {
+	height:100%;
+	background:#F7F7F7;
+}
+#main{
+	background-color:#F7F7F7;
+	margin: 0px 0px 0;
+	position:relative;
+	overflow:hidden;
+	bottom:1px;
+}
+#main .content{
+	padding:10px 0 30px;
+	color:#333;
+}
+#main .content .title{
+	border-bottom:#a3bfcb solid 1px;
+	padding:20px 30px;
+}
+#main .content h1{
+	color:#3483a1;
+	font-size:3em;
+	font-weight:normal;
+	letter-spacing:-1px;
+}
+#main .content .contwrap{
+	border-top:#fff solid 1px;
+	padding:20px 30px;
+}
+
+


### PR DESCRIPTION
don't load kmc.css in short link page. instead load shortlink.css which is a subset of kmc.css with just the relevant css classes and rules required for page layout and doesn't affect onpage playlist / chapters