### PR TITLE
input validation when add a user

### DIFF
--- a/api_v3/services/UserService.php
+++ b/api_v3/services/UserService.php
@@ -40,7 +40,6 @@ class UserService extends KalturaBaseUserService
 		}
 		$user->partnerId = $this->getPartnerId();
 
-
 		$lockKey = "user_add_" . $this->getPartnerId() . $user->id;
 		return kLock::runLocked($lockKey, array($this, 'adduserImpl'), array($user));
 	}
@@ -48,7 +47,7 @@ class UserService extends KalturaBaseUserService
 	function addUserImpl(KalturaUser $user)
 	{
 		$dbUser = null;
-		$user->validateForInsert();
+		$user->validateForInsert(array('partnerId'));
 		$dbUser = $user->toObject($dbUser);
 		try {
 			$dbUser = kuserPeer::addUser($dbUser, $user->password);

--- a/api_v3/services/UserService.php
+++ b/api_v3/services/UserService.php
@@ -45,9 +45,10 @@ class UserService extends KalturaBaseUserService
 		return kLock::runLocked($lockKey, array($this, 'adduserImpl'), array($user));
 	}
 	
-	function addUserImpl($user)
+	function addUserImpl(KalturaUser $user)
 	{
 		$dbUser = null;
+		$user->validateForInsert();
 		$dbUser = $user->toObject($dbUser);
 		try {
 			$dbUser = kuserPeer::addUser($dbUser, $user->password);


### PR DESCRIPTION
PLAT-4655
When adding a user we are not validating the input for insert and we then
insert the data to the object causing exceptions in the log
trying to insert a read only member.
Adding the input validation prior to the user object creation
will cause the add user to fail since we are
trying to set a read only member.

@MosheMaorKaltura please review it.