### PR TITLE
optimize asset.list actions

### DIFF
--- a/api_v3/lib/types/filters/KalturaFilterPager.php
+++ b/api_v3/lib/types/filters/KalturaFilterPager.php
@@ -32,4 +32,10 @@ class KalturaFilterPager extends KalturaObject
 		$offset = ($this->pageIndex - 1) * $this->pageSize;
 		$c->setOffset( $offset );
 	}
+	
+	public static function detachFromCriteria(Criteria $c)
+	{
+		$c->setOffset(0);
+		$c->setLimit(-1);
+	}
 }

--- a/api_v3/services/FlavorAssetService.php
+++ b/api_v3/services/FlavorAssetService.php
@@ -497,11 +497,18 @@ class FlavorAssetService extends KalturaAssetService
 		
 		$flavorTypes = assetPeer::retrieveAllFlavorsTypes();
 		$c->add(assetPeer::TYPE, $flavorTypes, Criteria::IN);
-		
-		$totalCount = assetPeer::doCount($c);
-		
+
 		$pager->attachToCriteria($c);
 		$dbList = assetPeer::doSelect($c);
+
+		$resultCount = count($dbList);
+		if ($resultCount && $resultCount < $pager->pageSize)
+			$totalCount = ($pager->pageIndex - 1) * $pager->pageSize + $resultCount;
+		else
+		{
+			KalturaFilterPager::detachFromCriteria($c);
+			$totalCount = assetPeer::doCount($c);
+		}
 		
 		$list = KalturaFlavorAssetArray::fromDbArray($dbList);
 		$response = new KalturaFlavorAssetListResponse();

--- a/api_v3/services/ThumbAssetService.php
+++ b/api_v3/services/ThumbAssetService.php
@@ -803,10 +803,17 @@ class ThumbAssetService extends KalturaAssetService
 		$thumbTypes = KalturaPluginManager::getExtendedTypes(assetPeer::OM_CLASS, assetType::THUMBNAIL);
 		$c->add(assetPeer::TYPE, $thumbTypes, Criteria::IN);
 		
-		$totalCount = assetPeer::doCount($c);
-		
 		$pager->attachToCriteria($c);
 		$dbList = assetPeer::doSelect($c);
+
+		$resultCount = count($dbList);
+		if ($resultCount && $resultCount < $pager->pageSize)
+			$totalCount = ($pager->pageIndex - 1) * $pager->pageSize + $resultCount;
+		else
+		{
+			KalturaFilterPager::detachFromCriteria($c);
+			$totalCount = assetPeer::doCount($c);
+		}
 		
 		$list = KalturaThumbAssetArray::fromDbArray($dbList);
 		$response = new KalturaThumbAssetListResponse();

--- a/plugins/content/attachment/services/AttachmentAssetService.php
+++ b/plugins/content/attachment/services/AttachmentAssetService.php
@@ -515,11 +515,18 @@ class AttachmentAssetService extends KalturaAssetService
 		$types = KalturaPluginManager::getExtendedTypes(assetPeer::OM_CLASS, AttachmentPlugin::getAssetTypeCoreValue(AttachmentAssetType::ATTACHMENT));
 		$c->add(assetPeer::TYPE, $types, Criteria::IN);
 		
-		$totalCount = assetPeer::doCount($c);
-		
 		$pager->attachToCriteria($c);
 		$dbList = assetPeer::doSelect($c);
-		
+
+		$resultCount = count($dbList);
+		if ($resultCount && $resultCount < $pager->pageSize)
+			$totalCount = ($pager->pageIndex - 1) * $pager->pageSize + $resultCount;
+		else
+		{
+			KalturaFilterPager::detachFromCriteria($c);
+			$totalCount = assetPeer::doCount($c);
+		}
+				
 		$list = KalturaAttachmentAssetArray::fromDbArray($dbList);
 		$response = new KalturaAttachmentAssetListResponse();
 		$response->objects = $list;

--- a/plugins/content/caption/base/services/CaptionAssetService.php
+++ b/plugins/content/caption/base/services/CaptionAssetService.php
@@ -671,11 +671,18 @@ class CaptionAssetService extends KalturaAssetService
 		
 		$types = KalturaPluginManager::getExtendedTypes(assetPeer::OM_CLASS, CaptionPlugin::getAssetTypeCoreValue(CaptionAssetType::CAPTION));
 		$c->add(assetPeer::TYPE, $types, Criteria::IN);
-		
-		$totalCount = assetPeer::doCount($c);
-		
+				
 		$pager->attachToCriteria($c);
 		$dbList = assetPeer::doSelect($c);
+
+		$resultCount = count($dbList);
+		if ($resultCount && $resultCount < $pager->pageSize)
+			$totalCount = ($pager->pageIndex - 1) * $pager->pageSize + $resultCount;
+		else
+		{
+			KalturaFilterPager::detachFromCriteria($c);
+			$totalCount = assetPeer::doCount($c);
+		}
 		
 		$list = KalturaCaptionAssetArray::fromDbArray($dbList);
 		$response = new KalturaCaptionAssetListResponse();


### PR DESCRIPTION
avoid calling doCount when the count can be determined according to the number of returned assets