### PR TITLE
Preview and embed broken when no playlists are available

### DIFF
--- a/alpha/web/lib/js/kmc/6.0.11/kmc.js
+++ b/alpha/web/lib/js/kmc/6.0.11/kmc.js
@@ -3590,7 +3590,7 @@ kmcApp.controller('PreviewCtrl', ['$scope', '$translate', 'previewService', func
 			options = options || {};
 			var playerId = (options.uiConfId) ? options.uiConfId : undefined;
 			// Exit if player not loaded
-			if(!kmc.vars.playlists_list || !kmc.vars.players_list) {
+			if(!kmc.vars.playlists_list && !kmc.vars.players_list) {
 				return ;
 			}
 			// List of players


### PR DESCRIPTION
The preview and embed was broken for some of my clients. It came down to the exit early statement in updatePlayers(). Here it is required to have at least one player and one playlist. After this patch you are no longer required to have both types. One player of either type will still work. 