### PR TITLE
The root cause for SUP-4103 is that there are no thumbnails available an...

### DIFF
--- a/alpha/apps/kaltura/lib/myEntryUtils.class.php
+++ b/alpha/apps/kaltura/lib/myEntryUtils.class.php
@@ -754,7 +754,7 @@ class myEntryUtils
 	    				if(is_null($flavorAsset) || !($flavorAsset->hasTag(flavorParams::TAG_MBR) || $flavorAsset->hasTag(flavorParams::TAG_WEB)))
 					    {
     						// try the best playable
-						    $flavorAsset = assetPeer::retrieveHighestBitrateByEntryId($entry->getId());
+                            $flavorAsset = assetPeer::retrieveHighestBitrateByEntryIdWithValidFileSync($entry->getId());
 					    }
 					    if (is_null($flavorAsset))
 					    {

--- a/alpha/apps/kaltura/lib/myEntryUtils.class.php
+++ b/alpha/apps/kaltura/lib/myEntryUtils.class.php
@@ -754,7 +754,7 @@ class myEntryUtils
 	    				if(is_null($flavorAsset) || !($flavorAsset->hasTag(flavorParams::TAG_MBR) || $flavorAsset->hasTag(flavorParams::TAG_WEB)))
 					    {
     						// try the best playable
-                            $flavorAsset = assetPeer::retrieveHighestBitrateByEntryIdWithValidFileSync($entry->getId());
+                            $flavorAsset = assetPeer::retrieveHighestBitrateByEntryId($entry->getId());
 					    }
 					    if (is_null($flavorAsset))
 					    {

--- a/alpha/lib/model/assetPeer.php
+++ b/alpha/lib/model/assetPeer.php
@@ -525,43 +525,12 @@ class assetPeer extends BaseassetPeer
 		return assetPeer::doSelectOne($c);
 	}
 	
-	/**
-	 * @param string $entryId
-	 * @param string $tag tag filter
-	 * @return flavorAsset
-	 */
-	public static function retrieveHighestBitrateByEntryId($entryId, $tag = null)
-	{
-		$c = new Criteria();
-		$c->add(assetPeer::ENTRY_ID, $entryId);
-		$c->add(assetPeer::STATUS, flavorAsset::FLAVOR_ASSET_STATUS_READY);
-		$flavorTypes = self::retrieveAllFlavorsTypes();
-		$c->add(assetPeer::TYPE, $flavorTypes, Criteria::IN);
-		
-		$flavorAssets = self::doSelect($c);
-		if(!count($flavorAssets))
-			return null;
-			
-		if(!is_null($tag))
-			$flavorAssets = self::filterByTag($flavorAssets, $tag);
-		
-		if(!count($flavorAssets))
-			return null;
-			
-		$ret = null;
-		foreach($flavorAssets as $flavorAsset)
-			if(!$ret || $ret->getBitrate() < $flavorAsset->getBitrate())
-				$ret = $flavorAsset;
-				
-		return $ret;
-	}
-
     /**
      * @param string $entryId
      * @param string $tag tag filter
-     * @return flavorAsset
+     * @return flavorAsset that has a file_sync in status ready
      */
-    public static function retrieveHighestBitrateByEntryIdWithValidFileSync($entryId, $tag = null)
+    public static function retrieveHighestBitrateByEntryId($entryId, $tag = null)
     {
         $c = new Criteria();
         $c->add(assetPeer::ENTRY_ID, $entryId);


### PR DESCRIPTION
The root cause for SUP-4103 is that there are no thumbnails available andd we try to generate them on the fly, in order to generate them we try to get the flavor_asset with the highest bitrate to get the thumbnails from, in this case the customer has external storage configured and "delete after export" so that some of the flavor assets are connected to file syncs that are deleted. The fix is to see if to get the flavor asset with the highest bitrate and a file sync that is in status "ready". Such a flavor asset doesn't have to exist but this is still a better solution than the one we have in place.

@yuly-roberman could you please review.