### PR TITLE
Fix JSON with metadata validation disabled

### DIFF
--- a/plugins/event_notification/providers/http/lib/api/KalturaHttpNotificationObjectData.php
+++ b/plugins/event_notification/providers/http/lib/api/KalturaHttpNotificationObjectData.php
@@ -116,7 +116,7 @@ class KalturaHttpNotificationObjectData extends KalturaHttpNotificationData
 				$serializer = new KalturaJsonSerializer($this->ignoreNull);				
 				$data = $serializer->serialize($notification);
 				if (!$httpNotificationTemplate->getUrlEncode())
-					return $data;
+					return "data=$data";
 				
 				$data = urlencode($data);
 				break;


### PR DESCRIPTION
In case $httpNotificationTemplate->getUrlEncode() is false the returned JSON data is invalid.