### PR TITLE
When bulkUploadXML engine is used to upload flavors with flavor param…

### DIFF
--- a/alpha/apps/kaltura/lib/batch2/kFlowManager.php
+++ b/alpha/apps/kaltura/lib/batch2/kFlowManager.php
@@ -8,7 +8,7 @@
  * @subpackage Batch
  *
  */
-class kFlowManager implements kBatchJobStatusEventConsumer, kObjectAddedEventConsumer, kObjectChangedEventConsumer, kObjectDeletedEventConsumer, kObjectReadyForReplacmentEventConsumer
+class kFlowManager implements kBatchJobStatusEventConsumer, kObjectAddedEventConsumer, kObjectChangedEventConsumer, kObjectDeletedEventConsumer, kObjectReadyForReplacmentEventConsumer,kObjectDataChangedEventConsumer
 {
 	public final function __construct()
 	{
@@ -481,63 +481,7 @@ class kFlowManager implements kBatchJobStatusEventConsumer, kObjectAddedEventCon
 	 */
 	public function objectAdded(BaseObject $object, BatchJob $raisedJob = null)
 	{
-		$entry = $object->getentry();
-
-		if($object->getStatus() == asset::FLAVOR_ASSET_STATUS_QUEUED || $object->getStatus() == asset::FLAVOR_ASSET_STATUS_IMPORTING)
-		{
-			if(!($object instanceof flavorAsset))
-			{
-				$object->setStatus(asset::FLAVOR_ASSET_STATUS_READY);
-				$object->save();
-			}
-			elseif($object->getIsOriginal())
-			{
-				if($entry->getType() == entryType::MEDIA_CLIP)
-				{
-					$syncKey = $object->getSyncKey(flavorAsset::FILE_SYNC_FLAVOR_ASSET_SUB_TYPE_ASSET);
-
-					if(kFileSyncUtils::fileSync_exists($syncKey)) {
-
-							// Get the asset fileSync.
-							// For URL typed sync - assume remote and use the relative file path.
-							// For the other types - use the ordinary kFileSyncUtils::getLocalFilePathForKey.
-						$fsArr=kFileSyncUtils::getReadyFileSyncForKey($syncKey,true,false);
-						$fs=$fsArr[0];
-						if($fs->getFileType()==FileSync::FILE_SYNC_FILE_TYPE_URL) {
-							$path = $fs->getFilePath();
-						}
-						else{
-							$path = kFileSyncUtils::getLocalFilePathForKey($syncKey);
-						}
-						kJobsManager::addConvertProfileJob($raisedJob, $entry, $object->getId(), $path);
-					}
-				}
-			}
-			else
-			{
-				$object->setStatus(asset::FLAVOR_ASSET_STATUS_VALIDATING);
-				$object->save();
-			}
-		}
-
-		 if($object->getStatus() == asset::FLAVOR_ASSET_STATUS_READY && $object instanceof thumbAsset)
-        {
-                if($object->getFlavorParamsId())
-                        kFlowHelper::generateThumbnailsFromFlavor($object->getEntryId(), $raisedJob, $object->getFlavorParamsId());
-                else
-                        if ($object->hasTag(thumbParams::TAG_DEFAULT_THUMB))
-                                kBusinessConvertDL::setAsDefaultThumbAsset($object);
-                return true;
-        }
-
-
-		if($object->getIsOriginal() && $entry->getStatus() == entryStatus::NO_CONTENT)
-		{
-			$entry->setStatus(entryStatus::PENDING);
-			$entry->save();
-		}
-
-		return true;
+		return $this->doObjectAddedOrDataAdded($object, $raisedJob);
 	}
 
 	/* (non-PHPdoc)
@@ -745,5 +689,98 @@ class kFlowManager implements kBatchJobStatusEventConsumer, kObjectAddedEventCon
 		kFlowHelper::handleUploadCanceled($object);
 		return true;
 	}
+
+	/**
+	 * @param BaseObject $object
+	 * @param string $previousVersion
+	 * @return bool true if the consumer should handle the event
+	 */
+	public function shouldConsumeDataChangedEvent(BaseObject $object, $previousVersion = null)
+	{
+		if($object instanceof asset)
+			return true;
+
+		return false;		
+	}
+
+	/**
+	 * @param BaseObject $object
+	 * @param string $previousVersion
+	 * @param BatchJob $raisedJob
+	 * @return bool true if should continue to the next consumer
+	 */
+	public function objectDataChanged(BaseObject $object, $previousVersion = null, BatchJob $raisedJob = null)
+	{
+		return $this->doObjectAddedOrDataAdded($object, $raisedJob);	
+	}
+
+	/**
+	 * @param BaseObject $object
+	 * @param BatchJob $raisedJob
+	 * @return bool
+	 * @throws Exception
+	 * @throws kCoreException
+	 */
+	protected function doObjectAddedOrDataAdded(BaseObject $object, BatchJob $raisedJob)
+	{
+		$entry = $object->getentry();
+
+		if ($object->getStatus() == asset::FLAVOR_ASSET_STATUS_QUEUED || $object->getStatus() == asset::FLAVOR_ASSET_STATUS_IMPORTING)
+		{
+			if (!($object instanceof flavorAsset))
+			{
+				$object->setStatus(asset::FLAVOR_ASSET_STATUS_READY);
+				$object->save();
+			} elseif ($object->getIsOriginal())
+			{
+				if ($entry->getType() == entryType::MEDIA_CLIP)
+				{
+					$syncKey = $object->getSyncKey(flavorAsset::FILE_SYNC_FLAVOR_ASSET_SUB_TYPE_ASSET);
+
+					if (kFileSyncUtils::fileSync_exists($syncKey))
+					{
+
+						// Get the asset fileSync.
+						// For URL typed sync - assume remote and use the relative file path.
+						// For the other types - use the ordinary kFileSyncUtils::getLocalFilePathForKey.
+						$fsArr = kFileSyncUtils::getReadyFileSyncForKey($syncKey, true, false);
+						$fs = $fsArr[0];
+						if ($fs->getFileType() == FileSync::FILE_SYNC_FILE_TYPE_URL)
+						{
+							$path = $fs->getFilePath();
+						} else
+						{
+							$path = kFileSyncUtils::getLocalFilePathForKey($syncKey);
+						}
+						kJobsManager::addConvertProfileJob($raisedJob, $entry, $object->getId(), $path);
+					}
+				}
+			} else
+			{
+				$object->setStatus(asset::FLAVOR_ASSET_STATUS_VALIDATING);
+				$object->save();
+			}
+		}
+
+		if ($object->getStatus() == asset::FLAVOR_ASSET_STATUS_READY && $object instanceof thumbAsset)
+		{
+			if ($object->getFlavorParamsId())
+				kFlowHelper::generateThumbnailsFromFlavor($object->getEntryId(), $raisedJob, $object->getFlavorParamsId());
+			else
+				if ($object->hasTag(thumbParams::TAG_DEFAULT_THUMB))
+					kBusinessConvertDL::setAsDefaultThumbAsset($object);
+			return true;
+		}
+
+
+		if ($object->getIsOriginal() && $entry->getStatus() == entryStatus::NO_CONTENT)
+		{
+			$entry->setStatus(entryStatus::PENDING);
+			$entry->save();
+		}
+
+		return true;
+	}
+
 
 }

--- a/alpha/apps/kaltura/lib/batch2/kFlowManager.php
+++ b/alpha/apps/kaltura/lib/batch2/kFlowManager.php
@@ -721,7 +721,7 @@ class kFlowManager implements kBatchJobStatusEventConsumer, kObjectAddedEventCon
 	 * @throws Exception
 	 * @throws kCoreException
 	 */
-	protected function doObjectAddedOrDataAdded(BaseObject $object, BatchJob $raisedJob)
+	protected function doObjectAddedOrDataAdded(BaseObject $object, BatchJob $raisedJob = null)
 	{
 		$entry = $object->getentry();
 


### PR DESCRIPTION
…s that aren't in the conversion profile being used we create the flavor params and add the content, since these are not new flavor assets no "objectCreated" event is sent but objectDataChanged is raised. If the flavor params where in the conversion profile then we would have another job of ConvertProfile which will move the flavors to ready but since they aren't then the flavors remain in status QUEUED, so this fix should catch the objectDataChanged event and move the status of the flavors to "ready" (the entry will not be ready becasue the conversion profile will not be converted).

SUP-7695