### PR TITLE
Use secure random function to generate password reset tokens

### DIFF
--- a/alpha/lib/model/UserLoginData.php
+++ b/alpha/lib/model/UserLoginData.php
@@ -265,7 +265,7 @@ class UserLoginData extends BaseUserLoginData {
 	{
 		$loginDataId = $this->getId();
 		$expiryTime = time() + (kConf::get('user_login_set_password_hash_key_validity')); // now + 24 hours
-		$random = sha1( uniqid() . (time() * rand(0,1)) );
+		$random = sha1( mcrypt_create_iv(32,MCRYPT_DEV_URANDOM) );
 		$hashKey = base64_encode(implode('|', array($loginDataId, $expiryTime, $random)));
 		return $hashKey;
 	}


### PR DESCRIPTION
I've modified this function to use a secure random byte source. mcrypt_create_iv() is used instead of random_bytes() so the change is compatible with PHP < 7.