### PR TITLE
Parsing dfxp captions correctly and not combining text word between e…

### DIFF
--- a/plugins/content/caption/base/lib/captionManagers/dfxpCaptionsContentManager.php
+++ b/plugins/content/caption/base/lib/captionManagers/dfxpCaptionsContentManager.php
@@ -179,6 +179,9 @@ class dfxpCaptionsContentManager extends kCaptionsContentManager
 		try
 		{
 			$xml->loadXML($content);
+			$xml->formatOutput = true;
+			$content = $xml->saveXML();
+			$xml->loadXML($content);
 		}
 		catch(Exception $e)
 		{


### PR DESCRIPTION
…lements. This fix is to make sure sphinx index words correctly.

PLAT-5484

@MosheMaorKaltura 