### PR TITLE
Keep uploadToken fileName ext when fileData is tmp

### DIFF
--- a/alpha/apps/kaltura/lib/kUploadTokenMgr.php
+++ b/alpha/apps/kaltura/lib/kUploadTokenMgr.php
@@ -218,7 +218,7 @@ class kUploadTokenMgr
 
 		// in firefox html5 upload the extension is missing (file name is "blob") so try fetching the extesion from
 		// the original file name that was passed to the uploadToken
-		if ($extension === "")
+		if ($extension === "" || ($extension == "tmp" && $this->_uploadToken->getFileName()))
 			$extension = strtolower(pathinfo($this->_uploadToken->getFileName(), PATHINFO_EXTENSION));
 
 		$uploadFilePath = $this->getUploadPath($this->_uploadToken->getId(), $extension);


### PR DESCRIPTION
SUP-4393

When uploading from KSR it sets the uploadToken fileName as mp4 but the extension of the upload_temp_path remained tmp.
Changed it so that the upload_temp_path extension will be taken from the uploadToken fileName if it was 'tmp'.