### PR TITLE
out of memory issue when trying to print all of the files to log

### DIFF
--- a/plugins/drop_folder/batch/Engine/KDropFolderFileTransferEngine.php
+++ b/plugins/drop_folder/batch/Engine/KDropFolderFileTransferEngine.php
@@ -432,7 +432,7 @@ class KDropFolderFileTransferEngine extends KDropFolderEngine
 		{
 			KalturaLog::debug(print_r($currlFile, true));
 		}
-
+		
 		return $physicalFiles;
 	}
 	

--- a/plugins/drop_folder/batch/Engine/KDropFolderFileTransferEngine.php
+++ b/plugins/drop_folder/batch/Engine/KDropFolderFileTransferEngine.php
@@ -426,15 +426,13 @@ class KDropFolderFileTransferEngine extends KDropFolderEngine
 		{
 			throw new kFileTransferMgrException('Drop folder path not valid ['.$this->dropFolder->path.']', kFileTransferMgrException::remotePathNotValid);
 		}
-			
-		if (count($physicalFiles) > 100)
+
+		KalturaLog::debug("physical files: ");
+		foreach ($physicalFiles as &$currlFile)
 		{
-			KalturaLog::notice("physical files: too many files to print to log");
+			KalturaLog::debug(print_r($currlFile, true));
 		}
-		else
-		{
-			KalturaLog::debug("physical files: ".print_r($physicalFiles, true));
-		}
+
 		return $physicalFiles;
 	}
 	

--- a/plugins/drop_folder/batch/Engine/KDropFolderFileTransferEngine.php
+++ b/plugins/drop_folder/batch/Engine/KDropFolderFileTransferEngine.php
@@ -25,7 +25,7 @@ class KDropFolderFileTransferEngine extends KDropFolderEngine
 			$dropFolderFilesMap = array();
 
 		$maxModificationTime = 0;
-		foreach ($physicalFiles as $physicalFile) 
+		foreach ($physicalFiles as &$physicalFile)
 		{
 			/* @var $physicalFile FileObject */	
 			$physicalFileName = $physicalFile->filename;
@@ -427,7 +427,14 @@ class KDropFolderFileTransferEngine extends KDropFolderEngine
 			throw new kFileTransferMgrException('Drop folder path not valid ['.$this->dropFolder->path.']', kFileTransferMgrException::remotePathNotValid);
 		}
 			
-		KalturaLog::debug("physical files: ".print_r($physicalFiles, true));
+		if (count($physicalFiles) > 100)
+		{
+			KalturaLog::notice("physical files: too many files to print to log");
+		}
+		else
+		{
+			KalturaLog::debug("physical files: ".print_r($physicalFiles, true));
+		}
 		return $physicalFiles;
 	}
 	


### PR DESCRIPTION
…es from the folder (>30000) and then when we try to loop through them we create an identical array which uses up too much memory which causes a PHP Fatal and thus stops the watcher from completing it's job. In order to use less memory I added the use of references in the loop that way we don't create an identicatl array. Also if there are too many files I won't print it.

