### PR TITLE
MySQL 5.6 has strict mode enabled by default causing some of the

### DIFF
--- a/deployment/base/sql/01.kaltura_ce_tables.sql
+++ b/deployment/base/sql/01.kaltura_ce_tables.sql
@@ -1,5 +1,5 @@
 /*Table structure for table `access_control` */
-
+SET GLOBAL sql_mode = '';
 CREATE TABLE IF NOT EXISTS `access_control` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
   `partner_id` int(11) NOT NULL,
@@ -2419,7 +2419,7 @@ CREATE TABLE `edge_server`
 	PRIMARY KEY (`id`),
 	KEY partner_id_status_system_name(`partner_id`, `status`, `system_name`),
 	KEY host_name(`host_name`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `user_entry`
 (
@@ -2435,24 +2435,3 @@ CREATE TABLE `user_entry`
 	PRIMARY KEY (`id`),
 	KEY (`entry_id`, `kuser_id`)
 )ENGINE=InnoDB COMMENT='Describes the relationship between a specific user and a specific entry';
-
-
-CREATE TABLE app_token
-(
-	id VARCHAR(20)  NOT NULL,
-	int_id INTEGER  NOT NULL AUTO_INCREMENT,
-	partner_id INTEGER,
-	created_at DATETIME,
-	updated_at DATETIME,
-	deleted_at DATETIME,
-	STATUS INTEGER,
-	expiry INTEGER,
-	session_type INTEGER,
-	session_user_id VARCHAR(100),
-	session_duration INTEGER,
-	session_privileges TEXT,
-	token TEXT,
-	custom_data TEXT,
-	PRIMARY KEY (id),
-	KEY int_id_index (int_id)
-)ENGINE=INNODB DEFAULT CHARSET=utf8;

--- a/deployment/base/sql/01.kaltura_ce_tables.sql
+++ b/deployment/base/sql/01.kaltura_ce_tables.sql
@@ -2435,3 +2435,24 @@ CREATE TABLE `user_entry`
 	PRIMARY KEY (`id`),
 	KEY (`entry_id`, `kuser_id`)
 )ENGINE=InnoDB COMMENT='Describes the relationship between a specific user and a specific entry';
+
+
+CREATE TABLE app_token
+(
+	id VARCHAR(20)  NOT NULL,
+	int_id INTEGER  NOT NULL AUTO_INCREMENT,
+	partner_id INTEGER,
+	created_at DATETIME,
+	updated_at DATETIME,
+	deleted_at DATETIME,
+	STATUS INTEGER,
+	expiry INTEGER,
+	session_type INTEGER,
+	session_user_id VARCHAR(100),
+	session_duration INTEGER,
+	session_privileges TEXT,
+	token TEXT,
+	custom_data TEXT,
+	PRIMARY KEY (id),
+	KEY int_id_index (int_id)
+)ENGINE=INNODB DEFAULT CHARSET=utf8;

--- a/deployment/base/sql/01.kaltura_sphinx_ce_tables.sql
+++ b/deployment/base/sql/01.kaltura_sphinx_ce_tables.sql
@@ -1,4 +1,4 @@
-
+SET GLOBAL sql_mode = '';
 /*Table structure for table `sphinx_log` */
 CREATE TABLE IF NOT EXISTS `sphinx_log` (
   `id` int(11) NOT NULL AUTO_INCREMENT,

--- a/deployment/base/sql/04.stored_procedures.sql
+++ b/deployment/base/sql/04.stored_procedures.sql
@@ -1,4 +1,4 @@
-
+SET GLOBAL sql_mode = '';
 DELIMITER $$
 
 /* Procedure structure for procedure `update_entries` */


### PR DESCRIPTION
DB population parts to fail. Disable strict mode prior to deploying.
Also, set ROW_FORMAT=DYNAMIC; to avoid getting:
ERROR 1071 (42000): Specified key was too long; max key length is 767
bytes

See:
http://mechanics.flite.com/blog/2014/07/29/using-innodb-large-prefix-to-avoid-error-1071/
for more info on that.