### PR TITLE
PLAT-3392 support update on metada change

### DIFF
--- a/plugins/content_distribution/providers/tvinci/lib/model/TvinciDistributionField.php
+++ b/plugins/content_distribution/providers/tvinci/lib/model/TvinciDistributionField.php
@@ -5,4 +5,10 @@
  */ 
 interface TvinciDistributionField extends BaseEnum
 {
+    // ENTRY related fields
+    const CUSTOM    = 'CUSTOM_DATA';
+
+    // METADATA related fields    
+    const META      = '*';
+
 }

--- a/plugins/content_distribution/providers/tvinci/lib/model/TvinciDistributionProfile.php
+++ b/plugins/content_distribution/providers/tvinci/lib/model/TvinciDistributionProfile.php
@@ -19,6 +19,34 @@ class TvinciDistributionProfile extends ConfigurableDistributionProfile
 		return TvinciDistributionPlugin::getProvider();
 	}
 
+	protected function getDefaultFieldConfigArray()
+	{
+		$fieldConfigArray = parent::getDefaultFieldConfigArray();
+
+		$fieldConfig = new DistributionFieldConfig();
+		$fieldConfig->setFieldName(TvinciDistributionField::CUSTOM);
+		$fieldConfig->setUserFriendlyFieldName('Custom Data:');
+		$fieldConfig->setUpdateOnChange(true);
+		$fieldConfig->setIsDefault(true);
+		$fieldConfig->setUpdateParams( array( entryPeer::CUSTOM_DATA, entryPeer::DESCRIPTION, entryPeer::NAME));
+		$fieldConfig->setIsRequired(DistributionFieldRequiredStatus::NOT_REQUIRED);
+		$fieldConfigArray[$fieldConfig->getFieldName()] = $fieldConfig;
+
+		return $fieldConfigArray;
+
+	}
+
+	public function getUpdateRequiredMetadataXPaths()
+	{
+		$metadataConfigArray = parent::getUpdateRequiredMetadataXPaths();
+		/* we want any change to the metadata to create an update possibility */
+		$metadataConfigArray[] = TvinciDistributionField::META;
+
+		return $metadataConfigArray;
+
+	}
+
+
 
 	public function validateForSubmission(EntryDistribution $entryDistribution, $action)
 	{


### PR DESCRIPTION
PLAT-3392
Distribution update is enabled for:
METADATA changes
CUSTOM_DATA changes (includes referenceID )
NAME
DESCRIPTION