### PR TITLE
Add handling of arrayNode of type item(array) in DoMultiRequest

### DIFF
--- a/generator/sources/csharp/KalturaClient/KalturaClientBase.cs
+++ b/generator/sources/csharp/KalturaClient/KalturaClientBase.cs
@@ -264,28 +264,35 @@ namespace Kaltura
             XmlElement multiRequestResult = DoQueue();
 
             KalturaMultiResponse multiResponse = new KalturaMultiResponse();
-			if (multiRequestResult == null)
-			{
-				return multiResponse;
-			}
-            int i = 0;
-            foreach (XmlElement arrayNode in multiRequestResult.ChildNodes)
+	    if (multiRequestResult == null)
             {
-				XmlElement error = arrayNode["error"];
-				if (error != null && error["code"] != null && error["message"] != null)
-                    multiResponse.Add(new KalturaAPIException(error["code"].InnerText, error["message"].InnerText));
-                else if (arrayNode["objectType"] != null)
-                    multiResponse.Add(KalturaObjectFactory.Create(arrayNode, _MultiRequestReturnType[i]));
-                else
-                    multiResponse.Add(arrayNode.InnerText);
-                i++;
+            	return multiResponse;
             }
+            multiResponse = ParseMultiRequestResult(multiRequestResult);
 
             _MultiRequestReturnType.Clear();
             _MultiRequestReturnType = null;
             return multiResponse;
         }
-
+        
+	private KalturaMultiResponse ParseMultiRequestResult(XmlElement childNode, bool incrementI = true) 
+	{
+            int i = 0;			
+	    KalturaMultiResponse multiResponse = new KalturaMultiResponse();
+	    foreach(XmlElement arrayNode in childNode.ChildNodes) 
+	    {
+		XmlElement error = arrayNode["error"];
+		if (error != null && error["code"] != null && error["message"] != null) multiResponse.Add(new KalturaAPIException(error["code"].InnerText, error["message"].InnerText));
+		else if (arrayNode["objectType"] != null) multiResponse.Add(KalturaObjectFactory.Create(arrayNode, _MultiRequestReturnType[i]));
+		else if (arrayNode["item"] != null) multiResponse.Add(ParseMultiRequestResult(arrayNode, false));
+		else multiResponse.Add(arrayNode.InnerText);
+		if (incrementI) 
+		    i++;
+ 	    }
+	
+	    return multiResponse;
+	}
+        
         public void MapMultiRequestParam(int resultNumber, int requestNumber, string requestParamName)
         {
             this.MapMultiRequestParam(resultNumber, null, requestNumber, requestParamName);


### PR DESCRIPTION
SUP-2038

There was no handling of arrayNode of type item(array), as opposed to the PHP version of the client.
For example, the result of PlaylistService.Execute returns a list of items so the arrayNode["objectType"] is null and we get to the 'else' and return the result as string.