### PR TITLE
SUP-3451 Swedish language support required

### DIFF
--- a/admin_console/configs/lang/sv.php
+++ b/admin_console/configs/lang/sv.php
@@ -1,0 +1,3 @@
+<?php
+
+return require dirname(__FILE__) . DIRECTORY_SEPARATOR . 'en.php';

--- a/admin_console/configs/lang/sv_SE.php
+++ b/admin_console/configs/lang/sv_SE.php
@@ -1,0 +1,3 @@
+<?php
+
+return require dirname(__FILE__) . DIRECTORY_SEPARATOR . 'en.php';

--- a/var_console/configs/lang/sv.php
+++ b/var_console/configs/lang/sv.php
@@ -1,0 +1,3 @@
+<?php
+
+return require dirname(__FILE__) . DIRECTORY_SEPARATOR . 'en.php';

--- a/var_console/configs/lang/sv_SE.php
+++ b/var_console/configs/lang/sv_SE.php
@@ -1,0 +1,3 @@
+<?php
+
+return require dirname(__FILE__) . DIRECTORY_SEPARATOR . 'en.php';


### PR DESCRIPTION
SUP-3451
Accept-Language header sent from page is set by Zend framework as not installed
Adding files to support Swedish in specific to redirect to english (as hebrew)

@MosheMaorKaltura 