### PR TITLE
limit the anonymous cache of non ready entries

### DIFF
--- a/alpha/apps/kaltura/lib/cache/kApiCache.php
+++ b/alpha/apps/kaltura/lib/cache/kApiCache.php
@@ -576,6 +576,9 @@ class kApiCache extends kApiCacheBase
 					$cacheExpiry = time() + $expiryInterval;
 					$this->_cacheRules[self::CACHE_MODE_ANONYMOUS] = array($cacheExpiry, $expiryInterval, $conditions);
 					$this->_cacheRulesDirty = true;
+					
+					// in case of multirequest, limit the cache time of the multirequest according to this request
+					$this->setExpiry($expiryInterval);
 				}
 				
 				if (count(self::$_activeInstances) > 1)
@@ -598,6 +601,9 @@ class kApiCache extends kApiCacheBase
 				if (kConf::hasParam('disable_cache_warmup_client_tags') && !in_array($this->clientTag, kConf::get('disable_cache_warmup_client_tags')))
 					self::warmCache($this->_cacheKey);
 			}
+			
+			// in case of multirequest, limit the cache time of the multirequest according to this request
+			$this->setExpiry($expiryInterval);
 
 			return self::CACHE_MODE_ANONYMOUS;
 		}

--- a/api_v3/services/BaseEntryService.php
+++ b/api_v3/services/BaseEntryService.php
@@ -485,9 +485,18 @@ class BaseEntryService extends KalturaEntryService
 			$pager = new KalturaFilterPager();
 		}
 
+		$result = $filter->getListResponse($pager, $this->getResponseProfile());
+		
+		if ($result->totalCount == 1 && $result->objects[0]->status != KalturaEntryStatus::READY)
+		{
+			// the purpose of this is to solve a case in which a player attempts to play a non-ready entry, 
+			// and the request becomes cached for a long time, preventing playback even after the entry
+			// becomes ready
+			kApiCache::setExpiry(60);
+		}
+		
 		// NOTE: The following is a hack in order to make sure all responses are of type KalturaBaseEntryListResponse.
 		//       The reason is that baseentry::list() is not being extended by derived classes.
-		$result = $filter->getListResponse($pager, $this->getResponseProfile());
 		$response = new KalturaBaseEntryListResponse();
 		$response->objects = $result->objects;
 		$response->totalCount = $result->totalCount;
@@ -700,6 +709,14 @@ class BaseEntryService extends KalturaEntryService
 		$dbEntry = entryPeer::retrieveByPK($entryId);
 		if (!$dbEntry)
 			throw new KalturaAPIException(KalturaErrors::ENTRY_ID_NOT_FOUND, $entryId);
+		
+		if ($dbEntry->getStatus() != entryStatus::READY)
+		{
+			// the purpose of this is to solve a case in which a player attempts to play a non-ready entry,
+			// and the request becomes cached for a long time, preventing playback even after the entry
+			// becomes ready
+			kApiCache::setExpiry(60);
+		}
 		
 		$asset = null;
 		if($contextDataParams->flavorAssetId)


### PR DESCRIPTION
to prevent an attempt to play a non-ready entry from being cached for a
long time, preventing playback even after it becomes ready