### PR TITLE
thumbnail action cache fix

### DIFF
--- a/alpha/apps/kaltura/modules/extwidget/actions/thumbnailAction.class.php
+++ b/alpha/apps/kaltura/modules/extwidget/actions/thumbnailAction.class.php
@@ -453,11 +453,8 @@ class thumbnailAction extends sfAction
 		else if (strpos($tempThumbPath, "_NOCACHE_") !== false)
 			$cacheAge = 60;
 		else
-			$cacheAge = 8640000;
-		
-		// cache result
-		if (!$nocache)
 		{
+			$cacheAge = 8640000;
 			$requestKey = $_SERVER["REQUEST_URI"];
 			$cache = new myCache("thumb", $cacheAge); // 30 days
 			$cache->put($requestKey, $tempThumbPath);


### PR DESCRIPTION
do not save the path to memcache if it contains _NOCACHE_, saving it to memcache can later cause index.php to return it with caching headers of 100 days