### PR TITLE
Update infraRequestUtils.class.php

### DIFF
--- a/alpha/apps/kaltura/lib/request/infraRequestUtils.class.php
+++ b/alpha/apps/kaltura/lib/request/infraRequestUtils.class.php
@@ -168,6 +168,9 @@ class infraRequestUtils
 						case "3gp":
 								$content_type ="video/3gpp";
 								break;
+				case "js":
+					$content_type ="application/javascript";
+					break;
 				default:
 					$content_type ="image/$ext";
 					break;


### PR DESCRIPTION
Chrome version 42 does not execute javascript sent with content-type different than 'application/javascript'. More details can be found in the issue I have opened at https://github.com/kaltura/server/issues/2498.
Tested in a Kaltura all-in-one installation at my office.