### PR TITLE
SUP 4001 - sphinx category filter double partnerID

### DIFF
--- a/plugins/sphinx_search/lib/SphinxCategoryCriteria.php
+++ b/plugins/sphinx_search/lib/SphinxCategoryCriteria.php
@@ -163,7 +163,7 @@ class SphinxCategoryCriteria extends SphinxCriteria
 		}
 		
 		if($filter->get('_eq_display_in_search')) {
-			$filter->set('_eq_display_in_search', $filter->get('_eq_display_in_search') . "P" . $partnerId);
+			$filter->set('_eq_display_in_search', $filter->get('_eq_display_in_search'));
 		}
 		
 		return parent::applyFilterFields($filter);


### PR DESCRIPTION
SUP-4001
PartnerID was concatenated twice to the sphix search condition for the case of category _eq_display_in_search