### PR TITLE
if 5 restarts within 5 cycles then timeout is not good for our

### DIFF
--- a/configurations/monit/monit.d/batch.template.rc
+++ b/configurations/monit/monit.d/batch.template.rc
@@ -3,7 +3,6 @@ check process batch
     start program = "/etc/init.d/kaltura-batch start" with timeout 60 seconds
     stop program = "/etc/init.d/kaltura-batch stop"
 
-    if 5 restarts within 5 cycles then timeout
 
     group kaltura
     depends on batchbin, batch.ini

--- a/configurations/monit/monit.d/httpd.template.rc
+++ b/configurations/monit/monit.d/httpd.template.rc
@@ -4,7 +4,6 @@ check process apache
     stop program = "/sbin/service @APACHE_SERVICE@ stop"
 
     if failed host localhost port @KALTURA_VIRTUAL_HOST_PORT@ protocol @PROTOCOL@ then restart
-    if 5 restarts within 5 cycles then timeout
 
     group kaltura
     depends on httpd.conf, httpd

--- a/configurations/monit/monit.d/mariadb.template.rc
+++ b/configurations/monit/monit.d/mariadb.template.rc
@@ -3,7 +3,6 @@ check process mariadb
     start program = "/sbin/service mariadb start" with timeout 60 seconds
     stop program = "/sbin/service mariadb stop"
 
-    if 5 restarts within 5 cycles then timeout
     if failed host localhost port 3306 protocol mysql then restart
 
     depends on mysqldbin, my.cnf

--- a/configurations/monit/monit.d/memcached.template.rc
+++ b/configurations/monit/monit.d/memcached.template.rc
@@ -3,7 +3,6 @@ check process memcache
     start program = "/sbin/service memcached start" with timeout 60 seconds
     stop program = "/sbin/service memcached stop"
 
-    if 5 restarts within 5 cycles then timeout
     if failed host localhost port 11211 protocol MEMCACHE then restart
 
     depends on memcachedbin, memcachedconf

--- a/configurations/monit/monit.d/mysqld.template.rc
+++ b/configurations/monit/monit.d/mysqld.template.rc
@@ -3,7 +3,6 @@ check process mysql
     start program = "/sbin/service mysqld start" with timeout 60 seconds
     stop program = "/sbin/service mysqld stop"
 
-    if 5 restarts within 5 cycles then timeout
     if failed host localhost port 3306 protocol mysql then restart
     
     depends on mysqldbin, my.cnf

--- a/configurations/monit/monit.d/nginx.template.rc
+++ b/configurations/monit/monit.d/nginx.template.rc
@@ -4,7 +4,6 @@ check process nginx
     stop program = "/sbin/service kaltura-nginx stop"
 
     if failed host localhost port @VOD_PACKAGER_PORT@ protocol http then restart
-    if 5 restarts within 5 cycles then timeout
 
     group kaltura
     depends on nginxbin, nginx.conf

--- a/configurations/monit/monit.d/percona.template.rc
+++ b/configurations/monit/monit.d/percona.template.rc
@@ -3,7 +3,6 @@ check process percona
     start program = "/sbin/service mysql start" with timeout 60 seconds
     stop program = "/sbin/service mysql stop"
 
-    if 5 restarts within 5 cycles then timeout
     if failed host localhost port 3306 protocol mysql then restart
     
     depends on mysqldbin, my.cnf

--- a/configurations/monit/monit.d/sphinx.populate.template.rc
+++ b/configurations/monit/monit.d/sphinx.populate.template.rc
@@ -3,7 +3,6 @@ check process sphinx-populate
     start program = "/etc/init.d/kaltura-populate start" with timeout 60 seconds
     stop program = "/etc/init.d/kaltura-populate stop"
     
-    if 5 restarts within 5 cycles then timeout
 
     group kaltura
     depends on populate.conf, populate_script

--- a/configurations/monit/monit.d/sphinx.template.rc
+++ b/configurations/monit/monit.d/sphinx.template.rc
@@ -3,7 +3,6 @@ check process sphinx
     start program = "/etc/init.d/kaltura-sphinx start" with timeout 60 seconds
     stop program = "/etc/init.d/kaltura-sphinx stop"
     
-    if 5 restarts within 5 cycles then timeout
     if failed host localhost port 9312 protocol mysql then restart
         
     group kaltura

--- a/configurations/monit/monit.d/wowza.template.rc
+++ b/configurations/monit/monit.d/wowza.template.rc
@@ -2,7 +2,6 @@ check process wowza with pidfile /var/run/WowzaStreamingEngine.pid
     start program = "/sbin/service WowzaStreamingEngine start" with timeout 60 seconds
     stop program = "/sbin/service WowzaStreamingEngine stop" 
     
-    if 5 restarts within 5 cycles then timeout
     if failed port 1935 protocol http then restart
         
     depends on wowza.conf, wowzabin


### PR DESCRIPTION
purposes.. the installation itself restarts these daemons quite a few
times for valid reasons.