### PR TITLE
There is a race condition if the database is updated but the code isn…

### DIFF
--- a/deployment/updates/sql/2015_14_05_metadata_profile_file_sync_version.sql
+++ b/deployment/updates/sql/2015_14_05_metadata_profile_file_sync_version.sql
@@ -1,3 +1,2 @@
 ALTER TABLE `metadata_profile` ADD `file_sync_version` int(11) AFTER `version`;
 UPDATE metadata_profile mp SET mp.file_sync_version = mp.version;
-UPDATE metadata_profile mp SET mp.version = 0;

--- a/plugins/metadata/lib/model/MetadataProfile.php
+++ b/plugins/metadata/lib/model/MetadataProfile.php
@@ -290,4 +290,16 @@ class MetadataProfile extends BaseMetadataProfile implements ISyncableFile
 	    $this->xsltData = $xsltData;
 	}
 
+	public function getFileSyncVersion()
+	{
+		$fileSyncVersion = parent::getFileSyncVersion();
+		if (is_null($fileSyncVersion))
+		{
+			return $this->getVersion();
+		}
+		return $fileSyncVersion;
+
+	}
+
+
 } // MetadataProfile


### PR DESCRIPTION
…'t then someone can create a metadataprofile and the fileSyncVersion will be null, we need to verify it's not null and return the version if it is. Also update script name to reflect that actual date it is pushed.
No need to update "version" to 0, useless.

reviewed by @MosheMaorKaltura 