### PR TITLE
serve playlist bug fix

### DIFF
--- a/alpha/apps/kaltura/modules/extwidget/actions/serveFlavorAction.class.php
+++ b/alpha/apps/kaltura/modules/extwidget/actions/serveFlavorAction.class.php
@@ -179,6 +179,7 @@ class serveFlavorAction extends kalturaAction
 			unset($entryIds[$i]);
 			unset($durations[$i]);
 		}
+		$durations = array_values($durations);		// if some duration was unset, this makes sure that durations will be rendered as an array in the json
 
 		// get the flavor params of the reference entry that should be returned
 		$referenceEntryFlavorParamsIds = array_keys($groupedFlavors[$referenceEntry->getId()]);


### PR DESCRIPTION
when one of the entries has no flavors, the durations array is unset, this makes php render it as an object in the json (e.g. {"0":64000,"1":30084,"3":50109} instead of [64000,30084,50109])