### PR TITLE
PHP7 required modifications

### DIFF
--- a/alpha/apps/kaltura/lib/cache/myCache.class.php
+++ b/alpha/apps/kaltura/lib/cache/myCache.class.php
@@ -20,7 +20,7 @@ class myCache
 
 	// if the cache will be used many times, a default expiry can be set to avoid setting evey time in the put method
 	// this is good when most objects have the same expiry time
-	public function myCache ( $namespace , $expiry = NULL )
+	public function __construct ( $namespace , $expiry = NULL )
 	{
 		$this->m_namespace = $namespace;
 		$this->m_expiry = $expiry ? $expiry : self::DEFAULT_EXPIRY_IN_SECONDS;

--- a/alpha/apps/kaltura/lib/cache/myObjectCache.class.php
+++ b/alpha/apps/kaltura/lib/cache/myObjectCache.class.php
@@ -207,7 +207,7 @@ class memoryCache
 {
 	private $m_expiry; // in seconds
 	private static $s_map = array();
-	function memoryCache ( $expiry = null )
+	function __construct ( $expiry = null )
 	{
 		$this->m_expiry = $expiry; 
 	}

--- a/alpha/apps/kaltura/lib/config/kConfigTable.class.php
+++ b/alpha/apps/kaltura/lib/config/kConfigTable.class.php
@@ -88,7 +88,7 @@ class kConfigTable
 		return $ct;
 	}
 	
-	protected function kConfigTable ( $file_name , $ignore_non_existing_columns = false )
+	protected function __construct ( $file_name , $ignore_non_existing_columns = false )
 	{
 		$this->id = $file_name;
 		

--- a/alpha/apps/kaltura/lib/conversion/kConversionClientBase.class.php
+++ b/alpha/apps/kaltura/lib/conversion/kConversionClientBase.class.php
@@ -25,7 +25,7 @@ class kConversionClientBase extends myBatchBase
 	protected $conv_cmd;
 
 
-	public function kConversionClientBase ( $script_name ,  $in_path , $server_cmd_path , $server_res_path , $commercial_server_cmd_path = null , $mode = 3 )
+	public function __construct ( $script_name ,  $in_path , $server_cmd_path , $server_res_path , $commercial_server_cmd_path = null , $mode = 3 )
 	{
 		$this->script_name = $script_name;
 		if ( $script_name )	$this->register( $script_name , $in_path , $server_res_path , $mode );

--- a/alpha/apps/kaltura/lib/filter/myHealthCheckAndSecurityFilter.class.php
+++ b/alpha/apps/kaltura/lib/filter/myHealthCheckAndSecurityFilter.class.php
@@ -309,7 +309,7 @@ class mySecurityRule
 	
 	private $m_rule_name = null;
 	
-	function mySecurityRule ( $rule_name )
+	function __construct ( $rule_name )
 	{
 		$this->m_rule_name = $rule_name;
 		$rule = sfConfig::get ( $rule_name );
@@ -353,7 +353,7 @@ class mySecurityRule
 
 class mySecurityError
 {
-	function mySecurityError ( $error )
+	function __construct ( $error )
 	{
 		echo "<br><strong>$error</strong><br>";
 	}

--- a/alpha/apps/kaltura/lib/media/myFlvStreamer.class.php
+++ b/alpha/apps/kaltura/lib/media/myFlvStreamer.class.php
@@ -17,7 +17,7 @@ class myFlvStreamer
 	
 	private $metadata;
 
-	public function myFlvStreamer ( $filePath, $timeline, $streamNum, $addPadding = false)
+	public function __construct ( $filePath, $timeline, $streamNum, $addPadding = false)
 	{
 		$this->addPadding = $addPadding;
 		$contentRoot = myContentStorage::getFSContentRootPath();

--- a/alpha/apps/kaltura/lib/model/PartnerPackages.class.php
+++ b/alpha/apps/kaltura/lib/model/PartnerPackages.class.php
@@ -36,7 +36,7 @@ class PartnerPackages
 	private $packagesClassOfService = null;
 	private $packagesVertical = null;
 	
-	public function PartnerPackages ()
+	public function __construct ()
 	{
 		$package_config = simplexml_load_string(file_get_contents(dirname(__FILE__).'/../../config/partnerPackages.xml'));
 		$package_nodes = $package_config->xpath('/packages/package');

--- a/alpha/apps/kaltura/lib/model/genericObjectWrapper.class.php
+++ b/alpha/apps/kaltura/lib/model/genericObjectWrapper.class.php
@@ -14,7 +14,7 @@ class genericObjectWrapper  implements Iterator
 	 * ignore null objects while extracting nested objects - if some object along the line is null, extracting of it's elements will return 
 	 * 	empty nullWrappers which will return empty strings
 	 */
-	public function genericObjectWrapper ( $object , $recursive_wrapping = false , $ignore_null = false  )
+	public function __construct ( $object , $recursive_wrapping = false , $ignore_null = false  )
 	{
 		$this->m_obj = $object;
 		$this->m_is_array = is_array( $object );

--- a/alpha/apps/kaltura/lib/model/kshowStub.class.php
+++ b/alpha/apps/kaltura/lib/model/kshowStub.class.php
@@ -9,7 +9,7 @@
 class kshowStub extends myBaseObject
 {
 
-	public function kshowStub ( kshow $kshow )
+	public function __construct ( kshow $kshow )
 	{
 		$this->init();
 		$this->fillObjectFromObject( $kshow , 

--- a/alpha/apps/kaltura/lib/myConfigWrapper.class.php
+++ b/alpha/apps/kaltura/lib/myConfigWrapper.class.php
@@ -7,7 +7,7 @@ class myConfigWrapper
 {
 	private $m_path_prefix = "";
 	
-	public function myConfigWrapper ( $path_prefix )
+	public function __construct ( $path_prefix )
 	{
 		$this->m_path_prefix = $path_prefix;
 	}

--- a/alpha/apps/kaltura/lib/myCustomData.class.php
+++ b/alpha/apps/kaltura/lib/myCustomData.class.php
@@ -15,7 +15,7 @@ class myCustomData
 	/**
 	 * @param string $str
 	 */
-	private function  myCustomData ( $str )
+	private function  __construct ( $str )
 	{
 		if ( empty ( $str ) )
 			$this->data = array();

--- a/alpha/apps/kaltura/lib/myFileIndicator.class.php
+++ b/alpha/apps/kaltura/lib/myFileIndicator.class.php
@@ -5,7 +5,7 @@ class myFileIndicator
 	private $pattern;
 	private static $s_indicator_path = null;// myContentStorage::getFSContentRootPath() . "../indicators/";
 	
-	public function myFileIndicator ( $file_name )
+	public function __construct ( $file_name )
 	{
 		if ( ! self::$s_indicator_path  )
 		{

--- a/alpha/apps/kaltura/lib/myMultiRequest.class.php
+++ b/alpha/apps/kaltura/lib/myMultiRequest.class.php
@@ -47,7 +47,7 @@ class myMultiRequest extends defPartnerservices2Action
 	 * @param array $original_request_params
 	 * @return myMultipleRequest
 	 */
-	public function myMultiRequest ( $original_request_params ,
+	public function __construct ( $original_request_params ,
 									$container_action = null ,
 									$input_type = self::REQUEST_TYPE_HTTP_REQUEST ,
 									$stop_on_error = self::STOP_ON_FIRST_ERROR )

--- a/alpha/apps/kaltura/lib/myNotificationMgr.class.php
+++ b/alpha/apps/kaltura/lib/myNotificationMgr.class.php
@@ -470,7 +470,7 @@ class myNotificationsConfig
 	}
 
 	// the separator can be either ',' or ';'
-	private function myNotificationsConfig ( $config_str )
+	private function __construct ( $config_str )
 	{
 		//$arr = explode ( "," , trim($config_str ));
 		$arr = preg_split ( "/[,;]/" , trim($config_str ) );

--- a/alpha/apps/kaltura/lib/myServiceConfig.class.php
+++ b/alpha/apps/kaltura/lib/myServiceConfig.class.php
@@ -99,7 +99,7 @@ class myServiceConfig
 	
 
 	
-	public function myServiceConfig ( $file_name , $service_name = null, $useDefualt = true )
+	public function __construct ( $file_name , $service_name = null, $useDefualt = true )
 	{
 		$path = $this->getPath();
 		KalturaLog::debug("Path [$path] File [$file_name] Service [$service_name]");

--- a/alpha/apps/kaltura/lib/mySmartPager.class.php
+++ b/alpha/apps/kaltura/lib/mySmartPager.class.php
@@ -40,7 +40,7 @@ class mySmartPager
 	private static $s_pager_count_cache;
 	private $m_count_came_from_cache = false;
 	
-	public function mySmartPager ( /*sfAction*/ $action , $criteria_class , $default_page_size , $prefix = NULL )
+	public function __construct ( /*sfAction*/ $action , $criteria_class , $default_page_size , $prefix = NULL )
 	{
 		self::initCache();
 		

--- a/alpha/apps/kaltura/lib/webservices/kalturaRssRenderer.class.php
+++ b/alpha/apps/kaltura/lib/webservices/kalturaRssRenderer.class.php
@@ -4,7 +4,7 @@ class kalturaRssRenderer
 	const TYPE_YAHOO = 1;
 	const TYPE_TABOOLA = 2;
 	
-	public function kalturaRssRenderer ( $type = self::TYPE_YAHOO )
+	public function __construct ( $type = self::TYPE_YAHOO )
 	{
 		$this->type = $type;
 	}

--- a/alpha/apps/kaltura/lib/webservices/kalturaWebserviceRenderer.class.php
+++ b/alpha/apps/kaltura/lib/webservices/kalturaWebserviceRenderer.class.php
@@ -23,7 +23,7 @@ class kalturaWebserviceRenderer
 	
 	private $my_cache;
 	private $cached_content = null;
-	public function kalturaWebserviceRenderer ( $container_action )
+	public function __construct ( $container_action )
 	{
 		$this->container_action = $container_action;
 	}

--- a/alpha/lib/model/FileSync.php
+++ b/alpha/lib/model/FileSync.php
@@ -197,7 +197,7 @@ class FileSyncKey
 
 class FileSyncException extends Exception
 {
-	public function FileSyncException ( $type , $sub_type , $allowed_sub_types )
+	public function __construct ( $type , $sub_type , $allowed_sub_types )
 	{
 		parent::__construct( "For FileSync type [$type], unknown sub_type [$sub_type]" );
 	}

--- a/alpha/scripts/create_api_event_log_from_api_v3_log.php
+++ b/alpha/scripts/create_api_event_log_from_api_v3_log.php
@@ -31,7 +31,7 @@ exception
 class kApiEvent 
 {
 	private $arr;
-	public function kApiEvent (  )
+	public function __construct (  )
 	{
 
 	}

--- a/alpha/scripts/create_api_event_log_from_ps2_log.php
+++ b/alpha/scripts/create_api_event_log_from_ps2_log.php
@@ -6,7 +6,7 @@ class kArgs
 {
 	private $prefix = "";
 	private $arr;
-	public function kArgs ( array $arr )
+	public function __construct ( array $arr )
 	{
 		$this->arr = $arr;
 	}
@@ -59,7 +59,7 @@ exception
 class kApiEvent 
 {
 	private $arr;
-	public function kApiEvent (  )
+	public function __construct (  )
 	{
 
 	}

--- a/alpha/scripts/create_event_log_from_apache_access_log.php
+++ b/alpha/scripts/create_event_log_from_apache_access_log.php
@@ -8,7 +8,7 @@ class kEvent
 {
 	private $arr;
 	private $prefix;
-	public function kEvent ( array $arr , $prefix )
+	public function __construct ( array $arr , $prefix )
 	{
 		$this->arr = $arr;
 		$this->prefix = $prefix;

--- a/api_v3/lib/ClientGeneratorFromPhp.php
+++ b/api_v3/lib/ClientGeneratorFromPhp.php
@@ -46,7 +46,7 @@ abstract class ClientGeneratorFromPhp
 		return $this->_includeList;
 	}
 
-	public function ClientGeneratorFromPhp($sourcePath = null)
+	public function __construct($sourcePath = null)
 	{
 		$this->_sourcePath = realpath($sourcePath);
 		
@@ -617,10 +617,12 @@ abstract class ClientGeneratorFromPhp
 					
 				if ($action == "*")
 				{
+	//				KalturaLog::debug("Excluding service [$service]");
 					unset($includeList[$service]);
 				}
 				else
 				{
+	//				KalturaLog::debug("Excluding action [$service.$action]");
 					unset($includeList[$service][$action]);
 				}
 			}

--- a/api_v3/lib/KalturaParamInfo.php
+++ b/api_v3/lib/KalturaParamInfo.php
@@ -7,9 +7,9 @@ class KalturaParamInfo extends KalturaPropertyInfo
 {
 	private $_optional = false;
 	 
-	public function KalturaParamInfo($type, $name, $optional = false)
+	public function __construct ($type, $name, $optional = false)
 	{
-		parent::KalturaPropertyInfo($type, $name);
+		parent::__construct($type, $name);
 		$this->_optional = $optional;
 	}
 

--- a/api_v3/lib/KalturaRequestDeserializer.php
+++ b/api_v3/lib/KalturaRequestDeserializer.php
@@ -13,7 +13,7 @@ class KalturaRequestDeserializer
 
 	const PREFIX = ":";
 
-	public function KalturaRequestDeserializer($params)
+	public function __construct($params)
 	{
 		$this->params = $params;
 		$this->groupParams();

--- a/api_v3/lib/KalturaXmlSerializer.php
+++ b/api_v3/lib/KalturaXmlSerializer.php
@@ -7,7 +7,7 @@ class KalturaXmlSerializer extends KalturaSerializer
 {
 	private $_ignoreNull = false;
 	
-	function KalturaXmlSerializer($ignoreNull)
+	function __construct($ignoreNull)
 	{
 		$this->_ignoreNull = (bool)$ignoreNull;
 	}

--- a/api_v3/lib/exceptions/KalturaAPIException.php
+++ b/api_v3/lib/exceptions/KalturaAPIException.php
@@ -12,7 +12,7 @@ class KalturaAPIException extends Exception
 	 * @param string $errorString A string in the format: "ERR_CODE;PARAMS;MSG_STRING"
 	 * @throws Exception
 	 */
-	function KalturaAPIException( $errorString )
+	function __construct( $errorString )
 	{
 		$errorArgs = func_get_args();
 		array_shift( $errorArgs );

--- a/generator/XmlClientGenerator.php
+++ b/generator/XmlClientGenerator.php
@@ -16,9 +16,9 @@ class XmlClientGenerator extends ClientGeneratorFromPhp
      */
     private $_requiredPlugins = array();
     
-    public function XmlClientGenerator()
+    public function __construct()
     {
-        parent::ClientGeneratorFromPhp();
+        parent::__construct();
         $this->_doc = new DOMDocument();
         $this->_doc->formatOutput = true; 
     }

--- a/infra/general/myGenericContainer.class.php
+++ b/infra/general/myGenericContainer.class.php
@@ -7,7 +7,7 @@ class myGenericContainer
 {
 	private $map = null;
 	
-	public function myGenericContainer ( $map )
+	public function __construct ( $map )
 	{
 		$this->map = $map;
 	}

--- a/infra/storage/kFile.class.php
+++ b/infra/storage/kFile.class.php
@@ -702,7 +702,7 @@ class kFileData
 	public $content = NULL;
 	public $raw_timestamp = NULL;
 	
-	public function kFileData($full_file_path, $add_content = false)
+	public function __construct($full_file_path, $add_content = false)
 	{
 		//debugUtils::st();
 		$this->full_path = realpath($full_file_path);

--- a/vendor/symfony/response/sfWebResponse.class.php
+++ b/vendor/symfony/response/sfWebResponse.class.php
@@ -317,9 +317,18 @@ class sfWebResponse extends sfResponse
    *
    * @return string Normalized header
    */
-  protected function normalizeHeaderName($name)
+
+ protected function normalizeHeaderName($name)
   {
-    return preg_replace('/\-(.)/e', "'-'.strtoupper('\\1')", strtr(ucfirst(strtolower($name)), '_', '-'));
+    // return preg_replace('/\-(.)/e', "'-'.strtoupper('\\1')", strtr(ucfirst(strtolower($name)), '_', '-'));    
+
+    return preg_replace_callback(
+                  '/\-(.)/', 
+                  function ($matches) {
+                    return '-'.strtoupper($matches[1]);
+                  }, 
+                  strtr(ucfirst(strtolower($name)), '_', '-')
+        );
   }
 
   /**


### PR DESCRIPTION
- Methods with the same name as their class will not be constructors in a future version of PHP
- preg_replace():  Support for the /e modifier has been removed. Use preg_replace_callback() instead. 