### PR TITLE
Don't add isQuiz to dynamic attributes so it won't be indexed when not needed

### DIFF
--- a/plugins/cue_points/quiz/QuizPlugin.php
+++ b/plugins/cue_points/quiz/QuizPlugin.php
@@ -271,12 +271,11 @@ class QuizPlugin extends KalturaPlugin implements IKalturaCuePoint, IKalturaServ
 	public static function getDynamicAttributes(IIndexable $object)
 	{
 		if ( $object instanceof entry ) {
-			$isQuiz = 0;
 			if ( !is_null($object->getFromCustomData(self::QUIZ_DATA)) )
-				$isQuiz = 1;
-
-			$dynamicAttribute = array(self::getDynamicAttributeName() => $isQuiz);
-			return $dynamicAttribute;
+			{
+				$dynamicAttribute = array(self::getDynamicAttributeName() => 1);
+				return $dynamicAttribute;
+			}
 		}
 
 		return array();

--- a/plugins/cue_points/quiz/QuizPlugin.php
+++ b/plugins/cue_points/quiz/QuizPlugin.php
@@ -273,8 +273,7 @@ class QuizPlugin extends KalturaPlugin implements IKalturaCuePoint, IKalturaServ
 		if ( $object instanceof entry ) {
 			if ( !is_null($object->getFromCustomData(self::QUIZ_DATA)) )
 			{
-				$dynamicAttribute = array(self::getDynamicAttributeName() => 1);
-				return $dynamicAttribute;
+				return array(self::getDynamicAttributeName() => 1);
 			}
 		}
 


### PR DESCRIPTION
As per @etameran 's request this parameter will be added only when the quiz is added.
When using the advanced filter KalturaQuizAdvancedFilter it will check weather dynamic_attributes.quiz_isQuiz=0 and when that parameter is missing that is true so the functionality stays the same.