### PR TITLE
call self::getRootObjects() instead of categoryPeer::getRootObjects()

### DIFF
--- a/alpha/lib/model/categoryEntryPeer.php
+++ b/alpha/lib/model/categoryEntryPeer.php
@@ -372,7 +372,7 @@ class categoryEntryPeer extends BasecategoryEntryPeer implements IRelatedObjectP
 		$category = categoryPeer::retrieveByPK($object->getCategoryId());
 		if($category)
 		{
-			$roots = categoryPeer::getRootObjects($category);
+			$roots = self::getRootObjects($category);
 			$roots[] = $category;
 		}
 		


### PR DESCRIPTION
in PHP7, this causes a fatal.