### PR TITLE
Fetching up to LIMIT results if a limit was supplied

### DIFF
--- a/alpha/apps/kaltura/lib/myPlaylistUtils.class.php
+++ b/alpha/apps/kaltura/lib/myPlaylistUtils.class.php
@@ -102,7 +102,7 @@ class myPlaylistUtils
 	 * if after the entryFilter retrieved a list, still not enough entries (less than list's total number of results) - go to next list
 	 * 
 	 */
-	public static function executePlaylistById ( $partner_id , $playlist_id ,  $extra_filters = null , $detailed = true)
+	public static function executePlaylistById ( $partner_id , $playlist_id ,  $filter = null , $detailed = true)
 	{
 		$playlist = entryPeer::retrieveByPK( $playlist_id );
 
@@ -119,10 +119,10 @@ class myPlaylistUtils
 		// the default of detrailed should be true - most of the time the kuse is needed 
 		if ( is_null ( $detailed ) ) $detailed = true ; 
 		
-		return self::executePlaylist ( $partner_id , $playlist ,  $extra_filters , $detailed);
+		return self::executePlaylist ( $partner_id , $playlist ,  $filter , $detailed);
 	}
 	
-	public static function executePlaylist ( $partner_id , $playlist ,  $extra_filters = null , $detailed = true )
+	public static function executePlaylist ( $partner_id , $playlist ,  $filter = null , $detailed = true )
 	{
 		if ( ! $playlist )
 		{
@@ -144,7 +144,7 @@ class myPlaylistUtils
 				$filter_list_content = $playlist->getDataContent( true );
 			}
 			
-			$entryObjectsArray = self::executeDynamicPlaylist ( $partner_id ,  $filter_list_content , $extra_filters , $detailed );
+			$entryObjectsArray = self::executeDynamicPlaylist ( $partner_id ,  $filter_list_content , $filter , $detailed );
 		}
 		elseif ( $playlist->getMediaType() == entry::ENTRY_MEDIA_TYPE_GENERIC_1 )
 		{
@@ -155,7 +155,7 @@ class myPlaylistUtils
 		{
 			// static playlist
 			// search the roughcut_entry for the playlist as a roughcut / group
-			$entryObjectsArray = self::executeStaticPlaylist ( $playlist , $extra_filters , $detailed );
+			$entryObjectsArray = self::executeStaticPlaylist ( $playlist , $filter , $detailed );
 		}
 
 		// Perform entries redirection
@@ -271,13 +271,13 @@ class myPlaylistUtils
 		return array($filter);
 	}
 	
-	public static function executeStaticPlaylist ( entry $playlist , $extra_filters  = null, $detailed = true )
+	public static function executeStaticPlaylist ( entry $playlist , $filter  = null, $detailed = true )
 	{
 		$entry_id_list_str = $playlist->getDataContent();
-		return self::executeStaticPlaylistFromEntryIdsString($entry_id_list_str, $extra_filters, $detailed);
+		return self::executeStaticPlaylistFromEntryIdsString($entry_id_list_str, $filter, $detailed);
 	}
 	
-	public static function executeStaticPlaylistFromEntryIdsString($entry_id_list_str, $extra_filters = null, $detailed = true)
+	public static function executeStaticPlaylistFromEntryIdsString($entry_id_list_str, $filter = null, $detailed = true)
 	{
 		if(! trim($entry_id_list_str))
 			return null;
@@ -287,10 +287,10 @@ class myPlaylistUtils
 		foreach ( $entry_id_list as &$entry_id ) 
 			$entry_id=trim($entry_id);
 		
-		return self::executeStaticPlaylistFromEntryIds($entry_id_list, $extra_filters, $detailed);
+		return self::executeStaticPlaylistFromEntryIds($entry_id_list, $filter, $detailed);
 	}
 	
-	public static function executeStaticPlaylistFromEntryIds(array $entry_id_list, $extra_filters = null, $detailed = true)
+	public static function executeStaticPlaylistFromEntryIds(array $entry_id_list, $entry_filter = null, $detailed = true)
 	{
 		// if exists extra_filters - use the first one to filter the entry_id_list
 		$c= KalturaCriteria::create(entryPeer::OM_CLASS);
@@ -308,11 +308,8 @@ class myPlaylistUtils
 		
 		self::addModerationToCriteria($c);
 		
-		if ( $extra_filters && isset ( $extra_filters[1] )  )
+		if ( $entry_filter )
 		{
-			// use index 1 - will be used as the first filter
-			$entry_filter = $extra_filters[1];
-			
 			// read the _eq_display_in_search field but ignore it because it's part of a more complex criterion - see bellow
 			$display_in_search = $entry_filter->get( "_eq_display_in_search");
 			if ( $display_in_search >= 2 )
@@ -421,7 +418,7 @@ class myPlaylistUtils
 		return $entry_filters;
 	}
 	
-	public static function executeDynamicPlaylist ( $partner_id , $xml , $extra_filters = null ,$detailed = true)
+	public static function executeDynamicPlaylist ( $partner_id , $xml , $filter = null ,$detailed = true)
 	{
 		list ( $total_results , $list_of_filters ) = self::getPlaylistFilterListStruct ( $xml );
 	
@@ -430,6 +427,16 @@ class myPlaylistUtils
 		if ( ! $list_of_filters ) return null;
 		// TODO - for now we assume that there are more or equal filters in the XML than the ones from the request
 		$i = 1; // the extra_filter is 1-based
+
+		if ( $filter && $filter->getLimit() > 0 )
+		{
+			// Get the max results from the limit of the first filter
+			$total_results = min( $total_results, $filter->getLimit() );
+
+			// Clear this limit so it won't overcloud the limits of $entry_filter_xml rules
+			$filter->setLimit( null );
+		}
+
 		foreach ( $list_of_filters as $entry_filter_xml )
 		{
 		    /* @var $entry_filter_xml SimpleXMLElement */
@@ -450,13 +457,12 @@ class myPlaylistUtils
 				$entry_filter->setLimit( self::TOTAL_RESULTS );
 			}
 			
-			$extra_filter = @$extra_filters[$i];
 			// merge the current_filter with the correcponding extra_filter
 			// allow the extra_filter to override properties of the current filter
 
-			if ( $extra_filter )
+			if ( $filter )
 			{
-				$entry_filter->fillObjectFromObject( $extra_filter , 
+				$entry_filter->fillObjectFromObject( $filter , 
 					myBaseObject::CLONE_FIELD_POLICY_THIS , 
 					myBaseObject::CLONE_POLICY_PREFER_NEW , null , null , false );
 					
@@ -476,15 +482,16 @@ class myPlaylistUtils
 		foreach ( $entry_filters as $entry_filter )
 		{
 			$current_limit = max ( 0 , $total_results - $number_of_entries ); // if the current_limit is < 0 - set it to be 0
+
+			// no need to fetch any more results
+			if ( $current_limit <= 0 ) break;
+
 			$exclude_id_list = self::getIds( $entry_list );
 			$c = KalturaCriteria::create(entryPeer::OM_CLASS);
 			
 			
 			// don't fetch the same entries twice - filter out all the entries that were already fetched
 			if( $exclude_id_list ) $c->add ( entryPeer::ID , $exclude_id_list , Criteria::NOT_IN );  
-			
-			// no need to fetch any more results
-			if ( $current_limit <= 0  )break;
 			
 			$filter_limit = $entry_filter->getLimit ();
 			

--- a/alpha/apps/kaltura/modules/partnerservices2/actions/executeplaylistAction.class.php
+++ b/alpha/apps/kaltura/modules/partnerservices2/actions/executeplaylistAction.class.php
@@ -69,35 +69,9 @@ class executeplaylistAction extends defPartnerservices2Action
 		$detailed = $this->getP ( "detailed" , false );
 		if (!$detailed)
 			$detailed = false;
-		$limit = $this->getP ( "page_size" , 10 );
-		$limit = $this->maxPageSize ( $limit );
-
-		$page = $this->getP ( "page" , 1 );
-
-		$user_filter_prefix = $this->getP ( "fp" , "filter" );
-		
-		$offset = ($page-1)* $limit;
-
-		// TODO - should limit search to partner ??
-//		kuserPeer::setUseCriteriaFilter( false );
-//		entryPeer::setUseCriteriaFilter( false );
 
 		$playlist_id= $this->getPM ( "playlist_id" );
-		$input_params = $this->getInputParams();
 		
-		$extra_filters = array();
-		for ( $i=1 ; $i< self::MAX_FILTER_COUNT ; $i++ )
-		{
-			// filter
-			$extra_filter = new entryFilter(  );
-			
-			$fields_set = $extra_filter->fillObjectFromRequest( $input_params , "{$user_filter_prefix}{$i}_" , null );
-			if ( $fields_set )		
-				$extra_filters[$i] = $extra_filter;
-		}
-		
-
-
 		if ( $create_cachekey ) 
 		{
 			if ( $this->isAdmin() )
@@ -115,7 +89,6 @@ class executeplaylistAction extends defPartnerservices2Action
 				
 			$cache_key_arr = array ( 
 				"playlist_id" => $playlist_id , 
-				"filters" => $extra_filters , 
 				"partner_id" => $partner_id ,
 				"ks_partner_id" => $ks_partner_id ,  
 				"detailed" => $detailed,
@@ -145,7 +118,7 @@ class executeplaylistAction extends defPartnerservices2Action
 		if ($this->isAdmin())
 			myPlaylistUtils::setIsAdminKs(true);
 
-		$entry_list = myPlaylistUtils::executePlaylistById( $partner_id , $playlist_id , $extra_filters , $detailed );
+		$entry_list = myPlaylistUtils::executePlaylistById( $partner_id , $playlist_id , null , $detailed );
 
 		myEntryUtils::updatePuserIdsForEntries ( $entry_list );
 		

--- a/alpha/apps/kaltura/modules/partnerservices2/actions/executeplaylistfromcontentAction.class.php
+++ b/alpha/apps/kaltura/modules/partnerservices2/actions/executeplaylistfromcontentAction.class.php
@@ -59,21 +59,7 @@ class executeplaylistfromcontentAction extends defPartnerservices2Action
 		$detailed = $this->getP ( "detailed" , false );
 		if (!$detailed)
 			$detailed = false;
-		$limit = $this->getP ( "page_size" , 10 );
-		$limit = $this->maxPageSize ( $limit );
 
-		$page = $this->getP ( "page" , 1 );
-
-		$user_filter_prefix = $this->getP ( "fp" , "filter" );
-		
-		$offset = ($page-1)* $limit;
-
-		// TODO - should limit search to partner ??
-//		kuserPeer::setUseCriteriaFilter( false );
-//		entryPeer::setUseCriteriaFilter( false );
-
-		$input_params = $this->getInputParams();
-		
 		// fill the playlist (infact only the mediaType and contentData are important
 		$playlist = new entry();
 		$playlist->setType ( entryType::PLAYLIST ); // prepare the playlist type before filling from request
@@ -84,23 +70,7 @@ class executeplaylistfromcontentAction extends defPartnerservices2Action
 		
 		$playlist->setDataContent( $data_content );
 		
-/*		
-		$updateable_fields = $obj_wrapper->getUpdateableFields() ;
-		$fields_modified = baseObjectUtils::fillObjectFromMapOrderedByFields( $input_params , $playlist , "playlist_" , 
-			$updateable_fields , BasePeer::TYPE_PHPNAME ,false );
-	*/	
-		// rest is similar to the executeplaylist service		
-		$extra_filters = array();
-		for ( $i=1 ; $i< self::MAX_FILTER_COUNT ; $i++ )
-		{
-			// filter
-			$extra_filter = new entryFilter(  );
-			
-			$fields_set = $extra_filter->fillObjectFromRequest( $input_params , "{$user_filter_prefix}{$i}_" , null );
-			$extra_filters[$i] = $extra_filter;
-		}
-	
-		$entry_list = myPlaylistUtils::executePlaylist ( $partner_id , $playlist , $extra_filters , $detailed );
+		$entry_list = myPlaylistUtils::executePlaylist ( $partner_id , $playlist , null , $detailed );
 
 		myEntryUtils::updatePuserIdsForEntries ( $entry_list );
 		

--- a/alpha/apps/kaltura/modules/partnerservices2/actions/getplayliststatsfromcontentAction.class.php
+++ b/alpha/apps/kaltura/modules/partnerservices2/actions/getplayliststatsfromcontentAction.class.php
@@ -48,21 +48,7 @@ class getplayliststatsfromcontentAction extends defPartnerservices2Action
 		// TODO -  verify permissions for viewing lists
 
 		$detailed = $this->getP ( "detailed" , false );
-		$limit = $this->getP ( "page_size" , 10 );
-		$limit = $this->maxPageSize ( $limit );
 
-		$page = $this->getP ( "page" , 1 );
-
-		$user_filter_prefix = $this->getP ( "fp" , "filter" );
-		
-		$offset = ($page-1)* $limit;
-
-		// TODO - should limit search to partner ??
-//		kuserPeer::setUseCriteriaFilter( false );
-//		entryPeer::setUseCriteriaFilter( false );
-
-		$input_params = $this->getInputParams();
-		
 		// fill the playlist (infact only the mediaType and contentData are important
 		$playlist = new entry();
 		$playlist->setType ( entryType::PLAYLIST ); // prepare the playlist type before filling from request
@@ -73,19 +59,7 @@ class getplayliststatsfromcontentAction extends defPartnerservices2Action
 		
 		$playlist->setDataContent( $data_content );
 		
-		// rest is similar to the executeplaylist service		
-		$extra_filters = array();
-		for ( $i=1 ; $i< self::MAX_FILTER_COUNT ; $i++ )
-		{
-			// filter
-			$extra_filter = new entryFilter(  );
-			
-			$fields_set = $extra_filter->fillObjectFromRequest( $input_params , "{$user_filter_prefix}{$i}_" , null );
-			$extra_filters[$i] = $extra_filter;
-		}
-	
-		//$entry_list = myPlaylistUtils::executePlaylist ( $partner_id , $playlist , $extra_filters , $detailed );
-		myPlaylistUtils::updatePlaylistStatistics ( $partner_id , $playlist );//, $extra_filters , $detailed );
+		myPlaylistUtils::updatePlaylistStatistics ( $partner_id , $playlist );
 		
 		$level = $detailed ? objectWrapperBase::DETAIL_LEVEL_DETAILED : objectWrapperBase::DETAIL_LEVEL_REGULAR ;
 		$wrapper =  objectWrapperBase::getWrapperClass( $playlist  , $level );

--- a/api_v3/services/PlaylistService.php
+++ b/api_v3/services/PlaylistService.php
@@ -298,7 +298,7 @@ class PlaylistService extends KalturaEntryService
 		if ($playlist->getType() != entryType::PLAYLIST)
 			throw new KalturaAPIException ( APIErrors::INVALID_PLAYLIST_TYPE );
 
-		$extraFilters = array();
+		$entryFilter = null;
 		if ($filter)
 		{
 			if ($playlist->getMediaType() == entry::ENTRY_MEDIA_TYPE_TEXT)
@@ -309,7 +309,7 @@ class PlaylistService extends KalturaEntryService
 
 			$coreFilter = new entryFilter();
 			$filter->toObject($coreFilter);
-			$extraFilters[1] = $coreFilter;
+			$entryFilter = $coreFilter;
 		}
 			
 		if ($this->getKs() && is_object($this->getKs()) && $this->getKs()->isAdmin())
@@ -328,7 +328,7 @@ class PlaylistService extends KalturaEntryService
 
 		try
 		{
-			$entryList = myPlaylistUtils::executePlaylist( $this->getPartnerId() , $playlist , $extraFilters , $detailed);
+			$entryList = myPlaylistUtils::executePlaylist( $this->getPartnerId() , $playlist , $entryFilter , $detailed);
 		}
 		catch (kCoreException $ex)
 		{   		


### PR DESCRIPTION
to myPlaylistUtils::executeDynamicPlaylist() and preserving per-rule limits (unless the requested limit is higher).
Also, removed filter from PS2 executeplaylist* as it is not being used.
PLAT-1680