### PR TITLE
Used CURLFile instead "@filename" when posting files if PHP>=5.5

### DIFF
--- a/alpha/scripts/compatCheck.php
+++ b/alpha/scripts/compatCheck.php
@@ -17,9 +17,9 @@ define('DB_NAME','kaltura');
 define('IP_ADDRESS_SALT', '');
 
 $PS2_TESTED_XML_ACTIONS = array(
-		'extwidget.playmanifest', 
-		'keditorservices.getmetadata', 
-		'keditorservices.getentryinfo', 
+		'extwidget.playmanifest',
+		'keditorservices.getmetadata',
+		'keditorservices.getentryinfo',
 		'partnerservices2.executeplaylist',
 		'partnerservices2.getentries',
 		'partnerservices2.getallentries',
@@ -40,7 +40,7 @@ $PS2_TESTED_BIN_ACTIONS = array(
 		'extwidget.thumbnail',
 		'extwidget.download',
 		'keditorservices.flvclipper',
-		'extwidget.raw',	
+		'extwidget.raw',
 		);
 
 $APIV3_TESTED_SERVICES = array(
@@ -91,7 +91,7 @@ $ID_FIELDS = array('id', 'guid', 'loc', 'title', 'link');
 class PartnerSecretPool
 {
 	protected $secrets = array();
-	
+
 	/**
 	 * @var resource
 	 */
@@ -115,7 +115,7 @@ class PartnerSecretPool
 			return $this->secrets[$partnerId];
 		if (!is_numeric($partnerId))
 			return null;
-			
+
 		$query = "SELECT admin_secret FROM partner WHERE id='{$partnerId}'";
 		$result = mysqli_query($this->link,$query) or die('Error: Select from func table query failed: ' . mysqli_error($link) . "\n");
 		$line = mysqli_fetch_array($result, MYSQLI_NUM);
@@ -144,15 +144,15 @@ function extendKsExpiry($ks)
 {
 	global $partnerSecretPool;
 	/* @var $partnerSecretPool PartnerSecretPool */
-	
+
 	$ksObj = new ks();
 	if (!$ksObj->parseKS($ks))
 		return null;
-	
+
 	$adminSecret = $partnerSecretPool->getPartnerSecret($ksObj->partner_id);
 	if (!$adminSecret)
 		return null;
-		
+
 	return kSessionBase::generateKsV1($adminSecret, $ksObj->user, $ksObj->type, $ksObj->partner_id, 86400, $ksObj->privileges, $ksObj->master_partner_id, $ksObj->additional_data);
 }
 
@@ -164,7 +164,7 @@ function print_r_reverse($in) {
     } else {
         if (!isset($lines[1]))
             return 'Array';
-    	 
+
         // this is an array, lets parse it
         if (preg_match('/(\s{5,})\(/', $lines[1], $match)) {
             // this is a tested array/recursive call to this function
@@ -210,7 +210,7 @@ function getSignedIpHeader($ipAddress)
 {
 	if (!IP_ADDRESS_SALT)
 		return array();
-	
+
 	$salt = IP_ADDRESS_SALT;
 	$curTime = time();
 	$uniqId = rand(1,32767);
@@ -223,9 +223,9 @@ function getSignedIpHeader($ipAddress)
 function doCurl($url, $params = array(), $files = array(), $range = null, $requestHeaders = array())
 {
 	global $extraRequestHeaders;
-	
+
 	$requestHeaders	= array_merge($requestHeaders, $extraRequestHeaders);
-	
+
 	$ch = curl_init();
 	curl_setopt($ch, CURLOPT_URL, $url);
 	if ($params)
@@ -234,9 +234,16 @@ function doCurl($url, $params = array(), $files = array(), $range = null, $reque
 	}
 	if (count($files) > 0)
 	{
-		foreach($files as &$file)
-			$file = "@".$file; // let curl know its a file
-		curl_setopt($ch, CURLOPT_POSTFIELDS, array_merge($params, $files));
+        foreach ($files as &$file) {
+            // The usage of the @filename API for file uploading is
+            // deprecated since PHP 5.5. CURLFile must be used instead.
+            if (PHP_VERSION_ID >= 50500) {
+                $file = new \CURLFile($file);
+            } else {
+                $file = "@" . $file; // let curl know its a file
+            }
+        }
+        curl_setopt($ch, CURLOPT_POSTFIELDS, array_merge($params, $files));
 	}
 	else if ($params)
 	{
@@ -252,17 +259,17 @@ function doCurl($url, $params = array(), $files = array(), $range = null, $reque
 	curl_setopt($ch, CURLOPT_USERAGENT, '');
 	curl_setopt($ch, CURLOPT_TIMEOUT, 0);
 	curl_setopt($ch, CURLOPT_HTTPHEADER, $requestHeaders );
-	
-	$beforeTime = microtime(true);	
+
+	$beforeTime = microtime(true);
 	$result = curl_exec($ch);
 	$endTime = microtime(true);
-	
+
 	$curlError = curl_error($ch);
 	curl_close($ch);
 	return array($result, $curlError, $endTime - $beforeTime);
 }
 
-function stripXMLInvalidChars($value) 
+function stripXMLInvalidChars($value)
 {
 	preg_match_all('/[^\t\n\r\x{20}-\x{d7ff}\x{e000}-\x{fffd}\x{10000}-\x{10ffff}]/u', $value, $invalidChars);
 	$invalidChars = reset($invalidChars);
@@ -279,7 +286,7 @@ function printStringDiff($string1, $string2)
 	{
 		if ($string1[$i] == $string2[$i])
 			continue;
-			
+
 		print "Byte offset: $i\n";
 		print "Char1: " . ord($string1[$i]) . "\n";
 		print "Char2: " . ord($string2[$i]) . "\n";
@@ -307,7 +314,7 @@ function stripInvalidUtf8Chars($value)
 /x
 END;
 	return preg_replace($regex, '$1', $value);
-	
+
 }
 
 function xmlToArray($xmlstring)
@@ -344,7 +351,7 @@ function normalizeKS($value, $ks)
 	$ksObj = new ks();
 	if (!$ksObj->parseKS($ks))
 		return $value;
-		
+
 	$ksFields = array(
 		$ksObj->partner_id,
 		$ksObj->partner_id,
@@ -364,8 +371,8 @@ function normalizeKS($value, $ks)
 function compareValues($newValue, $oldValue)
 {
 	return $newValue == $oldValue;
-}	
-	
+}
+
 function compareArraysInternal($resultNew, $resultOld, $path)
 {
 	global $ID_FIELDS;
@@ -374,13 +381,13 @@ function compareArraysInternal($resultNew, $resultOld, $path)
 	foreach ($resultOld as $key => $oldValue)
 	{
 		$subPath = "$path/$key";
-		
+
 		if (!array_key_exists($key, $resultNew))
 		{
 			$errors[$subPath] = "missing field $key (path=$path)";
 			continue;
 		}
-		
+
 		$newValue = $resultNew[$key];
 		if (is_array($oldValue) && is_array($newValue))
 		{
@@ -419,17 +426,17 @@ function compareArraysById($item1, $item2)
 
 	if (!is_array($item1) || !is_array($item2))
 		return 0;
-	
+
 	foreach ($ID_FIELDS as $idField)
 	{
-		if (isset($item1[$idField]) && isset($item2[$idField]) && 
+		if (isset($item1[$idField]) && isset($item2[$idField]) &&
 			$item1[$idField] != $item2[$idField])
 			return strcmp($item1[$idField], $item2[$idField]);
 	}
-	
+
 	return 0;
 }
-	
+
 function getCommonPrefixBase($string1, $string2)
 {
 	$left = 0;
@@ -467,7 +474,7 @@ function compareArrays($resultNew, $resultOld, $path)
 	$errors = compareArraysInternal($resultNew, $resultOld, $path);
 	if (count($errors) < 2)
 		return $errors;
-	
+
 	$ids = array();
 	$isOnlyIdErrors = true;
 	$errorPaths = array();
@@ -482,7 +489,7 @@ function compareArrays($resultNew, $resultOld, $path)
 				break;
 			}
 		}
-		
+
 		if (!$isCurIdError)
 		{
 			$isOnlyIdErrors = false;
@@ -491,23 +498,23 @@ function compareArrays($resultNew, $resultOld, $path)
 		$explodedError = explode('(path=', rtrim($curError, ')'));
 		$explodedError = explode(' new=', $explodedError[1]);
 		$errorPaths[] = $explodedError[0];
-		
+
 		$explodedError = explode(' old=', $explodedError[1]);
 		$ids[] = "'".$explodedError[0]."'";
 		$ids[] = "'".$explodedError[1]."'";
 	}
-	
+
 	if (!$isOnlyIdErrors)
 		return $errors;
-	
+
 	usort($resultNew, 'compareArraysById');
 	usort($resultOld, 'compareArraysById');
 	$newErrors = compareArraysInternal($resultNew, $resultOld, $path);
 	if ($newErrors)				// sorting didn't help
 		return $errors;
-	
+
 	$errorPath = getCommonPrefix($errorPaths);
-		
+
 	$ids = implode(',', array_unique($ids));
 	return array($errorPath => ('Different order ' . $ids));
 }
@@ -515,7 +522,7 @@ function compareArrays($resultNew, $resultOld, $path)
 function normalizeResultBuffer($result)
 {
 	global $serviceUrlNew, $serviceUrlOld, $KS_PATTERNS;
-	
+
 	$result = preg_replace('/<executionTime>[0-9\.]+<\/executionTime>/', '', $result);
 	$result = preg_replace('/<serverTime>[0-9\.]+<\/serverTime>/', '', $result);
 	$result = preg_replace('/<execute_impl_time>[\-0-9\.]+<\/execute_impl_time>/', '', $result);
@@ -525,12 +532,12 @@ function normalizeResultBuffer($result)
 	$result = preg_replace('/server_time="[0-9\.]+"/', '', $result);
 	$result = preg_replace('/kaltura_player_\d+/', 'KP', $result);
 	$result = preg_replace('/&ts=[0-9\.]+&/', '&ts=0&', $result);
-	
+
 	if (strlen($serviceUrlOld) < strlen($serviceUrlNew))		// this if is for case where one of the url is a prefix of the other
 		$result = str_replace($serviceUrlNew, $serviceUrlOld, $result);
 	else
 		$result = str_replace($serviceUrlOld, $serviceUrlNew, $result);
-	
+
 	$patterns = $KS_PATTERNS;
 	foreach ($patterns as $pattern)
 	{
@@ -563,7 +570,7 @@ define('KWIDGET_PARAMS_START', 'widgetId=');
 function parseWidget($buffer)
 {
 	$uncomp = gzuncompress(substr($buffer, 8));
-	
+
 	$apiResponseStart = strpos($uncomp, KWIDGET_API_START);
 	$apiResponseEnd = strrpos($uncomp, KWIDGET_API_END);
 	$apiResponse = null;
@@ -572,17 +579,17 @@ function parseWidget($buffer)
 		$apiResponse = substr($uncomp, $apiResponseStart, $apiResponseEnd + strlen(KWIDGET_API_END) - $apiResponseStart);
 		$uncomp = str_replace($apiResponse, '', $uncomp);
 	}
-		
+
 	$paramsStart = strpos($uncomp, KWIDGET_PARAMS_START);
 	$params = null;
 	if ($paramsStart !== false)
-	{ 
+	{
 		$paramsLen = unpack('V', substr($uncomp, $paramsStart - 10, 4));
 		$params = substr($uncomp, $paramsStart, $paramsLen[1]);
 		$uncomp = str_replace($params, '', $uncomp);
 		$params = normalizeResultBuffer($params);
 	}
-	
+
 	return array($uncomp, $apiResponse, $params);
 }
 
@@ -592,7 +599,7 @@ function compareResults($resultNew, $resultOld)
 	$resultOld = normalizeResultBuffer($resultOld);
 	if ($resultNew == $resultOld)
 		return array();
-		
+
 	$resultNew = xmlToArray($resultNew);
 	$resultOld = xmlToArray($resultOld);
 
@@ -600,26 +607,26 @@ function compareResults($resultNew, $resultOld)
 	{
 		return array('failed to parse both XMLs');
 	}
-	
+
 	if (!$resultNew)
 	{
 		return array('failed to parse new XML');
 	}
-	
+
 	if (!$resultOld)
 	{
 		return array('failed to parse old XML');
 	}
-	
+
 	return compareArrays($resultNew, $resultOld, "");
 }
 
-function beginsWith($str, $prefix) 
+function beginsWith($str, $prefix)
 {
 	return (substr($str, 0, strlen($prefix)) === $prefix);
 }
 
-function endsWith($str, $postfix) 
+function endsWith($str, $postfix)
 {
 	return (substr($str, -strlen($postfix)) === $postfix);
 }
@@ -635,7 +642,7 @@ function getRequestHash($fullActionName, $paramsForHash)
 			continue;
 		}
 	}
-	
+
 	$paramsToUnset = array(
 		"ks",
 		"kalsig",
@@ -662,79 +669,79 @@ function shouldProcessRequest($fullActionName, $parsedParams)
 {
 	global $testedActions, $testedRequests, $maxTestsPerActionType;
 	global $requestNumber, $startPosition, $endPosition;
-	
+
 	// test action type count
 	if (!array_key_exists($fullActionName, $testedActions))
 	{
 		$testedActions[$fullActionName] = 0;
 	}
-	
+
 	if ($maxTestsPerActionType && $testedActions[$fullActionName] > $maxTestsPerActionType)
 	{
 		return 'no';
 	}
-	
+
 	// test whether this action was already tested
 	$requestHash = getRequestHash($fullActionName, $parsedParams);
 	if (in_array($requestHash, $testedRequests))
 	{
 		return 'no';
 	}
-	
+
 	// apply start/end positions
 	$requestNumber++;
 	if ($endPosition != 0 && $requestNumber > $endPosition)
 	{
 		return 'quit';
 	}
-			
+
 	if ($requestNumber <= $startPosition)
 	{
 		return 'no';
 	}
-	
+
 	$testedRequests[] = $requestHash;
 	$testedActions[$fullActionName]++;
-	
+
 	return 'yes';
 }
 
 function testAction($ipAddress, $fullActionName, $parsedParams, $uri, $postParams = array(), $compareMode = CM_XML, $kalcliCmd = '')
 {
 	global $serviceUrlOld, $serviceUrlNew;
-	
+
 	print "Testing $fullActionName...";
-	
+
 	usleep(200000);         // sleep for 0.2 sec to avoid hogging the server
-	
+
 	$range = null;
 	if ($compareMode == CM_BINARY)
 		$range = '0-262144';		// 256K
-		
+
 	$requestHeaders = array();
 	for ($retries = 0; $retries < 3; $retries++)
 	{
 		if ($ipAddress)
-			$requestHeaders = getSignedIpHeader($ipAddress); 
+			$requestHeaders = getSignedIpHeader($ipAddress);
 		list($resultNew, $curlErrorNew, $newTime) = doCurl($serviceUrlNew . $uri, $postParams, array(), $range, $requestHeaders);
-		
+
 		if ($ipAddress)
-			$requestHeaders = getSignedIpHeader($ipAddress); 
+			$requestHeaders = getSignedIpHeader($ipAddress);
 		list($resultOld, $curlErrorOld, $oldTime) = doCurl($serviceUrlOld . $uri, $postParams, array(), $range, $requestHeaders);
-		
+
 		if ($curlErrorNew || $curlErrorOld)
 		{
 			print "Curl error [$curlErrorNew] [$curlErrorOld]\n";
 			return;
 		}
-		
-		if ($compareMode == CM_BINARY && 
-			substr($resultOld, 0, 5) ==  '<?xml' && 
+
+		if ($compareMode == CM_BINARY &&
+			substr($resultOld, 0, 5) ==  '<?xml' &&
 			substr($resultNew, 0, 5) ==  '<?xml')
 		{
 			$compareMode = CM_XML;
 		}
-		
+
 		switch ($compareMode)
 		{
 		case CM_WIDGET:
@@ -746,7 +753,7 @@ function testAction($ipAddress, $fullActionName, $parsedParams, $uri, $postParam
 			if ($paramsOld != $paramsNew)
 				$errors[] = 'Params dont match - new='.$paramsNew.' old='.$paramsOld;
 			break;
-				
+
 		case CM_BINARY:
 			$resultOld = normalizeResultBuffer($resultOld);
 			$resultNew = normalizeResultBuffer($resultNew);
@@ -760,12 +767,12 @@ function testAction($ipAddress, $fullActionName, $parsedParams, $uri, $postParam
 			else
 				$errors = array('Data does not match - size='.strlen($resultNew));
 			break;
-					
+
 		case CM_XML:
 			$errors = compareResults($resultNew, $resultOld);
 			break;
 		}
-		
+
 		if (!count($errors))
 		{
 			print sprintf("Ok (new=%.3f old=%.3f)\n", $newTime, $oldTime);
@@ -782,21 +789,21 @@ function testAction($ipAddress, $fullActionName, $parsedParams, $uri, $postParam
 					$sig = substr($parsedParams['1:ks'], 0, 20);
 				else
 					$sig = print_r($parsedParams, true);
-					
+
 				print "Warning: API became slow ({$sig})\n";
-			}			
+			}
 			return;
 		}
-		
+
 		if (count($errors) == 1 && beginsWith(reset($errors), 'Different order '))
 		{
 			break;			// retry doesn't help with different order, we can save the time
 		}
-		
+
 		print "\nRetrying $fullActionName...";
 		usleep(1000000);
 	}
-	
+
 	// check which requests failed with the multirequest
 	$badRequests = null;
 	if (beginsWith($fullActionName, 'multirequest'))
@@ -816,18 +823,18 @@ function testAction($ipAddress, $fullActionName, $parsedParams, $uri, $postParam
 			}
 		}
 	}
-	
+
 	if (is_array($badRequests))
 	{
 		$badRequests = array_unique($badRequests);
 		sort($badRequests);
 	}
-	
+
 	print "\n-------------------------------------------------------------------------------\n";
 	print "\tUrl = $serviceUrlNew$uri\n";
 	print "\tPostParams = ".var_export($postParams, true)."\n";
 	print "\tTestUrl = $serviceUrlNew$uri&".http_build_query($postParams)."\n";
-	
+
 	if ($kalcliCmd)
 	{
 		if (is_array($kalcliCmd))
@@ -847,7 +854,7 @@ function testAction($ipAddress, $fullActionName, $parsedParams, $uri, $postParam
 		}
 		print "\tkalcli = {$kalcliCmd}\n";
 	}
-	
+
 	foreach ($errors as $path => $error)
 	{
 		if (beginsWith($fullActionName, 'multirequest') && beginsWith($path, '/result/item/'))
@@ -861,10 +868,10 @@ function testAction($ipAddress, $fullActionName, $parsedParams, $uri, $postParam
 		{
 			$actionName = $fullActionName;
 		}
-		
+
 		print "\tError: ($actionName) $error\n";
 	}
-	
+
 	if ($compareMode == CM_XML && (count($errors) != 1 || !beginsWith(reset($errors), 'Different order ')))
 	{
 		print "Result - new\n";
@@ -884,30 +891,30 @@ function extendRequestKss(&$parsedParams)
 			return false;
 		$parsedParams['ks'] = $ks;
 	}
-	
+
 	for ($i = 1; ; $i++)
 	{
 		$ksKey = "{$i}:ks";
 		if (!array_key_exists($ksKey, $parsedParams))
 			break;
-		
+
 		$ks = $parsedParams[$ksKey];
 		$ks = extendKsExpiry($ks);
 		if (is_null($ks))
 			return false;
 		$parsedParams[$ksKey] = $ks;
 	}
-	
+
 	return true;
 }
 
 function isServiceApproved($service)
 {
 	global $APIV3_TESTED_SERVICES;
-	
+
 	if(in_array('*', $APIV3_TESTED_SERVICES))
 		return true;
-		
+
 	foreach ($APIV3_TESTED_SERVICES as $approvedService)
 	{
 		if (strcmp(strtolower($approvedService), strtolower($service)) == 0)
@@ -935,7 +942,7 @@ function isActionApproved($fullActionName, $action)
 				return false;
 		}
 	}
-	
+
 	foreach ($APIV3_TESTED_ACTIONS as $approvedAction)
 	{
 		if (beginsWith($approvedAction, '*.'))
@@ -959,7 +966,7 @@ function generateKalcliCommand($ipAddress, $service, $action, $parsedParams)
 	{
 		if (in_array($key, array('action', 'service')))
 			continue;
-		
+
 		$curParam = "{$key}={$value}";
 		if (!preg_match('/^[a-zA-Z0-9\:_\-,=\.\/]+$/', $curParam))
 			if (strpos($curParam, "'") === false)
@@ -984,7 +991,7 @@ function processMultiRequest($ipAddress, $parsedParams)
 			$commonParams[$paramName] = $paramValue;
 			continue;
 		}
-		
+
 		$requestIndex = (int)$explodedName[0];
 		$paramName = implode(':', array_slice($explodedName, 1));
 		if (!array_key_exists($requestIndex, $paramsByRequest))
@@ -994,12 +1001,12 @@ function processMultiRequest($ipAddress, $parsedParams)
 		$paramsByRequest[$requestIndex][$paramName] = $paramValue;
 	}
 	unset($commonParams['action']);		// sometimes multirequests have action=null
-	
+
 	if (!$paramsByRequest)
 	{
 		return;
 	}
-	
+
 	$fullActionName = 'multirequest';
 	$maxIndex = max(array_keys($paramsByRequest));
 	for ($reqIndex = 1; $reqIndex <= $maxIndex; $reqIndex++)
@@ -1010,16 +1017,16 @@ function processMultiRequest($ipAddress, $parsedParams)
 		{
 			return;
 		}
-		
+
 		$service = $paramsByRequest[$reqIndex]['service'];
 		$action = $paramsByRequest[$reqIndex]['action'];
-		
-		$curFullActionName = strtolower("$service.$action");		
+
+		$curFullActionName = strtolower("$service.$action");
 		if (!isServiceApproved($service) || !isActionApproved($curFullActionName, $action))
 		{
 			return;
 		}
-		
+
 		$fullActionName .= '/'.$curFullActionName;
 	}
 
@@ -1027,19 +1034,19 @@ function processMultiRequest($ipAddress, $parsedParams)
 	{
 		return;
 	}
-	
+
 	switch (shouldProcessRequest($fullActionName, $parsedParams))
 	{
 	case 'quit':
 		return true;
-		
+
 	case 'no':
 		return;
 	}
-	
+
 	$parsedParams['format'] = '2';		# XML
 	ksort($parsedParams);
-	
+
 	$uri = "/api_v3/index.php?service=multirequest";
 
 	$kalcliCmds = array();
@@ -1050,7 +1057,7 @@ function processMultiRequest($ipAddress, $parsedParams)
 		$action = $curParams['action'];
 		$kalcliCmds[] = generateKalcliCommand($ipAddress, $service, $action, array_merge($curParams, $commonParams));
 	}
-	
+
 	testAction($ipAddress, $fullActionName, $parsedParams, $uri, $parsedParams, CM_XML, $kalcliCmds);
 }
 
@@ -1064,7 +1071,7 @@ function processRequest($ipAddress, $parsedParams)
 
 	$service = $parsedParams['service'];
 	unset($parsedParams['service']);
-	
+
 	if (beginsWith(strtolower($service), "multirequest"))
 	{
 		if (strtolower($service) == "multirequest")
@@ -1073,39 +1080,39 @@ function processRequest($ipAddress, $parsedParams)
 		}
 		return;
 	}
-	
+
 	if (!array_key_exists('action', $parsedParams))
 	{
 		//print "Error: action not specified " . print_r($parsedParams, true) . "\n";
 		return;
 	}
-		
+
 	$action = $parsedParams['action'];
 	unset($parsedParams['action']);
-	
+
 	$fullActionName = strtolower("$service.$action");
 	$parsedParams['format'] = '2';		# XML
-	
-	if (!isServiceApproved($service) || 
+
+	if (!isServiceApproved($service) ||
 		!isActionApproved($fullActionName, $action) ||
 		!extendRequestKss($parsedParams))
 	{
 		return;
 	}
-	
+
 	switch (shouldProcessRequest($fullActionName, $parsedParams))
 	{
 	case 'quit':
 		return true;
-		
+
 	case 'no':
 		return;
 	}
-	
+
 	ksort($parsedParams);
-	
+
 	$kalcliCmd = generateKalcliCommand($ipAddress, $service, $action, $parsedParams);
-	
+
 	$uri = "/api_v3/index.php?service=$service&action=$action";
 	$compareMode = (beginsWith($action, 'serve') ? CM_BINARY : CM_XML);
 	testAction($ipAddress, $fullActionName, $parsedParams, $uri, $parsedParams, $compareMode, $kalcliCmd);
@@ -1121,21 +1128,21 @@ function processFeedRequest($ipAddress, $parsedParams)
 	{
 		return;
 	}
-	
+
 	switch (shouldProcessRequest($fullActionName, $parsedParams))
 	{
 	case 'quit':
 		return true;
-		
+
 	case 'no':
 		return;
 	}
-	
+
 	$parsedParams['nocache'] = '1';
 	ksort($parsedParams);
-	
+
 	$uri = "/api_v3/getFeed.php?" . http_build_query($parsedParams, null, "&");
-	
+
 	testAction($ipAddress, $fullActionName, $parsedParams, $uri);
 }
 
@@ -1150,7 +1157,7 @@ class LogProcessorApiV3 implements LogProcessor
 	protected $isFeed = false;
 	protected $params = '';
 	protected $ipAddress = '';
-	
+
 	function processLine($buffer)
 	{
 		if (!$this->inParams)
@@ -1181,7 +1188,7 @@ class LogProcessorApiV3 implements LogProcessor
 			if ($buffer[0] == ']')
 			{
 				$this->inParams = false;
-			
+
 				$parsedParams = print_r_reverse($this->params);
 				if (print_r($parsedParams, true) != $this->params)
 				{
@@ -1197,7 +1204,7 @@ class LogProcessorApiV3 implements LogProcessor
 				{
 					$shouldQuit = processRequest($this->ipAddress, $parsedParams);
 				}
-				
+
 				if ($shouldQuit)
 				{
 					return true;
@@ -1208,7 +1215,7 @@ class LogProcessorApiV3 implements LogProcessor
 				$this->params .= $buffer;
 			}
 		}
-	
+
 		return false;
 	}
 }
@@ -1231,36 +1238,36 @@ function processPS2Request($ipAddress, $parsedParams)
 	{
 		$parsedParams['format'] = '2';          # XML
 	}
-	
+
 	if (strtolower($module) == 'partnerservices2' &&
 		strtolower($action) == 'defpartnerservices2base')
 	{
 		$action = $parsedParams['myaction'];
 		unset($parsedParams['myaction']);
 	}
-	
+
 	$fullActionName = strtolower("$module.$action");
-	
-	if (!in_array($fullActionName, $PS2_TESTED_XML_ACTIONS) && 
+
+	if (!in_array($fullActionName, $PS2_TESTED_XML_ACTIONS) &&
 		!in_array($fullActionName, $PS2_TESTED_BIN_ACTIONS))
 	{
 		return;
 	}
-	
+
 	if (!extendRequestKss($parsedParams))
 	{
 		return;
 	}
-	
+
 	switch (shouldProcessRequest($fullActionName, $parsedParams))
 	{
 	case 'quit':
 		return true;
-		
+
 	case 'no':
 		return;
 	}
-	
+
 	ksort($parsedParams);
 	$uri = "/index.php/$module/$action?" . http_build_query($parsedParams, null, "&");
 
@@ -1274,7 +1281,7 @@ function processPS2Request($ipAddress, $parsedParams)
 }
 
 class LogProcessorPS2 implements LogProcessor
-{	
+{
 	function processLine($buffer)
 	{
 		$markerPos = strpos($buffer, PS2_START_MARKER);
@@ -1312,9 +1319,9 @@ class LogProcessorUriList implements LogProcessor
 	function processLine($buffer)
 	{
 		$uri = trim($buffer);
-		
+
 		// TODO: call extendRequestKss
-		
+
 		$service = '';
 		if (preg_match('/service=([\w_]+)/', $uri, $matches))
 			$service = $matches[1];
@@ -1326,7 +1333,7 @@ class LogProcessorUriList implements LogProcessor
 		$fullActionName = "$service.$action";
 		if ($fullActionName == '.')
 			$fullActionName = $uri;
-		
+
 		testAction(null, $fullActionName, array(), $uri);
 	}
 }
@@ -1340,7 +1347,7 @@ function processRegularFile($apiLogPath, LogProcessor $logProcessor)
 	$logStats = fstat($handle);
 	$origSize = $logStats['size'];
 
-	while (ftell($handle) < $origSize && ($buffer = fgets($handle)) !== false) 
+	while (ftell($handle) < $origSize && ($buffer = fgets($handle)) !== false)
 	{
 		if ($logProcessor->processLine($buffer))
 			break;
@@ -1355,7 +1362,7 @@ function processGZipFile($apiLogPath, LogProcessor $logProcessor)
 	if (!$handle)
 		die('Error: failed to open log file');
 
-	while (!gzeof($handle)) 
+	while (!gzeof($handle))
 	{
 		$buffer = gzgets($handle, 16384);
 		if ($logProcessor->processLine($buffer))

--- a/generator/sources/php5/KalturaClientBase.php
+++ b/generator/sources/php5/KalturaClientBase.php
@@ -47,7 +47,7 @@ class MultiRequestSubResult implements ArrayAccess
 	{
         return new MultiRequestSubResult($this->value . ':' . $name);
 	}
-	
+
 	public function offsetExists($offset)
 	{
 		return true;
@@ -61,7 +61,7 @@ class MultiRequestSubResult implements ArrayAccess
 	public function offsetSet($offset, $value)
 	{
 	}
-	
+
 	public function offsetUnset($offset)
 	{
 	}
@@ -157,13 +157,13 @@ class KalturaClientBase
 	* @var Array of response headers
 	*/
 	private $responseHeaders = array();
-	
+
 	/**
 	 * path to save served results
 	 * @var string
 	 */
 	protected $destinationPath = null;
-	
+
 	/**
 	 * return served results without unserializing them
 	 * @var boolean
@@ -249,7 +249,7 @@ class KalturaClientBase
 
 		// append the basic params
 		$this->addParam($params, "format", $this->config->format);
-	
+
 		foreach($this->clientConfiguration as $param => $value)
 		{
 			$this->addParam($params, $param, $value);
@@ -299,7 +299,7 @@ class KalturaClientBase
 			$this->resetRequest();
 			throw new KalturaClientException("Downloading files is not supported as part of multi-request.", KalturaClientException::ERROR_DOWNLOAD_IN_MULTIREQUEST);
 		}
-		
+
 		if (count($this->callsQueue) == 0)
 		{
 			$this->resetRequest();
@@ -320,7 +320,7 @@ class KalturaClientBase
 		{
 			$this->addParam($params, $param, $value);
 		}
-		
+
 		$url = $this->config->serviceUrl."/api_v3/index.php?service=";
 		if ($this->isMultiRequest)
 		{
@@ -376,7 +376,7 @@ class KalturaClientBase
 			}
 			if (!is_null($serverName) || !is_null($serverSession))
 				$this->log("server: [{$serverName}], session: [{$serverSession}]");
-			
+
 			$this->log("result (serialized): " . $postResult);
 
 			if($this->returnServedResult)
@@ -446,10 +446,10 @@ class KalturaClientBase
 	{
 		if (function_exists('curl_init'))
 			return $this->doCurl($url, $params, $files);
-			
+
 		if($this->destinationPath || $this->returnServedResult)
 			throw new KalturaClientException("Downloading files is not supported with stream context http request, please use curl.", KalturaClientException::ERROR_DOWNLOAD_NOT_SUPPORTED);
-				
+
 		return $this->doPostRequest($url, $params, $files);
 	}
 
@@ -481,9 +481,16 @@ class KalturaClientBase
 			$this->log("curl: $url&$opt");
 			if (count($files) > 0)
 			{
-				foreach($files as &$file)
-					$file = "@".$file; // let curl know its a file
-				curl_setopt($ch, CURLOPT_POSTFIELDS, array_merge($params, $files));
+                foreach ($files as &$file) {
+                    // The usage of the @filename API for file uploading is
+                    // deprecated since PHP 5.5. CURLFile must be used instead.
+                    if (PHP_VERSION_ID >= 50500) {
+                        $file = new \CURLFile($file);
+                    } else {
+                        $file = "@" . $file; // let curl know its a file
+                    }
+                }
+                curl_setopt($ch, CURLOPT_POSTFIELDS, array_merge($params, $files));
 			}
 			else
 			{
@@ -551,12 +558,12 @@ class KalturaClientBase
 		{
 			curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
 		}
-		
+
 		$result = curl_exec($ch);
-		
+
 		if($destinationResource)
 			fclose($destinationResource);
-			
+
 		$curlError = curl_error($ch);
 		curl_close($ch);
 		return array($result, $curlError);
@@ -686,7 +693,7 @@ class KalturaClientBase
 			}
 		}
 	}
-	
+
 	public function setRequestConfiguration(KalturaRequestConfiguration $configuration)
 	{
 		$params = get_class_vars('KalturaRequestConfiguration');
@@ -705,7 +712,7 @@ class KalturaClientBase
 			}
 		}
 	}
-	
+
 	/**
 	 * Add parameter to array of parameters that is passed by reference
 	 *
@@ -1115,7 +1122,7 @@ abstract class KalturaObjectBase
 	 * @var array
 	 */
 	public $relatedObjects;
-	
+
 	public function __construct($params = array())
 	{
 		foreach ($params as $key => $value)
@@ -1160,15 +1167,15 @@ abstract class KalturaObjectBase
 class KalturaException extends Exception
 {
 	private $arguments;
-	
+
     public function __construct($message, $code, $arguments)
     {
     	$this->code = $code;
     	$this->arguments = $arguments;
-    	
+
 		parent::__construct($message);
     }
-    
+
 	/**
 	 * @return array
 	 */
@@ -1176,7 +1183,7 @@ class KalturaException extends Exception
 	{
 		return $this->arguments;
 	}
-    
+
 	/**
 	 * @return string
 	 */
@@ -1186,7 +1193,7 @@ class KalturaException extends Exception
 		{
 			return $this->arguments[$argument];
 		}
-		
+
 		return null;
 	}
 }


### PR DESCRIPTION
Used [CURLFile](http://php.net/manual/es/class.curlfile.php) instead "@filename" when posting files if PHP>=5.5.

Replaces #2005.