### PR TITLE
Jupiter 10.15.0 file sync import fixes2

### DIFF
--- a/alpha/apps/kaltura/modules/extwidget/actions/serveMultiFileAction.class.php
+++ b/alpha/apps/kaltura/modules/extwidget/actions/serveMultiFileAction.class.php
@@ -6,7 +6,7 @@
 class serveMultiFileAction extends sfAction
 {
 	/**
-	 * Will forward to the regular swf player according to the widget_id 
+	 * Serves multiple files for synchronization between datacenters 
 	 */
 	public function execute()
 	{

--- a/plugins/multi_centers/lib/MultiCentersErrors.php
+++ b/plugins/multi_centers/lib/MultiCentersErrors.php
@@ -10,4 +10,6 @@ class MultiCentersErrors extends KalturaErrors
 	const GET_LOCK_CACHE_FAILED = "GET_LOCK_CACHE_FAILED;;Failed to get cache for locking file syncs";
 	
 	const GET_KEYS_CACHE_FAILED = "GET_KEYS_CACHE_FAILED;;Failed to get cache for storing file sync import status";
+	
+	const EXTEND_FILESYNC_LOCK_FAILED = "EXTEND_FILESYNC_LOCK_FAILED;;Failed to extend the file sync lock";
 }

--- a/plugins/multi_centers/services/FileSyncImportBatchService.php
+++ b/plugins/multi_centers/services/FileSyncImportBatchService.php
@@ -311,9 +311,9 @@ class FileSyncImportBatchService extends KalturaBatchService
 	}	
 
 	/**
-	 * batch renewFileSyncLock action extends the expiration of a file sync lock
+	 * batch extendFileSyncLock action extends the expiration of a file sync lock
 	 *
-	 * @action renewFileSyncLock
+	 * @action extendFileSyncLock
 	 * @param int $id The id of the file sync 
 	 */
 	function extendFileSyncLockAction($id)

--- a/plugins/multi_centers/services/FileSyncImportBatchService.php
+++ b/plugins/multi_centers/services/FileSyncImportBatchService.php
@@ -309,4 +309,27 @@ class FileSyncImportBatchService extends KalturaBatchService
 		
 		return $result;
 	}	
+
+	/**
+	 * batch renewFileSyncLock action extends the expiration of a file sync lock
+	 *
+	 * @action renewFileSyncLock
+	 * @param int $id The id of the file sync 
+	 */
+	function extendFileSyncLockAction($id)
+	{
+		// need to explicitly disable the cache since this action does not perform any queries
+		kApiCache::disableConditionalCache();
+		
+		$lockCache = kCacheManager::getSingleLayerCache(kCacheManager::CACHE_TYPE_LOCK_KEYS);
+		if (!$lockCache)
+		{
+			throw new KalturaAPIException(MultiCentersErrors::GET_LOCK_CACHE_FAILED);
+		}
+		
+		if (!$lockCache->set(self::LOCK_KEY_PREFIX . $id, true, self::LOCK_EXPIRY))
+		{
+			throw new KalturaAPIException(MultiCentersErrors::EXTEND_FILESYNC_LOCK_FAILED);
+		}
+	}
 }


### PR DESCRIPTION
1. need to recreate the curl handle every cycle, since there is no way to undo the setting of CURLOPT_FILE
2. renew the file sync lock when performing resume, to support extremely large files
3. fix the comment of serveMultiFileAction