### PR TITLE
http://httpd.apache.org/docs/current/upgrading.html:

### DIFF
--- a/configurations/apache/kaltura.ssl.conf.template
+++ b/configurations/apache/kaltura.ssl.conf.template
@@ -8,7 +8,12 @@ SSLSessionCache         shmcb:/var/cache/mod_ssl/scache(512000)
 SSLSessionCacheTimeout  300
 SSLRandomSeed startup file:/dev/urandom  256
 SSLRandomSeed connect builtin
-SSLMutex default
+<IfVersion < 2.4>
+        SSLMutex default
+</IfVersion>
+<IfVersion >= 2.4>
+        Mutex sysvsem default
+</IfVersion>
 SSLCryptoDevice builtin
 
 SSLCertificateFile @SSL_CERTIFICATE_FILE@


### PR DESCRIPTION
Directives AcceptMutex, LockFile, RewriteLock, SSLMutex,
SSLStaplingMutex, and WatchdogMutexPath have been replaced with a single
Mutex directive. You will need to evaluate any use of these removed
directives in your 2.2 configuration to determine if they can just be
deleted or will need to be replaced using Mutex.
http://httpd.apache.org/docs/current/mod/core.html#mutex