### PR TITLE
a hostname can consist of max of 255 chars.

### DIFF
--- a/deployment/base/sql/01.kaltura_ce_tables.sql
+++ b/deployment/base/sql/01.kaltura_ce_tables.sql
@@ -1807,7 +1807,7 @@ CREATE TABLE IF NOT EXISTS `scheduler` (
   `updated_at` datetime DEFAULT NULL,
   `updated_by` varchar(20) DEFAULT NULL,
   `configured_id` int(11) NOT NULL,
-  `name` varchar(20) DEFAULT '',
+  `name` varchar(255) DEFAULT '',
   `description` varchar(20) DEFAULT '',
   `statuses` varchar(255) NOT NULL,
   `last_status` datetime NOT NULL,

--- a/deployment/base/sql/01.kaltura_ce_tables.sql
+++ b/deployment/base/sql/01.kaltura_ce_tables.sql
@@ -2043,7 +2043,7 @@ CREATE TABLE IF NOT EXISTS `track_entry` (
   `context` varchar(511) DEFAULT NULL,
   `partner_id` int(11) DEFAULT NULL,
   `entry_id` varchar(20) DEFAULT NULL,
-  `host_name` varchar(20) DEFAULT NULL,
+  `host_name` varchar(255) DEFAULT NULL,
   `uid` varchar(63) DEFAULT NULL,
   `track_event_status_id` smallint(6) DEFAULT NULL,
   `changed_properties` varchar(1023) DEFAULT NULL,


### PR DESCRIPTION
Hostnames can be as long as 255 bytes (though most UNIX systems may limit them to 64:
see:
$ getconf HOST_NAME_MAX
Hostnames used in DNS can be as long as 253 bytes as a fully qualified
domain name (FQDN=host.example.com), in which case:
    The first DNS label (removing . and anything after it from the hostname) can only be up to 63 bytes
    The 253 byte limit applies to the entire FQDN, even if only the
first label is used for the Unix hostname

In short - we should enlarge to 255. 20 is hardly enough.