### PR TITLE
If the search parameter is less than 3 characters but contains spaces we will replace the spaces with " and search again.

### DIFF
--- a/api_v3/lib/types/KalturaObject.php
+++ b/api_v3/lib/types/KalturaObject.php
@@ -868,6 +868,14 @@ abstract class KalturaObject
 	    }
 	}
 
+	public function replaceSpaceInStringProperty($propertyName, $originalValue)
+	{
+		if (!$this->isNull($propertyName))
+		{
+			$this->$propertyName = str_replace(" ", "\"", $originalValue);
+		}
+	}
+
 	public function cast($className) {
 		if(!is_subclass_of($className, get_class($this)))
 			throw new KalturaAPIException(KalturaErrors::INVALID_OBJECT_TYPE, get_class($this));

--- a/api_v3/lib/types/KalturaObject.php
+++ b/api_v3/lib/types/KalturaObject.php
@@ -868,14 +868,6 @@ abstract class KalturaObject
 	    }
 	}
 
-	public function replaceSpaceInStringProperty($propertyName, $originalValue)
-	{
-		if (!$this->isNull($propertyName))
-		{
-			$this->$propertyName = str_replace(" ", "\"", $originalValue);
-		}
-	}
-
 	public function cast($className) {
 		if(!is_subclass_of($className, get_class($this)))
 			throw new KalturaAPIException(KalturaErrors::INVALID_OBJECT_TYPE, get_class($this));

--- a/plugins/tag_search/lib/api/filters/KalturaTagFilter.php
+++ b/plugins/tag_search/lib/api/filters/KalturaTagFilter.php
@@ -69,7 +69,7 @@ class KalturaTagFilter extends KalturaFilter
 		}
 		catch (Exception $e)
 		{
-			$this->replaceSpaceInStringProperty('tagStartsWith',$originalTagStartsWith);
+			$this->replaceLastSpaceWithQuotesInStringProperty('tagStartsWith',$originalTagStartsWith);
 			$this->validatePropertyMinLength('tagStartsWith', TagSearchPlugin::MIN_TAG_SEARCH_LENGTH, true, true);
 		}
 		$this->validatePropertyMinLength('tagEqual', TagSearchPlugin::MIN_TAG_SEARCH_LENGTH, true, true);
@@ -93,5 +93,13 @@ class KalturaTagFilter extends KalturaFilter
 		$object->set ('_likex_tag', str_replace(kTagFlowManager::$specialCharacters, kTagFlowManager::$specialCharactersReplacement, $this->tagStartsWith));
 		
 		return parent::toObject($object, $props_to_skip);
+	}
+
+	public function replaceLastSpaceWithQuotesInStringProperty($propertyName, $originalValue)
+	{
+		if (!$this->isNull($propertyName))
+		{
+			$this->$propertyName = preg_replace("/^(.*) $/","$1\"",$originalValue);
+		}
 	}
 }

--- a/plugins/tag_search/lib/api/filters/KalturaTagFilter.php
+++ b/plugins/tag_search/lib/api/filters/KalturaTagFilter.php
@@ -61,8 +61,17 @@ class KalturaTagFilter extends KalturaFilter
 
 	public function validate()
 	{
+		$originalTagStartsWith = $this->tagStartsWith;
 		$this->trimStringProperties(array ('tagStartsWith', 'tagEqual'));
-		$this->validatePropertyMinLength('tagStartsWith', TagSearchPlugin::MIN_TAG_SEARCH_LENGTH, true, true);
+		try
+		{
+			$this->validatePropertyMinLength('tagStartsWith', TagSearchPlugin::MIN_TAG_SEARCH_LENGTH, true, true);
+		}
+		catch (Exception $e)
+		{
+			$this->replaceSpaceInStringProperty('tagStartsWith',$originalTagStartsWith);
+			$this->validatePropertyMinLength('tagStartsWith', TagSearchPlugin::MIN_TAG_SEARCH_LENGTH, true, true);
+		}
 		$this->validatePropertyMinLength('tagEqual', TagSearchPlugin::MIN_TAG_SEARCH_LENGTH, true, true);
 	}
 	


### PR DESCRIPTION
Reviewed by @MosheMaorKaltura .
This keeps the regular functionality that we already had but allows to search for complex expressions that have spaces in them.
Solution brought forth by @Galmoss .

