### PR TITLE
Support changed MediaInfo format

### DIFF
--- a/infra/media/mediaInfoParser/KMediaInfoMediaParser.php
+++ b/infra/media/mediaInfoParser/KMediaInfoMediaParser.php
@@ -416,7 +416,7 @@ class KMediaInfoMediaParser extends KBaseMediaParser
 	
 	private static function convertDuration2msec($str)
 	{
-		preg_match_all("/(([0-9]*)h ?)?(([0-9]*)mn ?)?(([0-9]*)s ?)?(([0-9]*)ms ?)?/",
+		preg_match_all("/(([0-9]*)\s?h?\s?)?(([0-9]*)\s?mn?\s?)?(([0-9]*)\s?s?\s?)?(([0-9]*)\s?ms?\s?)?/",
 			$str, $res);
 			
 		$hour = @$res[2][0];


### PR DESCRIPTION
Proper way to fix this is either doing DateTime conversion or executing mediainfo with --Inform="Video;%Duration%" which will give milliseconds formatting. The ugly regex is now updated to allow zero or one spaces before and after the time indicators.