### PR TITLE
When getting root objects of Metadata we need to get all related pare…

### DIFF
--- a/plugins/metadata/lib/model/MetadataPeer.php
+++ b/plugins/metadata/lib/model/MetadataPeer.php
@@ -159,19 +159,15 @@ class MetadataPeer extends BaseMetadataPeer implements IRelatedObjectPeer
 	{
 		$parentObject = kMetadataManager::getObjectFromPeer($object);
 		$roots = array();
-		if($parentObject)
+		if($parentObject && $parentObject instanceof IBaseObject) 
 		{
-			if($parentObject instanceof IBaseObject)
+			$parentPeer = $parentObject->getPeer();
+			if($parentPeer instanceof IRelatedObjectPeer)
 			{
-				$parentPeer = $parentObject->getPeer();
-				if($parentPeer instanceof IRelatedObjectPeer)
-				{
-					$roots = $parentPeer->getRootObjects($parentObject);
-				}
+				$roots = $parentPeer->getRootObjects($parentObject);
 			}
 			$roots[] = $parentObject;
 		}
-
 		return $roots;
 	}
 


### PR DESCRIPTION
…nt objects of that object except those that don't implement IBaseObject, right now we might bring a few that are not (such as partner objects), this was fixed.