### PR TITLE
create resource only with existing parent id's. the exception is pare…

### DIFF
--- a/api_v3/lib/KalturaErrors.php
+++ b/api_v3/lib/KalturaErrors.php
@@ -88,6 +88,8 @@ class KalturaErrors extends APIErrors
 
 	const SYSTEM_NAME_ALREADY_EXISTS = "SYSTEM_NAME_ALREADY_EXISTS;SYS_NAME;System name [@SYS_NAME@] already exists";
 
+	const RESOURCE_PARENT_ID_NOT_FOUND = "RESOURCE_PARENT_ID_NOT_FOUND;PARENT_ID;Resource parent id [@PARENT_ID@] not found";
+
 	const LOCK_TIMED_OUT = "LOCK_TIMED_OUT;;Timed out while attempting to grab lock";
 	
 	const MAX_FILE_SYNCS_FOR_OBJECT_PER_DAY_REACHED = "MAX_FILE_SYNCS_FOR_OBJECT_PER_DAY_REACHED;OBJECT_ID;Max update limit was reached. Object ID \"@OBJECT_ID@\" will not updated with latest chnages";

--- a/plugins/schedule/base/lib/api/KalturaScheduleResource.php
+++ b/plugins/schedule/base/lib/api/KalturaScheduleResource.php
@@ -138,7 +138,7 @@ abstract class KalturaScheduleResource extends KalturaObject implements IRelated
 
 		if (!$this->isNull('parentId') && $this->parentId != 0 )
 		{
-			$scheduleResource = ScheduleEventPeer::retrieveByPK($this->parentId);
+			$scheduleResource = ScheduleResourcePeer::retrieveByPK($this->parentId);
 			if (is_null($scheduleResource))
 				throw new KalturaAPIException(KalturaErrors::RESOURCE_PARENT_ID_NOT_FOUND, $this->parentId);
 		}

--- a/plugins/schedule/base/lib/api/KalturaScheduleResource.php
+++ b/plugins/schedule/base/lib/api/KalturaScheduleResource.php
@@ -135,6 +135,13 @@ abstract class KalturaScheduleResource extends KalturaObject implements IRelated
 			if(ScheduleResourcePeer::doCount($c))
 				throw new KalturaAPIException(KalturaErrors::SYSTEM_NAME_ALREADY_EXISTS, $this->systemName);
 		}
+
+		if (!$this->isNull('parentId') && $this->parentId != 0 )
+		{
+			$scheduleResource = ScheduleEventPeer::retrieveByPK($this->parentId);
+			if (is_null($scheduleResource))
+				throw new KalturaAPIException(KalturaErrors::RESOURCE_PARENT_ID_NOT_FOUND, $this->parentId);
+		}
 		
 		return parent::validateForInsert($propertiesToSkip);
 	}


### PR DESCRIPTION
…ntId = 0 which represent no resource at all and therefore can't create childrens for him

PLAT-5513
@MosheMaorKaltura 
For merge on Lynx-12.3.0