### PR TITLE
kettle.sh is no longer placed under $BASE_DIR/bin/pentaho/kitchen.sh,

### DIFF
--- a/configurations/cron/dwh.template
+++ b/configurations/cron/dwh.template
@@ -1,5 +1,5 @@
-00 * * * * kaltura @DWH_DIR@/etlsource/execute/etl_hourly.sh -p @DWH_DIR@
-00 * * * * kaltura @DWH_DIR@/etlsource/execute/etl_update_dims.sh -p @DWH_DIR@
-59 0,4,8,12,16,20 * * * kaltura @DWH_DIR@/etlsource/execute/etl_daily.sh -p @DWH_DIR@
-30 12 * * * kaltura @DWH_DIR@/etlsource/execute/etl_perform_retention_policy.sh -p @DWH_DIR@
+00 * * * * kaltura @DWH_DIR@/etlsource/execute/etl_hourly.sh -p @DWH_DIR@ -k @KETTLE_SH@
+00 * * * * kaltura @DWH_DIR@/etlsource/execute/etl_update_dims.sh -p @DWH_DIR@ -k @KETTLE_SH@
+59 0,4,8,12,16,20 * * * kaltura @DWH_DIR@/etlsource/execute/etl_daily.sh -p @DWH_DIR@ -k @KETTLE_SH@
+30 12 * * * kaltura @DWH_DIR@/etlsource/execute/etl_perform_retention_policy.sh -p @DWH_DIR@ -k @KETTLE_SH@
 0 10 * * * kaltura @APP_DIR@/alpha/scripts/dwh/dwh_plays_views_sync.sh >> @LOG_DIR@/cron.log


### PR DESCRIPTION
this adds a token for its location.