### PR TITLE
SUP-4363

### DIFF
--- a/plugins/content/caption/base/services/CaptionAssetService.php
+++ b/plugins/content/caption/base/services/CaptionAssetService.php
@@ -400,7 +400,7 @@ class CaptionAssetService extends KalturaAssetService
 		$securyEntryHelper->validateForDownload();
 		
 		$captionAsset = null;
-		if(is_null($captionParamId))
+		if(!$captionParamId)
 		{
 			$captionAssets = assetPeer::retrieveByEntryId($entryId, array(CaptionPlugin::getAssetTypeCoreValue(CaptionAssetType::CAPTION)));
 			foreach($captionAssets as $checkCaptionAsset)


### PR DESCRIPTION
SUP-4363
Chnage serveByEntryIdAction to accept zero as argument
 which will lead to the same results as null
 since the 0 asset id is always the source