### PR TITLE
redo https://github.com/kaltura/server/pull/3057 

### DIFF
--- a/configurations/plugins.template.ini
+++ b/configurations/plugins.template.ini
@@ -105,4 +105,5 @@ ScheduledTaskMetadata
 ScheduledTaskEventNotification
 ScheduledTaskContentDistribution
 FeedDropFolder
+Integration
 Voicebase


### PR DESCRIPTION
was overridden by https://github.com/kaltura/server/pull/3062.