### PR TITLE
Collection’/’grouping/multi-flavor tagging support

### DIFF
--- a/alpha/lib/model/conversionProfile2.php
+++ b/alpha/lib/model/conversionProfile2.php
@@ -312,4 +312,11 @@ class conversionProfile2 extends BaseconversionProfile2 implements ISyncableFile
 	{
 		$this->putInCustomData('calculateComplexity', $v);
 	}
+	
+	/*
+	 * Defines the tags that should be used to define 'collective'/group/multi-flavor processing,
+	 * like 'mbr' or 'ism'
+	 */
+	public function getCollectionTags() { return $this->getFromCustomData('collectionTags', null, 'mbr,ism'); }
+	public function setCollectionTags($v) {	$this->putInCustomData('collectionTags', $v); }
 }


### PR DESCRIPTION
Define which tags represent flavors ‘grouping’ (aka ‘mbr’,’ism’).
‘Collection-tag’ causes activation of ‘optimization’ heuristics.
It can be used to define playback sets as well.
