### PR TITLE
change 'type' to 'engine' to support old mysql version

### DIFF
--- a/deployment/updates/sql/2015_01_20_kuser_kgroup_table.sql
+++ b/deployment/updates/sql/2015_01_20_kuser_kgroup_table.sql
@@ -20,4 +20,4 @@ CREATE TABLE `kuser_kgroup`
 	CONSTRAINT `kuser_kgroup_FK_2`
 	FOREIGN KEY (`kuser_id`)
 	REFERENCES `kuser` (`id`)
-)Type=InnoDB;
+)ENGINE=InnoDB DEFAULT CHARSET=utf8;


### PR DESCRIPTION
TYPE was removed somewhere in mysql v5.1
@erankor / @tan-tan-kanarek  - please review.

@AviBueno  - FYI