### PR TITLE
Removed mainObjectCode from BPM Notification Template

### DIFF
--- a/tests/standAloneClient/bpmNotificationsTemplates.xml
+++ b/tests/standAloneClient/bpmNotificationsTemplates.xml
@@ -898,7 +898,6 @@
 				<automaticDispatchEnabled>1</automaticDispatchEnabled>
 				<eventType>{php:return KalturaEventNotificationEventType::OBJECT_DATA_CHANGED;}</eventType>
 				<eventObjectType>{php:return KalturaEventNotificationEventObjectType::TRANSCRIPT_ASSET;}</eventObjectType>
-				<mainObjectCode>$object->getentry()</mainObjectCode>
 				<eventConditions objectType="array">
 					<item objectType="KalturaFieldMatchCondition">
 						<description>Status equals</description>


### PR DESCRIPTION
'mainObjectCode' is not needed, the internal integration job added by this BPM flow already uses entry object