### PR TITLE
Whitelist filename chars for flavorAsset-getUrl

### DIFF
--- a/alpha/lib/model/flavorAsset.php
+++ b/alpha/lib/model/flavorAsset.php
@@ -281,7 +281,7 @@ class flavorAsset extends asset
 		{
 			list($fileName , $extension) = kAssetUtils::getFileName($entry , $this);
 			$fileName = str_replace("\n", ' ', $fileName);
-			$fileName = kString::stripInvalidUrlChars($fileName);
+			$fileName = kString::keepOnlyValidUrlChars($fileName);
 	
 			if ($extension)
 				$fileName .= ".$extension";

--- a/infra/general/kString.class.php
+++ b/infra/general/kString.class.php
@@ -440,4 +440,9 @@ class kString
 		return str_replace(array('?', '|', '*', '\\', '/' , '>' , '<', '&', '[', ']',' '), '_', $url);
 	}
 
+	public static function keepOnlyValidUrlChars($url)
+	{
+	    return preg_replace('/[^A-Za-z0-9\-\.\_\~\!\$\&\(\)\*\+\,\;\=\:\@]/', '_', $url);
+	}
+	
 }

--- a/infra/general/kString.class.php
+++ b/infra/general/kString.class.php
@@ -442,7 +442,7 @@ class kString
 
 	public static function keepOnlyValidUrlChars($url)
 	{
-	    return preg_replace('/[^A-Za-z0-9\-\.\_\~\!\$\&\(\)\*\+\,\;\=\:\@]/', '_', $url);
+	    return preg_replace('/[^A-Za-z0-9\-._~!$&()*+,;=:@]/', '_', $url);
 	}
 	
 }


### PR DESCRIPTION
SUP-4491
Up until now we used to go over the file name and strip chars from a blacklist, but there are too many chars that can brake the url.
From now on we keep only chars that are in the whitelist and that we know they work.  