### PR TITLE
This is an invalid request and causing an ACTION_DOES_NOT_EXIST error…

### DIFF
--- a/generator/sources/php53/library/Kaltura/Client/Base.php
+++ b/generator/sources/php53/library/Kaltura/Client/Base.php
@@ -205,7 +205,7 @@ class Base
 		else
 		{
 			$call = $this->callsQueue[0];
-			$url .= "/{$call->service}/&action/{$call->action}";
+			$url .= "/{$call->service}/action/{$call->action}";
 			$params = array_merge($params, $call->params);
 			$files = $call->files;
 		}


### PR DESCRIPTION
… on php53. Committer had fixed it on other versions #aae10a64f8d77d2a1a9266e6563e6a05cce3c25e

The CI build is passing but reporting the ACTION_DOES_NOT_EXIST error as well.

https://travis-ci.org/kaltura/KalturaGeneratedAPIClientsPHP53/jobs/89586756