### PR TITLE
set version for first recorded asset of entry

### DIFF
--- a/api_v3/lib/KalturaLiveEntryService.php
+++ b/api_v3/lib/KalturaLiveEntryService.php
@@ -173,6 +173,7 @@ class KalturaLiveEntryService extends KalturaEntryService
 		$recordedAsset->setStatus(asset::FLAVOR_ASSET_STATUS_QUEUED);
 		$recordedAsset->setFlavorParamsId($flavorParams->getId());
 		$recordedAsset->setFromAssetParams($flavorParams);
+		$recordedAsset->setVersion(0);
 		if ( $dbAsset->hasTag(assetParams::TAG_RECORDING_ANCHOR) )
 		{
 			$recordedAsset->addTags(array(assetParams::TAG_RECORDING_ANCHOR));

--- a/api_v3/lib/KalturaLiveEntryService.php
+++ b/api_v3/lib/KalturaLiveEntryService.php
@@ -173,7 +173,7 @@ class KalturaLiveEntryService extends KalturaEntryService
 		$recordedAsset->setStatus(asset::FLAVOR_ASSET_STATUS_QUEUED);
 		$recordedAsset->setFlavorParamsId($flavorParams->getId());
 		$recordedAsset->setFromAssetParams($flavorParams);
-		$recordedAsset->setVersion(0);
+		$recordedAsset->incrementVersion();
 		if ( $dbAsset->hasTag(assetParams::TAG_RECORDING_ANCHOR) )
 		{
 			$recordedAsset->addTags(array(assetParams::TAG_RECORDING_ANCHOR));


### PR DESCRIPTION
so we will be able to get it correctly later on (DC sync issue)