### PR TITLE
file sync import touch ups

### DIFF
--- a/alpha/scripts/utils/fileSyncQueueStatus.php
+++ b/alpha/scripts/utils/fileSyncQueueStatus.php
@@ -1,5 +1,7 @@
 <?php
 
+fclose(STDOUT);		// hide the log messages written to stdout
+
 require_once(dirname(__FILE__).'/../bootstrap.php');
 
 define('MAX_FILESYNC_ID_PREFIX', 'fileSyncMaxId-dc');

--- a/plugins/multi_centers/services/FileSyncImportBatchService.php
+++ b/plugins/multi_centers/services/FileSyncImportBatchService.php
@@ -214,7 +214,7 @@ class FileSyncImportBatchService extends KalturaBatchService
 			if ($createdAtLessThanOrEqual)
 			{
 				$firstFileSync = reset($fileSyncs);
-				$lastId = $firstFileSync->getId();
+				$prevLastId = $firstFileSync->getId();
 				
 				foreach ($fileSyncs as $index => $fileSync)
 				{
@@ -222,10 +222,15 @@ class FileSyncImportBatchService extends KalturaBatchService
 					{
 						$done = true;
 						unset($fileSyncs[$index]);
+						if (!is_null($prevLastId))
+						{
+							$lastId = $prevLastId;
+							$prevLastId = null;
+						}
 					}
 					else
 					{
-						$lastId = $fileSync->getId();
+						$prevLastId = $fileSync->getId();
 					}
 				}
 				


### PR DESCRIPTION
- have the worker quit once an hour, in order to get config/code changes
- increase the sleep time when the worker has nothing to do
- hide log lines in fileSyncQueueStatus.php
- bug fix in the handling of createdAtLessThanOrEqual, lastId should be updated only when finding a file sync that is not old enough