### PR TITLE
recalc the original id when a link becomes file

### DIFF
--- a/alpha/apps/kaltura/lib/storage/kFileSyncUtils.class.php
+++ b/alpha/apps/kaltura/lib/storage/kFileSyncUtils.class.php
@@ -1365,10 +1365,10 @@ class kFileSyncUtils implements kObjectChangedEventConsumer, kObjectAddedEventCo
 			$firstLink->setFileType($fileSync->getFileType());
 			$firstLink->setLinkedId(0); // keep it zero instead of null, that's the only way to know it used to be a link.
 			$firstLink->setIsDir($fileSync->getIsDir());
-			if ($fileSync->getOriginalDc() && $fileSync->getOriginalId())
+			if (!is_null($fileSync->getOriginalDc()))
 			{
 				$firstLink->setOriginalDc($fileSync->getOriginalDc());
-				$firstLink->setOriginalId($fileSync->getOriginalId());
+				$firstLink->unsetOriginalId();		// recalculate the original id when importing the file sync
 			}
 			$firstLink->save();
 		}

--- a/plugins/multi_centers/services/FileSyncImportBatchService.php
+++ b/plugins/multi_centers/services/FileSyncImportBatchService.php
@@ -72,6 +72,17 @@ class FileSyncImportBatchService extends KalturaBatchService
 		return false;
 	}
 	
+	protected static function getOriginalFileSync($fileSync)
+	{
+		$c = new Criteria();
+		$c->addAnd(FileSyncPeer::OBJECT_ID, $fileSync->getObjectId());
+		$c->addAnd(FileSyncPeer::OBJECT_TYPE, $fileSync->getObjectType());
+		$c->addAnd(FileSyncPeer::VERSION, $fileSync->getVersion());
+		$c->addAnd(FileSyncPeer::OBJECT_SUB_TYPE, $fileSync->getObjectSubType());
+		$c->addAnd(FileSyncPeer::DC, $fileSync->getOriginalDc());
+		return FileSyncPeer::doSelectOne($c);
+	}
+	
 	/**
 	 * batch lockPendingFileSyncs action locks file syncs for import by the file sync periodic worker
 	 *
@@ -267,7 +278,20 @@ class FileSyncImportBatchService extends KalturaBatchService
 				
 				KalturaLog::debug('locked file sync ' . $fileSync->getId());
 				
-				// locked, add to the result set
+				// get the original id if not set
+				if (!$fileSync->getOriginalId())
+				{
+					$originalFileSync = self::getOriginalFileSync($fileSync);
+					if (!$originalFileSync)
+					{
+						KalturaLog::debug('failed to get original file sync for '.$fileSync->getId());
+						continue;
+					}
+					
+					$fileSync->setOriginalId($originalFileSync->getId());
+				}
+				
+				// add to the result set
 				$lockedFileSyncs[] = $fileSync;
 				$lockedFileSyncsSize += $fileSync->getFileSize();
 				


### PR DESCRIPTION
the initial original file sync is deleted and replaced by a link that turns into file, so the originalId be recalculated according to the file sync key