### PR TITLE
fixes

### DIFF
--- a/alpha/lib/model/DeliveryProfileGenericHttp.php
+++ b/alpha/lib/model/DeliveryProfileGenericHttp.php
@@ -37,11 +37,10 @@ class DeliveryProfileGenericHttp extends DeliveryProfileHttp {
 			return $result;
 	
 		// the profile supports seek if it has the {seekFromSec} placeholder in its pattern
-		if ($deliveryAttributes->getSeekFromTime() > 0 and strpos("{seekFromSec}", $this->getPattern()) === false)
+		if ($deliveryAttributes->getSeekFromTime() > 0 && strpos($this->getPattern(), "{seekFromSec}") === false)
 			return self::DYNAMIC_ATTRIBUTES_PARTIAL_SUPPORT;
 				
 		return $result;
 	}
-
 }
 

--- a/api_v3/lib/types/delivery/KalturaDeliveryProfile.php
+++ b/api_v3/lib/types/delivery/KalturaDeliveryProfile.php
@@ -125,7 +125,6 @@ class KalturaDeliveryProfile extends KalturaObject implements IFilterable
 	/**
 	 * priority used for ordering similar delivery profiles
 	 * @var int
-	 * @readonly
 	 */
 	public $priority;
 


### PR DESCRIPTION
The supportsDeliveryDynamicAttributes allow further flexibility by returning either full support / partial support or no support return values.
In case a delivery profile can ignore certain parameters (e.g. seekFrom) but still provide a valid url it will return "partial support" and in case no better profile exists, it will be used