### PR TITLE
Csharp client chunk upload enhancements

### DIFF
--- a/generator/CSharpClientGenerator.php
+++ b/generator/CSharpClientGenerator.php
@@ -739,7 +739,7 @@ class CSharpClientGenerator extends ClientGeneratorFromXml
 					$dotNetType = "IDictionary<string, ".$paramNode->getAttribute("arrayType").">";
 					break;
 				case "file":
-					$dotNetType = "FileStream";
+					$dotNetType = "Stream";
 					break;
 				case "bigint":
 					$dotNetType = "long";

--- a/generator/sources/csharp/KalturaClient/KalturaFiles.cs
+++ b/generator/sources/csharp/KalturaClient/KalturaFiles.cs
@@ -33,11 +33,11 @@ using System.IO;
 
 namespace Kaltura
 {
-    public class KalturaFiles : SortedList<string, FileStream>
+    public class KalturaFiles : SortedList<string, Stream>
     {
         public void Add(KalturaFiles files)
         {
-            foreach (KeyValuePair<string, FileStream> item in files)
+            foreach (KeyValuePair<string, Stream> item in files)
             {
                 this.Add(item.Key, item.Value);
             }

--- a/generator/sources/csharp/KalturaClient/KalturaParam.cs
+++ b/generator/sources/csharp/KalturaClient/KalturaParam.cs
@@ -38,6 +38,19 @@ namespace Kaltura
         #region Private Fields
 
         private string _Value;
+        private Nullable<bool> _BoolValue = null;
+        private long _LongValue;
+        private int _IntValue;
+        private float _FloatValue;
+
+
+        private string _ParamType;
+        private const string PARAM_TYPE_STRING = "string";
+        private const string PARAM_TYPE_BOOL = "bool";
+        private const string PARAM_TYPE_LONG = "long";
+        private const string PARAM_TYPE_INT = "int";
+        private const string PARAM_TYPE_FLOAT = "float";
+
 
         #endregion
 
@@ -47,13 +60,47 @@ namespace Kaltura
         public KalturaParam(string value)
         {
             _Value = value;
+            _ParamType = PARAM_TYPE_STRING;
+        }
+        public KalturaParam(bool value)
+        {
+            _BoolValue = value;
+            _ParamType = PARAM_TYPE_BOOL;
+        }
+        public KalturaParam(long value)
+        {
+            _LongValue = value;
+            _ParamType = PARAM_TYPE_LONG;
+        }
+        public KalturaParam(int value)
+        {
+            _IntValue = value;
+            _ParamType = PARAM_TYPE_INT;
+        }
+        public KalturaParam(float value)
+        {
+            _FloatValue = value;
+            _ParamType = PARAM_TYPE_FLOAT;
         }
 
         #endregion
 
         public string ToJson()
         {
-            return "\"" + _Value.Replace("\"", "\\\"").Replace("\r", "").Replace("\t", "\\t").Replace("\n", "\\n") + "\"";
+            switch(_ParamType)
+            {
+                case PARAM_TYPE_BOOL:
+                    return _BoolValue.Value ? "true" : "false";
+                case PARAM_TYPE_INT:
+                    return _IntValue.ToString();
+                case PARAM_TYPE_LONG:
+                    return _LongValue.ToString();
+                case PARAM_TYPE_FLOAT:
+                    return String.Format("{0:F20}", _FloatValue);
+                case PARAM_TYPE_STRING:
+                default:
+                    return "\"" + _Value.Replace("\"", "\\\"").Replace("\r", "").Replace("\t", "\\t").Replace("\n", "\\n") + "\"";
+            }
         }
 
         public string ToQueryString()

--- a/generator/sources/csharp/KalturaClient/KalturaParams.cs
+++ b/generator/sources/csharp/KalturaClient/KalturaParams.cs
@@ -133,6 +133,23 @@ namespace Kaltura
             this.Add(key, new KalturaParam(value));
         }
 
+        public void Add(string key, bool value)
+        {
+            this.Add(key, new KalturaParam(value));
+        }
+        public void Add(string key, int value)
+        {
+            this.Add(key, new KalturaParam(value));
+        }
+        public void Add(string key, long value)
+        {
+            this.Add(key, new KalturaParam(value));
+        }
+        public void Add(string key, float value)
+        {
+            this.Add(key, new KalturaParam(value));
+        }
+
         public void AddIfNotNull(string key, string value)
         {
             if (value != null)
@@ -142,14 +159,14 @@ namespace Kaltura
         public void AddIfNotNull(string key, int value)
         {
             if (value != int.MinValue)
-                this.Add(key, value.ToString());
+                this.Add(key, value);
         }
 
 
         public void AddIfNotNull(string key, float value)
         {
             if (value != Single.MinValue)
-                this.Add(key, value.ToString());
+                this.Add(key, value);
         }
 
         public void AddIfNotNull(string key, long value)
@@ -172,7 +189,7 @@ namespace Kaltura
         public void AddIfNotNull(string key, bool? value)
         {
             if (value.HasValue)
-                this.Add(key, (value.Value) ? "true" : "false");
+                this.Add(key, value.Value);
         }
 
         public void AddReplace(string key, string value)

--- a/generator/sources/csharp/KalturaClient/KalturaServiceActionCall.cs
+++ b/generator/sources/csharp/KalturaClient/KalturaServiceActionCall.cs
@@ -79,7 +79,7 @@ namespace Kaltura
         public KalturaFiles GetFilesForMultiRequest(int multiRequestNumber)
         {
             KalturaFiles multiRequestParams = new KalturaFiles();
-            foreach (KeyValuePair<string, FileStream> param in this._Files)
+            foreach (KeyValuePair<string, Stream> param in this._Files)
             {
                 multiRequestParams.Add(multiRequestNumber + ":" + param.Key, param.Value);
             }

--- a/generator/sources/csharp/KalturaClientTester/KalturaClientTester.cs
+++ b/generator/sources/csharp/KalturaClientTester/KalturaClientTester.cs
@@ -29,15 +29,21 @@ using System;
 using System.Collections.Generic;
 using System.Text;
 using System.IO;
+using System.Threading;
 
 namespace Kaltura
 {
     class KalturaClientTester : IKalturaLogger
     {
-		private const int PARTNER_ID = @YOUR_PARTNER_ID@; //enter your partner id
-		private const string ADMIN_SECRET = "@YOUR_ADMIN_SECRET@"; //enter your admin secret
-		private const string SERVICE_URL = "@SERVICE_URL@";
+        private const int PARTNER_ID = @YOUR_PARTNER_ID@; //enter your partner id
+        private const string ADMIN_SECRET = "@YOUR_ADMIN_SECRET@"; //enter your admin secret
+        private const string SERVICE_URL = "@SERVICE_URL@";
 		private const string USER_ID = "testUser";
+
+        private const string UPLOAD_REGULAR = "reg";
+        private const string UPLOAD_CHUNKED = "chunked";
+        private const string UPLOAD_MEMCHUNKED = "memchunked";
+        private const string UPLOAD_THREADED = "thread";
         
         private static string uniqueTag;
 
@@ -51,7 +57,15 @@ namespace Kaltura
             Console.WriteLine("Starting C# Kaltura API Client Library");
             int code = 0;
             uniqueTag = Guid.NewGuid().ToString().Replace("-", "").Substring(0, 20);
-
+            try
+            {
+                SampleThreadedChunkUpload();
+            }
+            catch (KalturaAPIException e0)
+            {
+                Console.WriteLine("failed chunk upload: " + e0.Message);
+            }
+            
             try
             {
                 ResponseProfileExample();
@@ -110,12 +124,123 @@ namespace Kaltura
             if (code == 0)
             {
                 Console.WriteLine("Finished running client library tests");
+                Console.ReadLine();
             }
 
             Environment.Exit(code);
         }
 
-        static KalturaConfiguration GetConfig()
+        // setting chunk size to a small chunk, because demo file is 500k size.
+        // in actual implementation, a chunk size of 10MB is good practice.
+        const int CHUNK_SIZE = 10240;
+        static void SampleThreadedChunkUpload()
+        {
+            KalturaClient client = new KalturaClient(GetConfig());
+            client.KS = client.GenerateSession(ADMIN_SECRET, USER_ID, KalturaSessionType.ADMIN, PARTNER_ID, 86400, "");
+
+            string fname = "DemoVideo.flv";
+            FileStream fileStream = new FileStream(fname, FileMode.Open, FileAccess.Read, FileShare.Read);
+            KalturaUploadToken myToken = new KalturaUploadToken();
+            myToken.FileName = fname;
+            FileInfo f = new FileInfo(fname);
+            myToken.FileSize = f.Length;
+
+            string mediaName = "C# Media Entry Uploaded in chunks using threads";
+
+            KalturaUploadToken uploadToken = client.UploadTokenService.Add(myToken);
+
+            chunkThreaded(client.KS, fileStream, uploadToken.Id);
+            
+            KalturaUploadedFileTokenResource mediaResource = new KalturaUploadedFileTokenResource();
+            mediaResource.Token = uploadToken.Id;
+            KalturaMediaEntry mediaEntry = new KalturaMediaEntry();
+            mediaEntry.Name = mediaName;
+            mediaEntry.MediaType = KalturaMediaType.VIDEO;
+            mediaEntry = client.MediaService.Add(mediaEntry);
+            mediaEntry = client.MediaService.AddContent(mediaEntry.Id, mediaResource);
+        }
+
+        static int maxUploadThreads = 4;
+        static public int workingThreads = 0;
+
+        static void chunkThreaded(string ks, FileStream fileStream, string uploadTokenId)
+        {
+            KalturaClient client = new KalturaClient(GetConfig());
+            client.KS = ks;
+
+            LinkedList<int> ranges = new LinkedList<int>();
+            int chunkSize = CHUNK_SIZE;
+
+            long fileSize = fileStream.Length - (fileStream.Length % chunkSize);
+            int lastPosition = unchecked((int)fileSize);
+            for (int i = chunkSize; i < fileSize; i = i + chunkSize)
+            {
+                LinkedListNode<int> pos = new LinkedListNode<int>(i);
+                ranges.AddFirst(pos);
+            }
+            KalturaUploadThread uploader = new KalturaUploadThread(ks, fileStream, chunkSize, ranges, uploadTokenId);
+
+            try
+            {
+                byte[] chunk = new byte[chunkSize];
+                fileStream.Seek(0, SeekOrigin.Begin);
+                int bytesRead = fileStream.Read(chunk, 0, chunkSize);
+                Stream chunkFile = new MemoryStream(chunk);
+                client.UploadTokenService.Upload(uploadTokenId, chunkFile, false, false);
+                chunkFile.Close();
+            }
+            catch (KalturaAPIException ex)
+            {
+                Console.WriteLine("failed uploading first chunk " + ex.Message);
+                throw ex;
+            }
+
+            int counter = 0;
+            Dictionary<int, Thread> threadList = new Dictionary<int, Thread>();
+            try
+            {
+                while (!ranges.Count.Equals(0))
+                {
+                    // this will open all threads allowed
+                    while (workingThreads < maxUploadThreads && !ranges.Count.Equals(0))
+                    {
+                        int threadID = workingThreads + 1;
+                        if (threadList.ContainsKey(threadID))
+                        {
+                            threadList.Remove(threadID);
+                        }
+                        threadList.Add(threadID, new Thread(new ThreadStart(uploader.upload)));
+                        threadList[threadID].Start();
+                        counter++;
+                        workingThreads += 1;
+                    }
+                }
+
+                while (workingThreads > 0)
+                {
+                    Thread.Sleep(100);
+                }
+
+                // threads have finished at this point. upload last chunk
+
+            }
+            catch (ThreadStateException e)
+            {
+                Console.WriteLine("thread exploded with " + e.Message);
+                throw e;
+            }
+
+            byte[] lastChunk = new byte[chunkSize];
+            long lengthLong = fileStream.Length - lastPosition;
+            int length = unchecked((int)lengthLong);
+            fileStream.Seek(lastPosition, SeekOrigin.Begin);
+            int lastBytesRead = fileStream.Read(lastChunk, 0, length);
+            Stream lastChunkFile = new MemoryStream(lastChunk);
+            client.UploadTokenService.Upload(uploadTokenId, lastChunkFile, true, true, lastPosition);
+            lastChunkFile.Close();
+        }
+
+        public static KalturaConfiguration GetConfig()
         {
             KalturaConfiguration config = new KalturaConfiguration();
             config.ServiceUrl = SERVICE_URL;

--- a/generator/sources/csharp/KalturaClientTester/KalturaClientTester.cs
+++ b/generator/sources/csharp/KalturaClientTester/KalturaClientTester.cs
@@ -38,12 +38,8 @@ namespace Kaltura
         private const int PARTNER_ID = @YOUR_PARTNER_ID@; //enter your partner id
         private const string ADMIN_SECRET = "@YOUR_ADMIN_SECRET@"; //enter your admin secret
         private const string SERVICE_URL = "@SERVICE_URL@";
-		private const string USER_ID = "testUser";
+        private const string USER_ID = "testUser";
 
-        private const string UPLOAD_REGULAR = "reg";
-        private const string UPLOAD_CHUNKED = "chunked";
-        private const string UPLOAD_MEMCHUNKED = "memchunked";
-        private const string UPLOAD_THREADED = "thread";
         
         private static string uniqueTag;
 

--- a/generator/sources/csharp/KalturaClientTester/KalturaUploadThread.cs
+++ b/generator/sources/csharp/KalturaClientTester/KalturaUploadThread.cs
@@ -1,0 +1,70 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using System.IO;
+using System.Threading;
+
+namespace Kaltura
+{
+    class KalturaUploadThread
+    {
+        public string ks;
+        public FileStream file;
+        public string uploadTokenId;
+        public int chunkSize;
+
+
+        /*
+         * position => uploaded
+         */
+        public LinkedList<int> ranges;
+
+        public KalturaUploadThread(string ks, FileStream file, int chunkSize, LinkedList<int> ranges, string uploadTokenId)
+        {
+            this.chunkSize = chunkSize;
+            this.file = file;
+            this.ks = ks;
+            this.ranges = ranges;
+            this.uploadTokenId = uploadTokenId;
+        }
+
+        public void upload()
+        {
+            KalturaClient client = new KalturaClient(KalturaClientTester.GetConfig());
+            client.KS = ks;
+
+            if(ranges.Count.Equals(0))
+            {
+                // no more items - avoid null pointer exception
+                KalturaClientTester.workingThreads--;
+                return;
+            }
+            byte[] chunk = new byte[this.chunkSize];
+            int index = ranges.Last.Value;
+            // mark as uploaded
+            ranges.RemoveLast();
+            // read part of file
+            file.Seek(index, SeekOrigin.Begin);
+            int bytesRead = file.Read(chunk, 0, this.chunkSize);
+            long resumeAt = index;
+
+            try
+            {
+
+                Stream chunkFile = new MemoryStream(chunk);
+                client.UploadTokenService.Upload(uploadTokenId, chunkFile, true, false, resumeAt);
+                chunkFile.Close();                
+            }
+            catch (KalturaAPIException ex)
+            {
+                Console.WriteLine("failed to upload and resume at position "+resumeAt + " message: ["+ex.Message+"] replacing last index "+index);
+                // put chunk start position back in the queue so will be picked by next thread
+                ranges.AddLast(index);
+            }
+            finally
+            {
+                KalturaClientTester.workingThreads--;
+            }
+        }
+    }
+}


### PR DESCRIPTION
Adding support for MemoryStream + example for threaded chunk upload.

Threaded chunk upload requires a small change in the backend service to allow writing a chunk after the current-end-of-file, thus this PR should not be merged before this BE change is implemented and merged.