### PR TITLE
add port to the cdn host that comes from the white list, in case someone configured Kaltura server on non standard port

### DIFF
--- a/alpha/apps/kaltura/lib/myPartnerUtils.class.php
+++ b/alpha/apps/kaltura/lib/myPartnerUtils.class.php
@@ -327,6 +327,10 @@ class myPartnerUtils
 		if ($partner && $partner->isInCDNWhiteList($_SERVER['HTTP_HOST']))
 		{
 			$cdnHost = $protocol.'://'.$_SERVER['HTTP_HOST'];
+			if (isset($_SERVER['SERVER_PORT']))
+			{
+				$cdnHost .= ":".$_SERVER['SERVER_PORT'];
+			}
 			return $cdnHost;
 		}
 


### PR DESCRIPTION
Per suggestion by @jessp01 in https://github.com/kaltura/server/pull/2715 I added the use of the port from $_SERVER['SERVER_PORT'] if it is given 