### PR TITLE
Authenticate temporary fix for live

### DIFF
--- a/api_v3/services/LiveStreamService.php
+++ b/api_v3/services/LiveStreamService.php
@@ -164,6 +164,9 @@ class LiveStreamService extends KalturaLiveEntryService
 				}
 			}
 			
+			/*
+			Patch for autenticate error while performing an immidiate stop/start. Checkup for duplicate streams moved to 
+			media-server for the moment.
 			if($url)
 			{
 				KalturaLog::info('Determining status of live stream URL [' .$url. ']');
@@ -175,7 +178,7 @@ class LiveStreamService extends KalturaLiveEntryService
 				{
 					throw new KalturaAPIException(KalturaErrors::LIVE_STREAM_ALREADY_BROADCASTING, $entryId, $mediaServer->getHostname());
 				}
-			}
+			} */
 		}
 		
 		// fetch current stream live params


### PR DESCRIPTION
Patch for authenticate error while performing an immediate stop/start. Checkup for duplicate streams moved to 
media-server for the moment.
A permanent fix will follow.