### PR TITLE
kSiteCondition shouldn't be cached since the refferer isn't part of t…

### DIFF
--- a/alpha/apps/kaltura/lib/rules/conditions/kSiteCondition.php
+++ b/alpha/apps/kaltura/lib/rules/conditions/kSiteCondition.php
@@ -70,6 +70,6 @@ class kSiteCondition extends kMatchCondition
 	 */
 	public function shouldFieldDisableCache($scope)
 	{
-		return false;
+		return true;
 	}
 }


### PR DESCRIPTION
…he cacheKey so that anyone doing the same request will get the cached result even if they're from another domain.

SUP-5785