### PR TITLE
akamai hls direct fix for remote storage

### DIFF
--- a/alpha/lib/model/DeliveryProfileAkamaiAppleHttpDirect.php
+++ b/alpha/lib/model/DeliveryProfileAkamaiAppleHttpDirect.php
@@ -23,7 +23,8 @@ class DeliveryProfileAkamaiAppleHttpDirect extends DeliveryProfileAkamaiAppleHtt
 	
 	protected function getUrlPrefix()
 	{
-		return parse_url($this->getUrl(), PHP_URL_HOST);
+		$parsedUrl = parse_url($this->getUrl());
+		return $parsedUrl["scheme"] . "://" . $parsedUrl["host"];
 	}
 	
 	protected function formatHdIos($path) {

--- a/alpha/lib/model/DeliveryProfileVod.php
+++ b/alpha/lib/model/DeliveryProfileVod.php
@@ -270,7 +270,7 @@ abstract class DeliveryProfileVod extends DeliveryProfile {
 	
 		$urlPrefix = '';
 		if (strpos($url, "://") === false) {
-			$urlPrefix = $this->getUrl();
+			$urlPrefix = $this->getUrlPrefix();
 			$url = "/".$url;
 		}
 	


### PR DESCRIPTION
only relevant when the delivery profile url has a path