### PR TITLE
While importing the data to the new partner if the original file didn…

### DIFF
--- a/plugins/content_distribution/providers/cross_kaltura/lib/batch/CrossKalturaDistributionEngine.php
+++ b/plugins/content_distribution/providers/cross_kaltura/lib/batch/CrossKalturaDistributionEngine.php
@@ -432,7 +432,9 @@ class CrossKalturaDistributionEngine extends DistributionEngine implements
 	    {
 	        // get local resource
 	        $contentResource = new KalturaUrlResource();
-	        $contentResource->url = $assetService->getUrl($assetId);
+		    $options = new KalturaFlavorAssetUrlOptions();
+		    $options->fileName = $assetId;
+		    $contentResource->url = $assetService->getUrl($assetId, null, false, $options);
 	    }
 	    return $contentResource;
 	}


### PR DESCRIPTION
…'t have a proper extension there is a problem since we add "(Source)" to the file-name by default which causes a problem to convert the file, instead I made the filename identical to the flavor_asset ID. Except for the convert job there is no meaning to the file name and it can be arbitrary.

SUP-5448 #time 2 hours