### PR TITLE
kwidget should return caching header for CDN

### DIFF
--- a/alpha/web/index.php
+++ b/alpha/web/index.php
@@ -129,7 +129,7 @@ function checkCache()
 				$max_age = 60 * 10;
 				header("X-Kaltura:cached-dispatcher");
 				header("Content-Type: application/x-shockwave-flash");
-				sendCachingHeaders($max_age, true, time());
+				sendCachingHeaders($max_age, false, time());
 				header("Content-Length: ".strlen($cachedResponse));
 				echo $cachedResponse;
 				die;


### PR DESCRIPTION
I found that CDN has no cache for /index.php/kwidget/wid/_101/uiconf_id/... because alpha/web/index.php returns 'Cache-Control: private'.

I propose to replace private to public for CDN caching.