### PR TITLE
add support for S3 server-side encryption KMS and AES-256

### DIFF
--- a/admin_console/forms/Partner/StorageConfiguration.php
+++ b/admin_console/forms/Partner/StorageConfiguration.php
@@ -46,6 +46,21 @@ class Form_Partner_StorageConfiguration extends Form_Partner_BaseStorageConfigur
 		));
 		$this->addElementToDisplayGroup('storage_info', 's3Region');
 
+		$this->addElement('select', 'sseType', array(
+				'label'			=> 'Server-Side Encryption(SSE) Type:',
+				'filters'		=> array('StringTrim'),
+				'multiOptions'	=> array('None' => 'None',
+									'KMS' => 'KMS',
+									'AES256' => 'AES256'
+									),
+		));
+		$this->addElementToDisplayGroup('storage_info', 'sseType');
+		
+		$this->addElement('text', 'sseKmsKeyId', array(
+				'label'			=> 'SSE KMS Key ID:',
+				'filters'		=> array('StringTrim'),
+		));
+		$this->addElementToDisplayGroup('storage_info', 'sseKmsKeyId');
 
 		$this->addElement('checkbox', 'storageFtpPassiveMode', array(
 			'label'			=> 'Storage FTP Passive Mode:',

--- a/admin_console/views/scripts/partner/configure-storage.phtml
+++ b/admin_console/views/scripts/partner/configure-storage.phtml
@@ -21,6 +21,10 @@ jQuery(document).ready(function() {
 			jQuery('#filesPermissionInS3').css('visibility', 'visible');
 			jQuery('#s3Region-label').css('visibility', 'visible');
 			jQuery('#s3Region').css('visibility', 'visible');
+			jQuery('#sseType-label').css('visibility', 'visible');
+			jQuery('#sseType').css('visibility', 'visible');
+			jQuery('#sseKmsKeyId-label').css('visibility', 'visible');
+			jQuery('#sseKmsKeyId').css('visibility', 'visible');
 			jQuery('#storageFtpPassiveMode').css('visibility', 'hidden');
 			jQuery('#storageFtpPassiveMode-label').css('visibility', 'hidden');
 			break;

--- a/admin_console/views/scripts/partner/configure-storage.phtml
+++ b/admin_console/views/scripts/partner/configure-storage.phtml
@@ -35,6 +35,10 @@ jQuery(document).ready(function() {
 			jQuery('#filesPermissionInS3').css('visibility', 'hidden');			
 			jQuery('#s3Region-label').css('visibility', 'hidden');
 			jQuery('#s3Region').css('visibility', 'hidden');
+			jQuery('#sseType-label').css('visibility', 'hidden');
+			jQuery('#sseType').css('visibility', 'hidden');
+			jQuery('#sseKmsKeyId-label').css('visibility', 'hidden');
+			jQuery('#sseKmsKeyId').css('visibility', 'hidden');
 			break;
 		case "<?php echo Kaltura_Client_Enum_StorageProfileProtocol::SFTP?>":
 			setKeyPairSettings(true);
@@ -44,6 +48,10 @@ jQuery(document).ready(function() {
 			jQuery('#filesPermissionInS3-label').css('visibility', 'hidden');
 			jQuery('#s3Region-label').css('visibility', 'hidden');
 			jQuery('#s3Region').css('visibility', 'hidden');
+			jQuery('#sseType-label').css('visibility', 'hidden');
+			jQuery('#sseType').css('visibility', 'hidden');
+			jQuery('#sseKmsKeyId-label').css('visibility', 'hidden');
+			jQuery('#sseKmsKeyId').css('visibility', 'hidden');
 			jQuery('#storageFtpPassiveMode').css('visibility', 'hidden');
 			jQuery('#storageFtpPassiveMode-label').css('visibility', 'hidden');
 			break;

--- a/alpha/apps/kaltura/lib/batch2/model/kAmazonS3StorageExportJobData.php
+++ b/alpha/apps/kaltura/lib/batch2/model/kAmazonS3StorageExportJobData.php
@@ -14,12 +14,24 @@ class kAmazonS3StorageExportJobData extends kStorageExportJobData
 	 * @var string
 	 */   	
     private $s3Region;
+	
+	/**
+	* $var string
+	*/
+	private $sseType;
+	
+	/**
+	* $var string
+	*/
+	private $sseKmsKeyId;
     
 	public function setStorageExportJobData(StorageProfile $externalStorage, FileSync $fileSync, $srcFileSyncLocalPath, $force = false)
 	{
 		parent::setStorageExportJobData($externalStorage, $fileSync, $srcFileSyncLocalPath);
 		$this->setFilesPermissionInS3($externalStorage->getFilesPermissionInS3());
 		$this->setS3Region($externalStorage->getS3Region());
+		$this->setSseType($externalStorage->getSseType());
+		$this->setSseKmsKeyId($externalStorage->getSseKmsKeyId());
 	}
 
 	/**
@@ -52,5 +64,37 @@ class kAmazonS3StorageExportJobData extends kStorageExportJobData
 	public function setS3Region($s3Region)
 	{
 		$this->s3Region = $s3Region;	
+	}	
+	
+	/**
+	 * @return the $sseType
+	 */
+	public function getSseType()
+	{
+		return $this->sseType;
+	}
+	
+	/**
+	 * @param $sseType the $sseType to set
+	 */
+	public function setSseType($sseType)
+	{
+		$this->sseType = $sseType;	
+	}	
+	
+	/**
+	 * @return the $sseKmsKeyId
+	 */
+	public function getSseKmsKeyId()
+	{
+		return $this->sseKmsKeyId;
+	}
+	
+	/**
+	 * @param $sseKmsKeyId the $sseKmsKeyId to set
+	 */
+	public function setSseKmsKeyId($sseKmsKeyId)
+	{
+		$this->sseKmsKeyId = $sseKmsKeyId;	
 	}	
 }

--- a/alpha/lib/model/AmazonS3StorageProfile.php
+++ b/alpha/lib/model/AmazonS3StorageProfile.php
@@ -26,7 +26,8 @@ class AmazonS3StorageProfile extends StorageProfile
 	
 	public function setFilesPermissionInS3($v)
 	{
-		if (!is_null($v)){
+		if (!is_null($v))
+		{
 	    	$this->putInCustomData(self::CUSTOM_DATA_FILES_PERMISSION_IN_S3, $v);
 		}
 	}
@@ -39,7 +40,8 @@ class AmazonS3StorageProfile extends StorageProfile
 
 	public function setS3Region($v)
 	{
-		if (!is_null($v)){
+		if (!is_null($v))
+		{
 	    	$this->putInCustomData(self::CUSTOM_DATA_S3_REGION, $v);
 		}
 	}
@@ -52,7 +54,8 @@ class AmazonS3StorageProfile extends StorageProfile
 	
 	public function setSseType($v)
 	{
-		if (!is_null($v)){
+		if (!is_null($v))
+		{
 	    	$this->putInCustomData(self::CUSTOM_DATA_SSE_TYPE, $v);
 		}
 	}
@@ -65,7 +68,8 @@ class AmazonS3StorageProfile extends StorageProfile
 	
 	public function setSseKmsKeyId($v)
 	{
-		if (!is_null($v)){
+		if (!is_null($v))
+		{
 	    	$this->putInCustomData(self::CUSTOM_DATA_SSE_KMS_KEY_ID, $v);
 		}
 	}

--- a/alpha/lib/model/AmazonS3StorageProfile.php
+++ b/alpha/lib/model/AmazonS3StorageProfile.php
@@ -14,6 +14,8 @@ class AmazonS3StorageProfile extends StorageProfile
 	
 	const CUSTOM_DATA_FILES_PERMISSION_IN_S3 = 'files_permission_in_s3';
 	const CUSTOM_DATA_S3_REGION = 's3Region';
+	const CUSTOM_DATA_SSE_TYPE = 'sseType';
+	const CUSTOM_DATA_SSE_KMS_KEY_ID = 'sseKmsKeyId';
 	
 	public function getKalturaObjectType()
 	{
@@ -45,6 +47,32 @@ class AmazonS3StorageProfile extends StorageProfile
 	public function getS3Region()
 	{
 	    $v = $this->getFromCustomData(self::CUSTOM_DATA_S3_REGION);
+	    return $v;
+	}
+	
+	public function setSseType($v)
+	{
+		if (!is_null($v)){
+	    	$this->putInCustomData(self::CUSTOM_DATA_SSE_TYPE, $v);
+		}
+	}
+	
+	public function getSseType()
+	{
+	    $v = $this->getFromCustomData(self::CUSTOM_DATA_SSE_TYPE);
+	    return $v;
+	}
+	
+	public function setSseKmsKeyId($v)
+	{
+		if (!is_null($v)){
+	    	$this->putInCustomData(self::CUSTOM_DATA_SSE_KMS_KEY_ID, $v);
+		}
+	}
+	
+	public function getSseKmsKeyId()
+	{
+	    $v = $this->getFromCustomData(self::CUSTOM_DATA_SSE_KMS_KEY_ID);
 	    return $v;
 	}
 }

--- a/api_v3/lib/types/batch/KalturaAmazonS3StorageExportJobData.php
+++ b/api_v3/lib/types/batch/KalturaAmazonS3StorageExportJobData.php
@@ -14,11 +14,23 @@ class KalturaAmazonS3StorageExportJobData extends KalturaStorageExportJobData
 	 * @var string
 	 */   	
     public $s3Region;   
+	
+	/**
+	 * @var string
+	 */   	
+    public $sseType;   
+	
+	/**
+	 * @var string
+	 */   	
+    public $sseKmsKeyId;   
     
 	private static $map_between_objects = array
 	(
 		"filesPermissionInS3",	
 		"s3Region",	
+		"sseType",
+		"sseKmsKeyId",
 	);
 
 	public function getMapBetweenObjects ( )

--- a/api_v3/lib/types/storageProfile/KalturaAmazonS3StorageProfile.php
+++ b/api_v3/lib/types/storageProfile/KalturaAmazonS3StorageProfile.php
@@ -15,10 +15,22 @@ class KalturaAmazonS3StorageProfile extends KalturaStorageProfile
 	 */
 	public $s3Region;
 	
+	/**
+	 * @var string
+	 */
+	public $sseType;
+	
+	/**
+	 * @var string
+	 */
+	public $sseKmsKeyId;
+	
 	private static $map_between_objects = array
 	(
 		"filesPermissionInS3",
 		"s3Region",
+		"sseType",
+		"sseKmsKeyId",
 	);
 	
 	public function getMapBetweenObjects()

--- a/batch/batches/Storage/Engine/KFileTransferExportEngine.php
+++ b/batch/batches/Storage/Engine/KFileTransferExportEngine.php
@@ -33,6 +33,8 @@ class KFileTransferExportEngine extends KExportEngine
 		{
 			$engineOptions['filesAcl'] = $this->data->filesPermissionInS3;
 			$engineOptions['s3Region'] = $this->data->s3Region;
+			$engineOptions['sseType'] = $this->data->sseType;
+			$engineOptions['sseKmsKeyId'] = $this->data->sseKmsKeyId;
 		}
 			
 		$engine = kFileTransferMgr::getInstance($this->protocol, $engineOptions);

--- a/infra/storage/file_transfer_managers/s3Mgr.class.php
+++ b/infra/storage/file_transfer_managers/s3Mgr.class.php
@@ -29,16 +29,24 @@ class s3Mgr extends kFileTransferMgr
 		parent::__construct($options);
 	
 		if($options && isset($options['filesAcl']))
+		{
 			$this->filesAcl = $options['filesAcl'];
-			
+		}
+		
 		if($options && isset($options['s3Region']))
+		{
 			$this->s3Region = $options['s3Region'];
+		}
 		
 		if($options && isset($options['sseType']))
+		{
 			$this->sseType = $options['sseType'];
+		}
 		
 		if($options && isset($options['sseKmsKeyId']))
+		{
 			$this->sseKmsKeyId = $options['sseKmsKeyId'];
+		}
 		
 		// do nothing
 		$this->connection_id = 1; //SIMULATING!
@@ -68,7 +76,8 @@ class s3Mgr extends kFileTransferMgr
 	//
 	protected function doLogin($sftp_user, $sftp_pass)
 	{
-		if(!class_exists('Aws\S3\S3Client')) {
+		if(!class_exists('Aws\S3\S3Client')) 
+		{
 			KalturaLog::err('Class Aws\S3\S3Client was not found!!');
 			return false;
 		}
@@ -158,7 +167,9 @@ class s3Mgr extends kFileTransferMgr
 
 		$response = $this->s3->getObject( $params );
 		if($response && !$local_file)
+		{
 			return $response['Body'];
+		}
 			
 		return $response;
 	}
@@ -179,7 +190,8 @@ class s3Mgr extends kFileTransferMgr
 	protected function doFileExists($remote_file)
 	{
 		list($bucket, $remote_file) = explode("/",ltrim($remote_file,"/"),2);
-		if($this->isdirectory($remote_file)) {
+		if($this->isdirectory($remote_file)) 
+		{
 			return true;
 		}
 		KalturaLog::debug("remote_file: ".$remote_file);


### PR DESCRIPTION
- Adds Amazon S3's SSE-S3 and SSE-KMS support to the S3 remote storage connector. SSE-C is NOT covered in this.
https://docs.aws.amazon.com/AmazonS3/latest/dev/serv-side-encryption.html
- Changes signature from default v2 to v4 to add support for SSE and New Europe and Asia datacenters
