### PR TITLE
Add 'getUrl' action and update the 'servePdf' action in the following…

### DIFF
--- a/release-notes.md
+++ b/release-notes.md
@@ -1,3 +1,18 @@
+# Kajam-11.1.0 #
+## Add new action 'getUrl' and update the 'servePdf' Action
+ - Issue Type: New Feature
+ - Issue ID: PLAT-3975
+
+#### Configuration ####
+
+- Run the following permission script:
+	php deployment\updates\scripts\add_permissions\2015_09_17_update_quiz_permissions.php
+
+#### Known Issues & Limitations ####
+
+None.
+
+
 # Kajam-11.0.0 #
 
 ## New scheduled task profile ##


### PR DESCRIPTION
… way: 1. Rename action 'serverPdf'==> 'serve' 2. Add a parameter to the actionthat defines the file type that will be generated. Currently only PDF files are supported. In this commit the release notes are updated

Kajam-11.1.0-PLAT-3975-fix # 3 days