### PR TITLE
Wrapped remote_addr_header_salt val in ' '

### DIFF
--- a/configurations/local.template.ini
+++ b/configurations/local.template.ini
@@ -142,7 +142,7 @@ plays_limit = 100000
 ; end of dwh settings
 
 ;html5 settings
-remote_addr_header_salt = @APP_REMOTE_ADDR_HEADER_SALT@
+remote_addr_header_salt = '@APP_REMOTE_ADDR_HEADER_SALT@'
 remote_addr_header_timeout = 120
 remote_addr_header_server = @WWW_HOST@
 


### PR DESCRIPTION
@jessp01, I've had to fix this on the old version since it fails the ssl installation.