### PR TITLE
fixes

### DIFF
--- a/alpha/lib/model/DeliveryProfile.php
+++ b/alpha/lib/model/DeliveryProfile.php
@@ -9,6 +9,10 @@ abstract class DeliveryProfile extends BaseDeliveryProfile {
 	
 	protected $DEFAULT_RENDERER_CLASS = 'kF4MManifestRenderer';
 	
+	const DYNAMIC_ATTRIBUTES_FULL_SUPPORT = 0;		// the profile fully supports the required attirbutes
+	const DYNAMIC_ATTRIBUTES_PARTIAL_SUPPORT = 1;	// the profile may support the required attirbutes however its better to try and find a more suitable profile
+	const DYNAMIC_ATTRIBUTES_NO_SUPPORT = 2;		// the profile doesn't support the required attirbutes
+	
 	/**
 	 * @var DeliveryProfileDynamicAttributes
 	 */
@@ -44,10 +48,10 @@ abstract class DeliveryProfile extends BaseDeliveryProfile {
 		{
 			$supportedProtocols = explode(",", $this->getMediaProtocols());
 			if(!in_array($deliveryAttributes->getMediaProtocol(), $supportedProtocols)) 
-				return false;
+				return self::DYNAMIC_ATTRIBUTES_NO_SUPPORT;
 		}
 		
-		return true;
+		return self::DYNAMIC_ATTRIBUTES_FULL_SUPPORT;
 	}
 	
 	/**

--- a/alpha/lib/model/DeliveryProfileGenericHttp.php
+++ b/alpha/lib/model/DeliveryProfileGenericHttp.php
@@ -31,13 +31,16 @@ class DeliveryProfileGenericHttp extends DeliveryProfileHttp {
 	 * @param DeliveryProfileDynamicAttributes $deliveryAttributes
 	 */
 	public function supportsDeliveryDynamicAttributes(DeliveryProfileDynamicAttributes $deliveryAttributes) {
-		if (!parent::supportsDeliveryDynamicAttributes($deliveryAttributes))
-			return false;
+		$result = parent::supportsDeliveryDynamicAttributes($deliveryAttributes);
+		
+		if ($result == self::DYNAMIC_ATTRIBUTES_NO_SUPPORT)
+			return $result;
 	
-		if ($deliveryAttributes->getSeekFromTime() > 0)
-			return false;
+		// the profile supports seek if it has the {seekFromSec} placeholder in its pattern
+		if ($deliveryAttributes->getSeekFromTime() > 0 and strpos("{seekFromSec}", $this->getPattern()) === false)
+			return self::DYNAMIC_ATTRIBUTES_PARTIAL_SUPPORT;
 				
-		return true;
+		return $result;
 	}
 
 }

--- a/alpha/lib/model/DeliveryProfilePeer.php
+++ b/alpha/lib/model/DeliveryProfilePeer.php
@@ -291,11 +291,18 @@ class DeliveryProfilePeer extends BaseDeliveryProfilePeer {
 			$deliveryAttributes->setMediaProtocol(null);
 		}
 	
+		$partialSupport = null;
+		
+		// find either a fully supported deliveryProfile or the first partial supported one
 		foreach ($deliveries as $delivery) {
-			if ($delivery->supportsDeliveryDynamicAttributes($deliveryAttributes))
+			$result = $delivery->supportsDeliveryDynamicAttributes($deliveryAttributes);
+			if ($result == DeliveryProfile::DYNAMIC_ATTRIBUTES_FULL_SUPPORT)
 				return $delivery;
+			else if (!$partialSupport && $result == DeliveryProfile::DYNAMIC_ATTRIBUTES_PARTIAL_SUPPORT)
+				$partialSupport = $delivery;
 		}
-		return null;
+		
+		return $partialSupport;
 	}
 	
 	/**

--- a/alpha/lib/model/DeliveryProfileVodPackagerHds.php
+++ b/alpha/lib/model/DeliveryProfileVodPackagerHds.php
@@ -30,14 +30,16 @@ class DeliveryProfileVodPackagerHds extends DeliveryProfileHds {
 	 * @param DeliveryProfileDynamicAttributes $deliveryAttributes
 	 */
 	public function supportsDeliveryDynamicAttributes(DeliveryProfileDynamicAttributes $deliveryAttributes) {
-		if (!parent::supportsDeliveryDynamicAttributes($deliveryAttributes))
-			return false;
+		$result = parent::supportsDeliveryDynamicAttributes($deliveryAttributes);
+		
+		if ($result == self::DYNAMIC_ATTRIBUTES_NO_SUPPORT)
+			return $result;
 	
 		foreach($deliveryAttributes->getFlavorAssets() as $flavorAsset) {
 			if (strtolower($flavorAsset->getFileExt()) == 'flv' || strtolower($flavorAsset->getContainerFormat()) == 'flash video')
-				return false;
+				return self::DYNAMIC_ATTRIBUTES_NO_SUPPORT;
 		}
 				
-		return true;
+		return $result;
 	}
 }


### PR DESCRIPTION
The supportsDeliveryDynamicAttributes allow further flexibility by returning either full support / partial support or no support return values.
In case a delivery profile can ignore certain parameters (e.g. seekFrom) but still provide a valid url it will return "partial support" and in case no better profile exists, it will be used