### PR TITLE
open only udg:// with fsockopen

### DIFF
--- a/infra/log/KalturaSerializableStream.php
+++ b/infra/log/KalturaSerializableStream.php
@@ -45,7 +45,7 @@ class KalturaSerializableStream extends Zend_Log_Writer_Stream
 	{
 		$errno = null;
 		$errstr = null;
-		if (strpos($this->_url, "://") !== false)
+		if (strpos($this->_url, "udg://") === 0)
 		{
 			$this->_stream = @fsockopen($this->_url, 0, $errno, $errstr, 1);
 		}


### PR DESCRIPTION
sometimes php://output is used as the log file name