### PR TITLE
reduce logger memory usage

### DIFF
--- a/infra/log/KalturaLog.php
+++ b/infra/log/KalturaLog.php
@@ -189,7 +189,7 @@ class LogMethod
 	public function __toString()
 	{
 		$backtraceIndex = 3;
-		$backtrace = debug_backtrace();
+		$backtrace = debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS);
 		
 		while(
 			$backtraceIndex < count($backtrace)


### PR DESCRIPTION
backtrace is only used to get the calling function name, no need for the args / objects