### PR TITLE
The KalturaConfiguration no longer receives a partnerId in it's const…

### DIFF
--- a/plugins/drop_folder/external_script/SyncDropFolderWatcher.php
+++ b/plugins/drop_folder/external_script/SyncDropFolderWatcher.php
@@ -55,12 +55,13 @@ writeLog($logPrefix, 'file name:'.$fileName);
 writeLog($logPrefix, 'file size:'.$fileSize);
 
 
-$kClientConfig = new KalturaConfiguration(-1);
+$kClientConfig = new KalturaConfiguration();
 $kClientConfig->serviceUrl = $serviceUrl;
 $kClientConfig->curlTimeout = 180;
 $kClientConfig->setLogger(new SyncDropFolderWatcherLogger($logPrefix));
 
 $kClient = new KalturaClient($kClientConfig);
+$kClient->setPartnerId(-1);
 $dropFolderPlugin = KalturaDropFolderClientPlugin::get($kClient);
 
 try 


### PR DESCRIPTION
…ructor. Furthermore it doesn't hold the partner ID in any way, it needs to be set on the client itself.

plat-4814