### PR TITLE
Fixes PHP Notice:  curl_setopt(): CURLOPT_SSL_VERIFYHOST no longer accepts the value 1, value 2 will be used instead

### DIFF
--- a/infra/general/KCurlWrapper.class.php
+++ b/infra/general/KCurlWrapper.class.php
@@ -175,7 +175,7 @@ class KCurlWrapper
 		if(!$params || !isset($params->curlVerifySSL) || !$params->curlVerifySSL)
 		{
 			curl_setopt($this->ch, CURLOPT_SSL_VERIFYPEER, false);
-			curl_setopt($this->ch, CURLOPT_SSL_VERIFYHOST, 1);
+			curl_setopt($this->ch, CURLOPT_SSL_VERIFYHOST, 2);
 		}
 	}
 


### PR DESCRIPTION
see http://www.serverphorums.com/read.php?7,620892