### PR TITLE
To be honest, I'm not sure why we even care what the file ext is... 

### DIFF
--- a/alpha/apps/kaltura/lib/myInsertEntryHelper.class.php
+++ b/alpha/apps/kaltura/lib/myInsertEntryHelper.class.php
@@ -191,7 +191,9 @@ class myInsertEntryHelper
 			// if the url ends with .ext, we'll extract it this way
 			$urlext = strrchr($entry_url, '.');
 			// TODO: fix this patch
-			if( strlen( $urlext ) > 4 ) $urlext = '.jpg'; // if we got something wierd, assume we're downloading a jpg
+			if (!in_array($urlext, kConf::get("video_file_ext")) && !in_array($urlext, kConf::get("image_file_ext")) && !in_array($urlext, kConf::get("audio_file_ext"))){
+			    $urlext = '.jpg';
+			}
 			$entry_fileName = $entry_data_prefix.$urlext;
 			
 			KalturaLog::debug("handleEntry: media_type: $media_type");


### PR DESCRIPTION
but this way, at least things like:
https://github.com/kaltura/server/blob/Kajam-11.9.0/configurations/base.ini#L263
https://github.com/kaltura/server/blob/Kajam-11.9.0/configurations/base.ini#L268
https://github.com/kaltura/server/blob/Kajam-11.9.0/configurations/base.ini#L285
https://github.com/kaltura/server/blob/Kajam-11.9.0/configurations/base.ini#L244

will not suddenly become jpg.