### PR TITLE
Case insensitive search for Transfer-Encoding HTTP header

### DIFF
--- a/infra/storage/kFile.class.php
+++ b/infra/storage/kFile.class.php
@@ -591,7 +591,7 @@ class kFile
 		$length = strlen($string);
 
 		// we shouldnt return a chunked encoded header as we read the whole response and echo it after curl extracts it
-		if (strpos($string, "Transfer-Encoding: chunked") === FALSE)
+		if (stripos($string, "Transfer-Encoding: chunked") === FALSE)
 		{
 			header($string);
 		}


### PR DESCRIPTION
for example, AWS ELB returns that as 'transfer-encoding' and it causes problem when
requesting embedded player loader.