### PR TITLE
As of PHP 5.4.0, removed call-time pass-by-refer

### DIFF
--- a/batch/batches/Convert/Engines/KConversionEngineFfmpeg.class.php
+++ b/batch/batches/Convert/Engines/KConversionEngineFfmpeg.class.php
@@ -200,7 +200,7 @@ class KConversionEngineFfmpeg  extends KJobConversionEngine
 			 */
 		$runChunkedEncode = new KChunkedEncodeSessionManager($setup);
 		if($runChunkedEncode->Initialize()!=true){
-			$output = $runChunkedEncode->ExecuteFallback($cmdLine, &$returnVar);
+			$output = $runChunkedEncode->ExecuteFallback($cmdLine, $returnVar);
 			return $output;
 		}
 		$sessionFilename = $runChunkedEncode->chunker->getSessionName("session");


### PR DESCRIPTION
Otherwise,  using it will trigger a fatal error.