### PR TITLE
In BaseEntry->copyInto the first thing that should be copied is the c…

### DIFF
--- a/alpha/lib/model/om/Baseentry.php
+++ b/alpha/lib/model/om/Baseentry.php
@@ -4377,6 +4377,8 @@ abstract class Baseentry extends BaseObject  implements Persistent {
 	public function copyInto($copyObj, $deepCopy = false)
 	{
 
+		$copyObj->setCustomData($this->custom_data);
+		
 		$copyObj->setId($this->id);
 
 		$copyObj->setKshowId($this->kshow_id);
@@ -4432,8 +4434,6 @@ abstract class Baseentry extends BaseObject  implements Persistent {
 		$copyObj->setDisplayInSearch($this->display_in_search);
 
 		$copyObj->setSubpId($this->subp_id);
-
-		$copyObj->setCustomData($this->custom_data);
 
 		$copyObj->setScreenName($this->screen_name);
 


### PR DESCRIPTION
…ustom_data since some of the other copy functions sometimes try to get it from the new object and if it doesn't exist it is set as the default and if it is set we will not actually set it in the future, so this has to be done first.

PLAT-3325 #time 0.5 days