### PR TITLE
Better checking of unlink return status

### DIFF
--- a/batch/batches/DeleteFile/KAsyncDeleteFile.class.php
+++ b/batch/batches/DeleteFile/KAsyncDeleteFile.class.php
@@ -24,7 +24,7 @@ class KAsyncDeleteFile extends KJobHandlerWorker
 		/* @var $jobData KalturaDeleteFileJobData */
 		$result = unlink($jobData->localFileSyncPath);
 		
-		if (!$result)
+		if (!$result && file_exists($jobData->localFileSyncPath))
 			return $this->closeJob($job, KalturaBatchJobErrorTypes::RUNTIME, null, "Failed to delete file from disk", KalturaBatchJobStatus::FAILED);
 		
 		return $this->closeJob($job, null, null, 'File deleted successfully', KalturaBatchJobStatus::FINISHED);


### PR DESCRIPTION
Don't fail the delete file job, if the file to delete doesn't exist or it has been already deleted.
My point is - the delete file job is to make sure the file is gone - and `unlink` fails if file to delete doesn't exist.