### PR TITLE
PLAT-6650 New X265/HEVC support

### DIFF
--- a/batch/batches/Convert/OperationEngines/KOperationEngineFfmpeg.php
+++ b/batch/batches/Convert/OperationEngines/KOperationEngineFfmpeg.php
@@ -8,7 +8,9 @@ class KOperationEngineFfmpeg  extends KSingleOutputOperationEngine
 	protected function getCmdLine()
 	{
 		$cmdLine=parent::getCmdLine();
-		$cmdLine=KConversionEngineFfmpeg::experimentalFixing($cmdLine, $this->data->flavorParamsOutput, $this->cmd, $this->inFilePath, $this->outFilePath);
+		if(get_class($this)=='KOperationEngineFfmpegVp8'){
+			$cmdLine=KConversionEngineFfmpeg::experimentalFixing($cmdLine, $this->data->flavorParamsOutput, $this->cmd, $this->inFilePath, $this->outFilePath);
+		}
 		$cmdLine=KDLOperatorFfmpeg::ExpandForcedKeyframesParams($cmdLine);
 		
 		// impersonite


### PR DESCRIPTION
Limit 'old' h265/vp9 flow to engine 98 (experimental), in order to provide graceful switch for the users that currently run the 'old' flow.