### PR TITLE
check if the method $item,'set'.$key exists before trying to call it

### DIFF
--- a/alpha/scripts/utils/permissions/addPermissionsAndItems.php
+++ b/alpha/scripts/utils/permissions/addPermissionsAndItems.php
@@ -249,6 +249,8 @@ function addParameterPermissionItem($itemCfg)
 			$setterCallback = array ( $item ,"set{$key}");	
 			if (method_exists($item,'set'.$key)){
 			    call_user_func_array( $setterCallback , array ($value ) );
+			}else{
+			    KalturaLog::log("Skipping call to set$key() since there is no such method.");
 			}
 		}
 		$item->save();

--- a/alpha/scripts/utils/permissions/addPermissionsAndItems.php
+++ b/alpha/scripts/utils/permissions/addPermissionsAndItems.php
@@ -250,7 +250,7 @@ function addParameterPermissionItem($itemCfg)
 			if (method_exists($item,'set'.$key)){
 			    call_user_func_array( $setterCallback , array ($value ) );
 			}else{
-			    KalturaLog::log("Skipping call to set$key() since there is no such method.");
+			    KalturaLog::err("Skipping call to set$key() since there is no such method.");
 			}
 		}
 		$item->save();

--- a/alpha/scripts/utils/permissions/addPermissionsAndItems.php
+++ b/alpha/scripts/utils/permissions/addPermissionsAndItems.php
@@ -247,7 +247,9 @@ function addParameterPermissionItem($itemCfg)
 			}
 					
 			$setterCallback = array ( $item ,"set{$key}");	
-			call_user_func_array( $setterCallback , array ($value ) );
+			if (method_exists($item,'set'.$key)){
+			    call_user_func_array( $setterCallback , array ($value ) );
+			}
 		}
 		$item->save();
 		KalturaLog::log('New permission item id ['.$item->getId().'] added for ['.$item->getAction().'->'.$item->getObject().'->'.$item->getParameter().'] partner id ['.$item->getPartnerId().']');


### PR DESCRIPTION
sample data looks like this:         
            [object] => KalturaAdCuePoint
            [parameter] => KalturaAdCuePoint
            [action] => insert
            [partnerId] => 0
            [inherit] => 1
            [param4] =>
            [param5] =>
            [tags] =>
            [permissions] => cuePoint.MANAGE,
-1>PARTNER_-1_GROUP_*_PERMISSION, BASE_USER_SESSION_PERMISSION

There is no setinherit() function, so, check if the method $item,'set'.$key exists before trying to call it.