### PR TITLE
support added custom parameters on akamai hds urls

### DIFF
--- a/alpha/lib/model/DeliveryProfile.php
+++ b/alpha/lib/model/DeliveryProfile.php
@@ -384,4 +384,13 @@ abstract class DeliveryProfile extends BaseDeliveryProfile implements IBaseObjec
 		return $deliveryUrl;
 	}
 	
+	public function setExtraParams($v)
+	{
+		$this->putInCustomData("extraParams", $v);
+	}
+	
+	public function getExtraParams()
+	{
+		return $this->getFromCustomData("extraParams");
+	}
 } 

--- a/alpha/lib/model/DeliveryProfileAkamaiHds.php
+++ b/alpha/lib/model/DeliveryProfileAkamaiHds.php
@@ -70,6 +70,11 @@ class DeliveryProfileAkamaiHds extends DeliveryProfileHds {
 			return null;
 		}
 		
+		if ($this->getExtraParams())
+		{
+			$flavor['url'] = kDeliveryUtils::addQueryParameter($flavor['url'], $this->getExtraParams());
+		}	 
+		
 		return $flavor;
 	}
 	

--- a/api_v3/lib/types/delivery/KalturaDeliveryProfile.php
+++ b/api_v3/lib/types/delivery/KalturaDeliveryProfile.php
@@ -128,6 +128,12 @@ class KalturaDeliveryProfile extends KalturaObject implements IFilterable
 	 */
 	public $priority;
 
+	/**
+	 * Extra query string parameters that should be added to the url
+	 * @var string
+	 */
+	public $extraParams;
+	
  	private static $map_between_objects = array
 	(
 			"createdAt",
@@ -148,6 +154,7 @@ class KalturaDeliveryProfile extends KalturaObject implements IFilterable
 			"type",
 			"mediaProtocols",
 			"priority",
+			"extraParams",
 	);
 	
 	public function getMapBetweenObjects ( )


### PR DESCRIPTION
- needed in order to add hdcore=x.x.x when playing without the player Akamai HD plugin
- the field was added on the base class to support using it in additional delivery profiles in the future