### PR TITLE
fixes https://github.com/kaltura/platform-install-packages/issues/436.

### DIFF
--- a/configurations/apache/kaltura.ssl.conf.template
+++ b/configurations/apache/kaltura.ssl.conf.template
@@ -8,12 +8,23 @@ SSLSessionCache         shmcb:/var/cache/mod_ssl/scache(512000)
 SSLSessionCacheTimeout  300
 SSLRandomSeed startup file:/dev/urandom  256
 SSLRandomSeed connect builtin
-SSLMutex default
+<IfVersion < 2.4>
+        SSLMutex default
+</IfVersion>
+<IfVersion >= 2.4>
+        Mutex sysvsem default
+</IfVersion>
 SSLCryptoDevice builtin
 
 SSLCertificateFile @SSL_CERTIFICATE_FILE@
 SSLCertificateKeyFile @SSL_CERTIFICATE_KEY_FILE@
-SSLCertificateChainFile @SSL_CERTIFICATE_CHAIN_FILE@
+
+<IfVersion < 2.4>
+    SSLCertificateChainFile @SSL_CERTIFICATE_CHAIN_FILE@
+</IfVersion>
+<IfVersion >= 2.4>
+    SSLCertificateFile @SSL_CERTIFICATE_CHAIN_FILE@
+</IfVersion>
 <VirtualHost @KALTURA_FULL_VIRTUAL_HOST_NAME@>
 	SSLEngine on
 	SSLProtocol all -SSLv2


### PR DESCRIPTION
Directives AcceptMutex, LockFile, RewriteLock, SSLMutex,
SSLStaplingMutex, and WatchdogMutexPath have been replaced with a single
Mutex directive. You will need to evaluate any use of these removed
directives in your 2.2 configuration to determine if they can just be
deleted or will need to be replaced using Mutex.
http://httpd.apache.org/docs/current/mod/core.html#mutex