### PR TITLE
Copying cuepoints on RECORDING_ANCHOR VOD flavor only

### DIFF
--- a/alpha/apps/kaltura/lib/batch2/bcdl/kBusinessConvertDL.php
+++ b/alpha/apps/kaltura/lib/batch2/bcdl/kBusinessConvertDL.php
@@ -65,7 +65,10 @@ class kBusinessConvertDL
 			if(isset($newAssets[$oldAsset->getType()]) && isset($newAssets[$oldAsset->getType()][$oldAsset->getFlavorParamsId()]))
 			{
 				$newAsset = $newAssets[$oldAsset->getType()][$oldAsset->getFlavorParamsId()];
-				$newAsset->addTags($oldAsset->getTagsArray());
+				if ( $oldAsset->hasTag(assetParams::TAG_RECORDING_ANCHOR) )
+				{
+					$newAsset->addTags(array(assetParams::TAG_RECORDING_ANCHOR));
+				}
 
 				/* @var $newAsset asset */
 				KalturaLog::debug("Create link from new asset [" . $newAsset->getId() . "] to old asset [" . $oldAsset->getId() . "] for flavor [" . $oldAsset->getFlavorParamsId() . "]");

--- a/alpha/apps/kaltura/lib/batch2/bcdl/kBusinessConvertDL.php
+++ b/alpha/apps/kaltura/lib/batch2/bcdl/kBusinessConvertDL.php
@@ -65,6 +65,7 @@ class kBusinessConvertDL
 			if(isset($newAssets[$oldAsset->getType()]) && isset($newAssets[$oldAsset->getType()][$oldAsset->getFlavorParamsId()]))
 			{
 				$newAsset = $newAssets[$oldAsset->getType()][$oldAsset->getFlavorParamsId()];
+				$newAsset->addTags($oldAsset->getTagsArray());
 
 				/* @var $newAsset asset */
 				KalturaLog::debug("Create link from new asset [" . $newAsset->getId() . "] to old asset [" . $oldAsset->getId() . "] for flavor [" . $oldAsset->getFlavorParamsId() . "]");

--- a/api_v3/lib/KalturaLiveEntryService.php
+++ b/api_v3/lib/KalturaLiveEntryService.php
@@ -116,7 +116,7 @@ class KalturaLiveEntryService extends KalturaEntryService
 			$recordedEntry = entryPeer::retrieveByPK($dbEntry->getRecordedEntryId());
 			if($recordedEntry)
 			{
-				$this->ingestAsset($recordedEntry, $dbAsset->getFlavorParamsId(), $filename);
+				$this->ingestAsset($recordedEntry, $dbAsset, $filename);
 			}
 		}
 		
@@ -125,8 +125,9 @@ class KalturaLiveEntryService extends KalturaEntryService
 		return $entry;
 	}
 
-	private function ingestAsset(entry $entry, $flavorParamsId, $filename)
-	{	
+	private function ingestAsset(entry $entry, $dbAsset, $filename)
+	{
+		$flavorParamsId = $dbAsset->getFlavorParamsId();
 		$flavorParams = assetParamsPeer::retrieveByPKNoFilter($flavorParamsId);
 		
 		// is first chunk
@@ -144,6 +145,7 @@ class KalturaLiveEntryService extends KalturaEntryService
 		$recordedAsset->setStatus(asset::FLAVOR_ASSET_STATUS_QUEUED);
 		$recordedAsset->setFlavorParamsId($flavorParams->getId());
 		$recordedAsset->setFromAssetParams($flavorParams);
+		$recordedAsset->addTags($dbAsset->getTagsArray());
 		
 		if($flavorParams->hasTag(assetParams::TAG_SOURCE))
 		{

--- a/api_v3/lib/KalturaLiveEntryService.php
+++ b/api_v3/lib/KalturaLiveEntryService.php
@@ -145,7 +145,10 @@ class KalturaLiveEntryService extends KalturaEntryService
 		$recordedAsset->setStatus(asset::FLAVOR_ASSET_STATUS_QUEUED);
 		$recordedAsset->setFlavorParamsId($flavorParams->getId());
 		$recordedAsset->setFromAssetParams($flavorParams);
-		$recordedAsset->addTags($dbAsset->getTagsArray());
+		if ( $dbAsset->hasTag(assetParams::TAG_RECORDING_ANCHOR) )
+		{
+			$recordedAsset->addTags(array(assetParams::TAG_RECORDING_ANCHOR));
+		}
 		
 		if($flavorParams->hasTag(assetParams::TAG_SOURCE))
 		{

--- a/plugins/cue_points/base/lib/kCuePointManager.php
+++ b/plugins/cue_points/base/lib/kCuePointManager.php
@@ -57,8 +57,7 @@ class kCuePointManager implements kObjectDeletedEventConsumer, kObjectChangedEve
 			return null;
 		}
 
-		$flavorAssetId = $mediaInfo->getFlavorAssetId();
-		$flavorAsset = assetPeer::retrieveById( $flavorAssetId );
+		$flavorAsset = $mediaInfo->getasset();
 		if ( ! $flavorAsset || ! $flavorAsset->hasTag(assetParams::TAG_RECORDING_ANCHOR) )
 		{
 			return null;


### PR DESCRIPTION
1. Ensuring all LIVE asset tags are copied to VOD,
2. Copying cuepoints from LIVE to VOD only when the mediaInfo was created for the VOD asset with the RECORDING_ANCHOR tag.

PLAT-2451 #time 2d