### PR TITLE
fall back to the current version of the thumbnail

### DIFF
--- a/alpha/apps/kaltura/lib/myEntryUtils.class.php
+++ b/alpha/apps/kaltura/lib/myEntryUtils.class.php
@@ -865,6 +865,11 @@ class myEntryUtils
 		$sub_type = $entry->getMediaType() == entry::ENTRY_MEDIA_TYPE_IMAGE ? entry::FILE_SYNC_ENTRY_SUB_TYPE_DATA : entry::FILE_SYNC_ENTRY_SUB_TYPE_THUMB;
 		$entry_image_key = $entry->getSyncKey($sub_type, $version);
 		$entry_image_path = kFileSyncUtils::getReadyLocalFilePathForKey($entry_image_key);
+		if (!$entry_image_path && $version == 100000)
+		{
+			$entry_image_key = $entry->getSyncKey($sub_type);
+			$entry_image_path = kFileSyncUtils::getReadyLocalFilePathForKey($entry_image_key);
+		}
 		
 		return $entry_image_path;
 	} 


### PR DESCRIPTION
if the requested version is 100000 and it's not found.
this is in order to support clients who blindly create thumbnail urls with /version/100000