### PR TITLE
sphinx datasources must start with 0 index due to connectFallbackLogic i...

### DIFF
--- a/configurations/db.template.ini
+++ b/configurations/db.template.ini
@@ -5,8 +5,8 @@
 ; #################################################
 
 [sphinx_datasources]
-datasources.1 = sphinx1
-datasources.2 = sphinx2
+datasources.0 = sphinx1
+datasources.1 = sphinx2
 cache_expiry = 300
 
 [datasources]


### PR DESCRIPTION
...n DbManager.php

This is required for sphinx redundancy to work.