### PR TITLE
Revert addition to "orderby" on Answer,Question cue points and QuizUserEntry

### DIFF
--- a/plugins/cue_points/quiz/lib/api/KalturaAnswerCuePoint.php
+++ b/plugins/cue_points/quiz/lib/api/KalturaAnswerCuePoint.php
@@ -25,7 +25,6 @@ class KalturaAnswerCuePoint extends KalturaCuePoint
 	/**
 	 * @var KalturaNullableBoolean
 	 * @readonly
- 	 * @filter order
 	 */
 	public $isCorrect;
 

--- a/plugins/cue_points/quiz/lib/api/KalturaQuestionCuePoint.php
+++ b/plugins/cue_points/quiz/lib/api/KalturaQuestionCuePoint.php
@@ -21,7 +21,7 @@ class KalturaQuestionCuePoint extends KalturaCuePoint
 
 	/**
 	 * @var string
-	 * @filter like,mlikeor,mlikeand,order
+	 * @filter like,mlikeor,mlikeand
 	 */
 	public $question;
 

--- a/plugins/cue_points/quiz/lib/api/KalturaQuizUserEntry.php
+++ b/plugins/cue_points/quiz/lib/api/KalturaQuizUserEntry.php
@@ -9,7 +9,6 @@ class KalturaQuizUserEntry extends KalturaUserEntry{
 	/**
 	 * @var int
 	 * @readonly
-	 * @filter order
 	 */
 	public $score;
 

--- a/plugins/cue_points/quiz/lib/api/filters/base/KalturaAnswerCuePointBaseFilter.php
+++ b/plugins/cue_points/quiz/lib/api/filters/base/KalturaAnswerCuePointBaseFilter.php
@@ -12,8 +12,6 @@ abstract class KalturaAnswerCuePointBaseFilter extends KalturaCuePointFilter
 
 	static private $order_by_map = array
 	(
-		"+isCorrect" => "+is_correct",
-		"-isCorrect" => "-is_correct",
 	);
 
 	public function getMapBetweenObjects()

--- a/plugins/cue_points/quiz/lib/api/filters/base/KalturaQuestionCuePointBaseFilter.php
+++ b/plugins/cue_points/quiz/lib/api/filters/base/KalturaQuestionCuePointBaseFilter.php
@@ -15,8 +15,6 @@ abstract class KalturaQuestionCuePointBaseFilter extends KalturaCuePointFilter
 
 	static private $order_by_map = array
 	(
-		"+question" => "+question",
-		"-question" => "-question",
 	);
 
 	public function getMapBetweenObjects()

--- a/plugins/cue_points/quiz/lib/api/filters/base/KalturaQuizUserEntryBaseFilter.php
+++ b/plugins/cue_points/quiz/lib/api/filters/base/KalturaQuizUserEntryBaseFilter.php
@@ -12,8 +12,6 @@ abstract class KalturaQuizUserEntryBaseFilter extends KalturaUserEntryFilter
 
 	static private $order_by_map = array
 	(
-		"+score" => "+score",
-		"-score" => "-score",
 	);
 
 	public function getMapBetweenObjects()

--- a/plugins/cue_points/quiz/lib/api/filters/orderEnums/KalturaAnswerCuePointOrderBy.php
+++ b/plugins/cue_points/quiz/lib/api/filters/orderEnums/KalturaAnswerCuePointOrderBy.php
@@ -5,6 +5,4 @@
  */
 class KalturaAnswerCuePointOrderBy extends KalturaCuePointOrderBy
 {
-	const IS_CORRECT_ASC = "+isCorrect";
-	const IS_CORRECT_DESC = "-isCorrect";
 }

--- a/plugins/cue_points/quiz/lib/api/filters/orderEnums/KalturaQuestionCuePointOrderBy.php
+++ b/plugins/cue_points/quiz/lib/api/filters/orderEnums/KalturaQuestionCuePointOrderBy.php
@@ -5,6 +5,4 @@
  */
 class KalturaQuestionCuePointOrderBy extends KalturaCuePointOrderBy
 {
-	const QUESTION_ASC = "+question";
-	const QUESTION_DESC = "-question";
 }

--- a/plugins/cue_points/quiz/lib/api/filters/orderEnums/KalturaQuizUserEntryOrderBy.php
+++ b/plugins/cue_points/quiz/lib/api/filters/orderEnums/KalturaQuizUserEntryOrderBy.php
@@ -5,6 +5,4 @@
  */
 class KalturaQuizUserEntryOrderBy extends KalturaUserEntryOrderBy
 {
-	const SCORE_ASC = "+score";
-	const SCORE_DESC = "-score";
 }


### PR DESCRIPTION
Reverting some changes from "https://github.com/kaltura/server/pull/2696"
There is no need for order by on these and the client libraries are generated correctly and built fine.