### PR TITLE
As of PHP 5.4.0, call-time pass-by-reference was removed

### DIFF
--- a/batch/batches/Convert/Engines/KConversionEngineFfmpeg.class.php
+++ b/batch/batches/Convert/Engines/KConversionEngineFfmpeg.class.php
@@ -200,7 +200,7 @@ class KConversionEngineFfmpeg  extends KJobConversionEngine
 			 */
 		$runChunkedEncode = new KChunkedEncodeSessionManager($setup);
 		if($runChunkedEncode->Initialize()!=true){
-			$output = $runChunkedEncode->ExecuteFallback($cmdLine, &$returnVar);
+			$output = $runChunkedEncode->ExecuteFallback($cmdLine, $returnVar);
 			return $output;
 		}
 		$sessionFilename = $runChunkedEncode->chunker->getSessionName("session");

--- a/infra/chunkedEncode/KChunkedEncodeSessionManager.php
+++ b/infra/chunkedEncode/KChunkedEncodeSessionManager.php
@@ -375,7 +375,7 @@
 					return false;
 				}
 			}
-			if($this->chunker->ValidateMergedFile(&$msgStr)!=true){
+			if($this->chunker->ValidateMergedFile($msgStr)!=true){
 				$this->returnMessages[] = $msgStr;
 				$this->returnStatus = KChunkedEncodeReturnStatus::MergeThreshError;
 				return false;
@@ -394,20 +394,20 @@
 				$cmd = "rm -f $chunkName_wc";
 				KalturaLog::log("cleanup cmd:$cmd");
 				$rv = null; $op = null;
-				$output = exec($cmd, $op, &$rv);
+				$output = exec($cmd, $op, $rv);
 			}
 			$mergedFilenameAudio = $this->chunker->getSessionName("audio");
 			$cmd = "rm -f $mergedFilenameAudio* ".$concatFilenameLog = $this->chunker->getSessionName("concat");
 			KalturaLog::log("cleanup cmd:$cmd");
 			$rv = null; $op = null;
-			$output = exec($cmd, $op, &$rv);
+			$output = exec($cmd, $op, $rv);
 			return;
 			$cmd = "rm -f $setup->output*.$this->videoChunkPostfix*";
 			$cmd.= " ".$this->chunker->getSessionName("audio")."*";
 			$cmd.= " ".$this->chunker->getSessionName("session");
 			KalturaLog::log("cleanup cmd:$cmd");
 			$rv = null; $op = null;
-			$output = exec($cmd, $op, &$rv);
+			$output = exec($cmd, $op, $rv);
 		}
 		
 		/********************
@@ -520,7 +520,7 @@
 			$runningArr = array();
 			$processCnt = 0;
 
-			$runningArr = $this->getRunningArray(&$processCnt);
+			$runningArr = $this->getRunningArray($processCnt);
 
 			$this->processArr = $runningArr;
 			$runningCnt = count($runningArr);


### PR DESCRIPTION
Using it wll trigger a fatal error.