### PR TITLE
PLAT-6650 New X265/HEVC support

### DIFF
--- a/batch/batches/Convert/Engines/KConversionEngineFfmpeg.class.php
+++ b/batch/batches/Convert/Engines/KConversionEngineFfmpeg.class.php
@@ -59,7 +59,10 @@ class KConversionEngineFfmpeg  extends KJobConversionEngine
 			 *		stands for duration of 462 seconds, gop size 2 seconds
 			 */
 		foreach($cmdLines as $k=>$cmdLine){
-			$exec_cmd = self::experimentalFixing($cmdLine->exec_cmd, $data->flavorParamsOutput, $this->getCmd(), $this->inFilePath, $this->outFilePath);
+			if(KConversionEngineFfmpegVp8::FFMPEG_VP8==$this->getName()){
+				$exec_cmd = self::experimentalFixing($cmdLine->exec_cmd, $data->flavorParamsOutput, $this->getCmd(), $this->inFilePath, $this->outFilePath);
+			}
+			else $exec_cmd = $cmdLine->exec_cmd;
 			$exec_cmd = KDLOperatorFfmpeg::ExpandForcedKeyframesParams($exec_cmd);
 			
 			if(strstr($exec_cmd, "ffmpeg")==false) {


### PR DESCRIPTION
Limit 'old' h265/vp9 flow to engine 98 (experimental), in order to provide graceful switch for the users that currently run the 'old' flow.