### PR TITLE
file sync import fixes

### DIFF
--- a/alpha/apps/kaltura/lib/storage/kFileSyncUtils.class.php
+++ b/alpha/apps/kaltura/lib/storage/kFileSyncUtils.class.php
@@ -1364,6 +1364,12 @@ class kFileSyncUtils implements kObjectChangedEventConsumer, kObjectAddedEventCo
 			$firstLink->setFilePath($fileSync->getFilePath());
 			$firstLink->setFileType($fileSync->getFileType());
 			$firstLink->setLinkedId(0); // keep it zero instead of null, that's the only way to know it used to be a link.
+			$firstLink->setIsDir($fileSync->getIsDir());
+			if ($fileSync->getOriginalDc() && $fileSync->getOriginalId())
+			{
+				$firstLink->setOriginalDc($fileSync->getOriginalDc());
+				$firstLink->setOriginalId($fileSync->getOriginalId());
+			}
 			$firstLink->save();
 		}
 		

--- a/alpha/apps/kaltura/modules/extwidget/actions/serveMultiFileAction.class.php
+++ b/alpha/apps/kaltura/modules/extwidget/actions/serveMultiFileAction.class.php
@@ -56,7 +56,7 @@ class serveMultiFileAction extends sfAction
 						
 			if (!file_exists($resolvedPath))
 			{
-				$error = "Path [$resolvedPath] for fileSync id [$file_sync_id] does not exist";
+				$error = "Path [$resolvedPath] for fileSync id [".$fileSync->getId()."] does not exist";
 				KalturaLog::err($error);
 				continue;
 			}


### PR DESCRIPTION
1. when a link becomes file, need to copy the originalDc and originalId in
case the file was pending
2. fixed the printing of file sync in a log line