### PR TITLE
TYPE = InnoDB was deprecated in MySQL 5.0 and was removed in My SQL 5.1

### DIFF
--- a/deployment/base/sql/01.kaltura_ce_tables.sql
+++ b/deployment/base/sql/01.kaltura_ce_tables.sql
@@ -2441,4 +2441,4 @@ CREATE TABLE `user_entry`
 	CONSTRAINT `user_entry_FK_2`
 		FOREIGN KEY (`kuser_id`)
 		REFERENCES `kuser` (`id`)
-)Type=InnoDB COMMENT='Describes the relationship between a specific user and a specific entry';
+)ENGINE=InnoDB COMMENT='Describes the relationship between a specific user and a specific entry';


### PR DESCRIPTION
and later versions.