### PR TITLE
fromObject: validate param is object

### DIFF
--- a/api_v3/lib/types/KalturaObject.php
+++ b/api_v3/lib/types/KalturaObject.php
@@ -352,6 +352,12 @@ abstract class KalturaObject implements IApiObject
 	
 	final public function fromObject($srcObj, KalturaDetachedResponseProfile $responseProfile = null)
 	{
+		if (!is_object($srcObj))
+		{
+			KalturaLog::err("expected an object, got " . print_r($srcObj, true));
+			return;
+		}
+		
 		$thisClass = get_class($this);
 		$srcObjClass = get_class($srcObj);
 		$fromObjectClass = "Map_{$thisClass}_{$srcObjClass}";


### PR DESCRIPTION
prevent a crash in entry investigation page due to the deprecation of file sync jobs