### PR TITLE
PLAT-2705 | Remove real-time report permission from Admin Console

### DIFF
--- a/configurations/admin.template.ini
+++ b/configurations/admin.template.ini
@@ -751,14 +751,6 @@ moduls.disableRememberMe.basePermissionType =
 moduls.disableRememberMe.basePermissionName =
 moduls.disableRememberMe.group = GROUP_ENABLE_DISABLE_FEATURES
 
-moduls.realTimeReports.enabled = true
-moduls.realTimeReports.permissionType = 2
-moduls.realTimeReports.label = Enable Real-time reports
-moduls.realTimeReports.permissionName = FEATURE_REAL_TIME_REPORTS
-moduls.realTimeReports.basePermissionType = 2
-moduls.realTimeReports.basePermissionType =
-moduls.realTimeReports.basePermissionName =
-moduls.realTimeReports.group = GROUP_ENABLE_DISABLE_FEATURES
 
 ; ACCESS PERMISSIONS
 

--- a/release-notes.md
+++ b/release-notes.md
@@ -1,6 +1,24 @@
 ----------
 # Jupiter-10.8.0 #
 
+## Real-time dashboard permission in now based on the general live-stream permission ##
+
+- Issue Type: Change Request
+- Issue ID: PLAT-2705
+
+#### Configuration ####
+
+Remove moduls.realTimeReports config from configurations/admin.ini
+
+#### Deployment Scripts ####
+
+None.
+
+#### Known Issues & Limitations ####
+
+None.
+
+
 ## Dynamic Objects ##
 
 - Issue Type: New Feature


### PR DESCRIPTION
Real-time dashboard permission in now based on the general live-stream permission