### PR TITLE
if we don't have a puserId (such as in widgetKS) we need to check for…

### DIFF
--- a/plugins/cue_points/base/lib/model/CuePointPeer.php
+++ b/plugins/cue_points/base/lib/model/CuePointPeer.php
@@ -35,6 +35,13 @@ class CuePointPeer extends BaseCuePointPeer implements IMetadataPeer, IRelatedOb
 	{
 		self::$userContentOnly = $contentOnly;
 	}
+
+	private static $showOnlyPublic = true;
+
+	public static function setShowOnlyPublic($showOwnlyPublic)
+	{
+		self::$showOnlyPublic = $showOwnlyPublic;
+	}
 	
 	/* (non-PHPdoc)
 	 * @see BaseCuePointPeer::setDefaultCriteriaFilter()
@@ -46,7 +53,7 @@ class CuePointPeer extends BaseCuePointPeer implements IMetadataPeer, IRelatedOb
 		
 		$c = KalturaCriteria::create(CuePointPeer::OM_CLASS);
 		$c->addAnd(CuePointPeer::STATUS, CuePointStatus::DELETED, Criteria::NOT_EQUAL);
-		
+
 		if(self::$userContentOnly)
 		{
 			$puserId = kCurrentContext::$ks_uid;
@@ -78,6 +85,14 @@ class CuePointPeer extends BaseCuePointPeer implements IMetadataPeer, IRelatedOb
 				);
 			
 				$c->addAnd($criterionUserOrPublic);
+			}
+			else if (!$puserId)
+			{
+				if (self::$showOnlyPublic)
+				{
+					$criterionIsPublic = $c->getNewCriterion(self::IS_PUBLIC, true, Criteria::EQUAL);
+					$c->addAnd($criterionIsPublic);
+				}
 			}
 		}
 		

--- a/plugins/cue_points/quiz/lib/api/filters/KalturaAnswerCuePointFilter.php
+++ b/plugins/cue_points/quiz/lib/api/filters/KalturaAnswerCuePointFilter.php
@@ -18,6 +18,10 @@ class KalturaAnswerCuePointFilter extends KalturaAnswerCuePointBaseFilter
 	 */
 	public function getTypeListResponse(KalturaFilterPager $pager, KalturaDetachedResponseProfile $responseProfile = null, $type = null)
 	{
+		if ($this->quizUserEntryIdIn || $this->quizUserEntryIdEqual)
+		{
+			CuePointPeer::setShowOnlyPublic(false);			
+		}
 		return parent::getTypeListResponse($pager, $responseProfile, QuizPlugin::getCoreValue('CuePointType',QuizCuePointType::QUIZ_ANSWER));
 	}
 	


### PR DESCRIPTION
… answerCuePoints weather or not we can display public cue points, this is determined weather or not there is a filter on quizUserEntryIdEqual or quizUserEntryIdIn is set.

PLAT-5165