### PR TITLE
Jupiter 10.4.0 client lib changes

### DIFF
--- a/configurations/generator.ini
+++ b/configurations/generator.ini
@@ -55,6 +55,8 @@ clearPath = admin_console/lib/Kaltura/Client
 generator = Xml2As3ClientGenerator
 params.type = flex_client
 ignore = KalturaUploadedFileResource, KalturaCopyJobData
+internal = true
+nopackage = true
 generateDocs = true
 
 [mediaServerClient : java]
@@ -86,6 +88,8 @@ ignore = KalturaUploadedFileResource, KalturaCopyJobData
 generateDocs = true
 package = Kaltura
 subpackage = Client
+internal = true
+nopackage = true
 
 [php4 : public]
 generator = Php4ClientGenerator
@@ -154,4 +158,5 @@ exclude = media.addfrombulk
 
 [nodePlayServer : node]
 include = cuePoint_cuePoint.list, cuePoint_cuePoint.add, liveStream.get, liveStream.createPeriodicSyncPoints, session.start, uiconf.get, baseEntry.get, metadata_metadata.list, permission.list
-
+internal = true
+nopackage = true

--- a/generator/ObjCClientGenerator.php
+++ b/generator/ObjCClientGenerator.php
@@ -137,7 +137,7 @@ class ObjCClientGenerator extends ClientGeneratorFromXml
 	{
 		if (kString::beginsWith($propertyName, 'new') ||
 			kString::beginsWith($propertyName, 'copy'))
-			return "_$propertyName";
+			return "a$propertyName";		// prefixing with _ still produces the warning, need to use a real letter
 		return $propertyName;
 	}
 	

--- a/generator/sources/cli/lib/KalturaCurlWrapper.php
+++ b/generator/sources/cli/lib/KalturaCurlWrapper.php
@@ -91,6 +91,7 @@ class KalturaCurlWrapper
 		if(curl_errno($ch))
 		{
 			echo 'curl error: ' . curl_error($ch);
+			$data = false;
 		}
 		else
 		{


### PR DESCRIPTION
objc - prefixing new/copy properties with _ is not enough, need to use a real letter
kalcli - return a non-zero code on error
generator.ini - marked some client libs as internal