### PR TITLE
Fix $obj to $object in flavorAsset, this causes getInstance to fail f…

### DIFF
--- a/api_v3/lib/types/conversionProfile/KalturaAsset.php
+++ b/api_v3/lib/types/conversionProfile/KalturaAsset.php
@@ -167,15 +167,15 @@ class KalturaAsset extends KalturaObject implements IRelatedFilterable, IApiObje
 	         default:
 	             if(in_array($type, KalturaPluginManager::getExtendedTypes(assetParamsPeer::OM_CLASS, assetType::THUMBNAIL)))
 	             {
-	                 $obj = KalturaPluginManager::loadObject('KalturaThumbAsset', $type);
+	                 $object = KalturaPluginManager::loadObject('KalturaThumbAsset', $type);
 	             }
 	             elseif(in_array($type, KalturaPluginManager::getExtendedTypes(assetParamsPeer::OM_CLASS, assetType::FLAVOR)))
 	             {
-	                 $obj = KalturaPluginManager::loadObject('KalturaFlavorAsset', $type);
+	                 $object = KalturaPluginManager::loadObject('KalturaFlavorAsset', $type);
 	             }
 	             else
 	             {
-	                 $obj = KalturaPluginManager::loadObject('KalturaAsset', $type);
+	                 $object = KalturaPluginManager::loadObject('KalturaAsset', $type);
 	             }
 	     }
 	     


### PR DESCRIPTION
…or specific flavor asset types such as widevine (but not only) and in turn causes get/list of widevine flavors to not return them

PLAT-3458