### PR TITLE
Whenever the play-manifest requests for a non-existing entry (either

### DIFF
--- a/alpha/apps/kaltura/modules/extwidget/actions/playManifestAction.class.php
+++ b/alpha/apps/kaltura/modules/extwidget/actions/playManifestAction.class.php
@@ -873,6 +873,9 @@ class playManifestAction extends kalturaAction
 	
 	public function execute()
 	{
+		
+		KExternalErrors::setResponseErrorCode(KExternalErrors::HTTP_STATUS_NOT_FOUND);
+		
 		$this->deliveryAttributes = new DeliveryProfileDynamicAttributes();
 		// Parse input parameters
 		$this->deliveryAttributes->setSeekFromTime($this->getRequestParameter ( "seekFrom" , -1));


### PR DESCRIPTION
deleted, or just non-existing) the return value will be http status not
found (404) instead of the current 200.
The response header of (X-Kaltura-App) will be kept as usual.