### PR TITLE
fixed 2 bugs with KalturaUserFilter::loginEnabledEqual

### DIFF
--- a/alpha/apps/kaltura/lib/model/objectfilters/kuserFilter.class.php
+++ b/alpha/apps/kaltura/lib/model/objectfilters/kuserFilter.class.php
@@ -39,6 +39,7 @@ class kuserFilter extends baseObjectFilter
 				"_lte_id" ,
 				"_notin_id",
 				"_gte_login_data_id",
+				"_gt_login_data_id",
 				"_ltornull_login_data_id",
 				"_eq_is_admin",
 				"_likex_puser_id_or_screen_name",

--- a/api_v3/lib/types/filters/KalturaUserFilter.php
+++ b/api_v3/lib/types/filters/KalturaUserFilter.php
@@ -51,7 +51,7 @@ class KalturaUserFilter extends KalturaUserBaseFilter
 		
 		if (!is_null($this->loginEnabledEqual)) {
 			if ($this->loginEnabledEqual === true)
-				$object_to_fill->set('_gte_login_data_id', 0);
+				$object_to_fill->set('_gt_login_data_id', 0);
 				
 			if ($this->loginEnabledEqual === false)
 				$object_to_fill->set('_ltornull_login_data_id', 0);
@@ -64,13 +64,13 @@ class KalturaUserFilter extends KalturaUserBaseFilter
 	{
 		parent::doFromObject($source_object, $responseProfile);
 		
-		$loginDataIdGreaterOrEqualValue =  $source_object->get('_gte_login_data_id');
+		$loginDataIdGreaterOrEqualValue =  $source_object->get('_gt_login_data_id');
 		$loginDataIdLessThanOrNullValue =  $source_object->get('_ltornull_login_data_id');
 		
-		if ($loginDataIdGreaterOrEqualValue == 0) {
+		if ($loginDataIdGreaterOrEqualValue === 0) {
 			$this->loginEnabledEqual = true;
 		}
-		else if ($loginDataIdLessThanOrNullValue == 0) {
+		else if ($loginDataIdLessThanOrNullValue === 0) {
 			$this->loginEnabledEqual = false;
 		}				
 	}


### PR DESCRIPTION
1. loginEnabledEqual should be translated to _gt_login_data_id instead of _gte_login_data_id. login_data_id is nullable in mysql but 0'd in sphinx.
2. when setting loginEnabledEqual in doFromObject, we should use the identical comparison operator (===), otherwise null is equal to 0.