### PR TITLE
currently, one gets: 'Exception' with message 'Pending plugin name [integration] is not available, plugin [VoicebasePlugin] could not be loaded.'

### DIFF
--- a/configurations/plugins.template.ini
+++ b/configurations/plugins.template.ini
@@ -105,4 +105,5 @@ ScheduledTaskMetadata
 ScheduledTaskEventNotification
 ScheduledTaskContentDistribution
 FeedDropFolder
+integration
 Voicebase

--- a/configurations/plugins.template.ini
+++ b/configurations/plugins.template.ini
@@ -105,5 +105,5 @@ ScheduledTaskMetadata
 ScheduledTaskEventNotification
 ScheduledTaskContentDistribution
 FeedDropFolder
-integration
+Integration
 Voicebase


### PR DESCRIPTION
2015-08-20 05:45:38 [KalturaPluginManager::isValid] ERR: exception
'Exception' with message 'Pending plugin name [integration] is not
available, plugin [VoicebasePlugin] could not be loaded.' in
/opt/kaltura/app/infra/log/KalturaLog.ph

when trying to generate clientlibs.