### PR TITLE
don't redirect error to output on ffprobe command

### DIFF
--- a/infra/media/mediaInfoParser/KAMFMediaInfoParser.php
+++ b/infra/media/mediaInfoParser/KAMFMediaInfoParser.php
@@ -50,7 +50,7 @@ class KAMFMediaInfoParser{
 
     protected function getCommand()
     {
-        return "{$this->ffprobeBin} -i {$this->filePath} -select_streams 2:2 -show_streams -show_programs -v quiet -show_data -show_packets -print_format json 2>&1";
+        return "{$this->ffprobeBin} -i {$this->filePath} -select_streams 2:2 -show_streams -show_programs -v quiet -show_data -show_packets -print_format json";
     }
 
     // parse the output of the command and return an array of string of the form pts;timestamp


### PR DESCRIPTION
it caused a problem on one of the QA servers running old Fedora version