### PR TITLE
api cache bug fix

### DIFF
--- a/alpha/apps/kaltura/lib/cache/kApiCache.php
+++ b/alpha/apps/kaltura/lib/cache/kApiCache.php
@@ -24,7 +24,7 @@ class kApiCache extends kApiCacheBase
 	const SUFFIX_RULES = '.rules';
 	const SUFFIX_LOG = '.log';
 
-	const CACHE_VERSION = '12';
+	const CACHE_VERSION = '14';
 
 	// cache modes
 	const CACHE_MODE_ANONYMOUS = 1;				// anonymous caching should be performed - the cached response will not be associated with any conditions
@@ -760,9 +760,10 @@ class kApiCache extends kApiCacheBase
 			return false;
 		}
 
-		$this->_responseMetadata = $responseMetadata;
 		if($responseMetadata)
 			$this->_responseMetadata = unserialize($responseMetadata);
+		else
+			$this->_responseMetadata = array();
 
 		if ($this->_cacheRulesDirty)
 		{
@@ -936,9 +937,6 @@ class kApiCache extends kApiCacheBase
 		if (!$foundHeader)
 			header("X-Kaltura: cache-key,".$this->_cacheKey);
 		
-		if($responseMetadata)
-			$responseMetadata = serialize($responseMetadata);
-
 		$this->_responseMetadata = $responseMetadata;
 		$this->_cacheId = microtime(true) . '_' . getmypid();
 
@@ -956,7 +954,8 @@ class kApiCache extends kApiCacheBase
 			if (self::$_debugMode)
 				$curCacheStore->set($this->_cacheKey . self::SUFFIX_LOG, print_r($this->_params, true), $maxExpiry + self::EXPIRY_MARGIN);
 			$curCacheStore->set($this->_cacheKey . self::SUFFIX_RULES, serialize($this->_cacheRules), $maxExpiry + self::EXPIRY_MARGIN);
-			$curCacheStore->set($this->_cacheKey . self::SUFFIX_DATA, implode(self::CACHE_DELIMITER, array($this->_cacheId, $this->_responseMetadata, $response)), $maxExpiry);
+			$responseMetadata = $this->_responseMetadata ? serialize($this->_responseMetadata) : '';
+			$curCacheStore->set($this->_cacheKey . self::SUFFIX_DATA, implode(self::CACHE_DELIMITER, array($this->_cacheId, $responseMetadata, $response)), $maxExpiry);
 		}
 	}
 


### PR DESCRIPTION
this->_responseMetadata should always be unserialized, need to serialize
it right before saving to memcache. In the previous implementation, after
storeCache it was serialized. In cases where a cache was extended (e.g.
from central cache to local cache) it doesn't go through storeCache and
therefore the unserialized array was saved without serialization.