### PR TITLE
Change so that when someone wants to filter according to nameOrRefere…

### DIFF
--- a/plugins/sphinx_search/lib/SphinxCategoryCriteria.php
+++ b/plugins/sphinx_search/lib/SphinxCategoryCriteria.php
@@ -143,8 +143,8 @@ class SphinxCategoryCriteria extends SphinxCriteria
 		{
 			$names = $filter->get('_likex_name_or_reference_id');
 			KalturaLog::debug("Attach free text [$names]");
-			
-			$this->addFreeTextToMatchClauseByMatchFields($names, categoryFilter::NAME_REFERNCE_ID, null, true);
+			$additional = array("(@(name,reference_id) $names)");
+			$this->addFreeTextToMatchClauseByMatchFields($names, categoryFilter::NAME_REFERNCE_ID, $additional, true);
 		}
 		$filter->unsetByName('_likex_name_or_reference_id');
 		

--- a/plugins/sphinx_search/lib/SphinxCategoryCriteria.php
+++ b/plugins/sphinx_search/lib/SphinxCategoryCriteria.php
@@ -143,8 +143,7 @@ class SphinxCategoryCriteria extends SphinxCriteria
 		{
 			$names = $filter->get('_likex_name_or_reference_id');
 			KalturaLog::debug("Attach free text [$names]");
-			$additional = array("(@(name,reference_id) $names)");
-			$this->addFreeTextToMatchClauseByMatchFields($names, categoryFilter::NAME_REFERNCE_ID, $additional, true);
+			$this->addFreeTextToMatchClauseByMatchFields($names, categoryFilter::NAME_REFERNCE_ID, null, true);
 		}
 		$filter->unsetByName('_likex_name_or_reference_id');
 		

--- a/plugins/sphinx_search/lib/SphinxCriteria.php
+++ b/plugins/sphinx_search/lib/SphinxCriteria.php
@@ -1036,7 +1036,7 @@ abstract class SphinxCriteria extends KalturaCriteria implements IKalturaIndexQu
 			$freeText = "^$freeText$";
 			$condition = "@(" . $matchFields . ") $freeText";
 			if($isLikeExpr)
-				$condition .= "\\\*";
+				$condition .= " | $freeText\\\*";
 			$additionalConditions[] = $condition;
 		}
 		else
@@ -1066,7 +1066,7 @@ abstract class SphinxCriteria extends KalturaCriteria implements IKalturaIndexQu
 				{
 					$condition = "@(" . $matchFields . ") $freeText";
 					if($isLikeExpr)
-						$condition .= "\\\*";
+						$condition .= " | $freeText\\\*";
 					$additionalConditions[] = $condition;
 				}
 			}
@@ -1076,7 +1076,7 @@ abstract class SphinxCriteria extends KalturaCriteria implements IKalturaIndexQu
 				$freeTextExpr = implode(baseObjectFilter::AND_SEPARATOR, $freeTextsArr);
 				$condition = "@(" . $matchFields . ") $freeTextExpr";
 				if($isLikeExpr)
-					$condition .= "\\\*";
+					$condition .= " | $freeTextExpr\\\*";
 				$additionalConditions[] = $condition;
 			}
 		}


### PR DESCRIPTION
…nceIdStartsWith then we will definitely return also the exact match and also the completions for that expression.

I made the change so that only this request with this filter will be changed. _likex_name_or_reference_id is used only when the filter has nameOrReferenceIdStartsWith field this way I will affect only sphinx queries that have that 
