### PR TITLE
hls compatibility features

### DIFF
--- a/alpha/apps/kaltura/lib/kManifestRenderers.php
+++ b/alpha/apps/kaltura/lib/kManifestRenderers.php
@@ -823,12 +823,7 @@ class kM3U8ManifestRenderer extends kMultiFlavorManifestRenderer
 	 */
 	protected function getManifestHeader()
 	{
-		$header = "#EXTM3U";
-		// add version in case of audio flavors
-		if ($this->hasAudioFlavors) {
-			$header .= "\n#EXT-X-VERSION:4";
-		}
-		return $header;
+		return "#EXTM3U";
 	}
 
 }

--- a/plugins/content/caption/base/lib/kWebVTTGenerator.php
+++ b/plugins/content/caption/base/lib/kWebVTTGenerator.php
@@ -64,7 +64,11 @@ class kWebVTTGenerator
 		$segmentEndTime = $segmentIndex * $segmentDuration * 1000;
 
 		$result = "WEBVTT\n";
-		$result .= "X-TIMESTAMP-MAP=MPEGTS:900000,LOCAL:" . self::formatWebVTTTimeStamp($localTimestamp) . "\n\n";
+		if ($localTimestamp != 10000)
+		{
+			$result .= "X-TIMESTAMP-MAP=MPEGTS:900000,LOCAL:" . self::formatWebVTTTimeStamp($localTimestamp) . "\n";
+		}
+		$result .= "\n";
 
 		foreach ($parsedCaption as $curCaption)
 		{
@@ -140,8 +144,9 @@ class kWebVTTGenerator
 		$result = implode('', $headerInfo);
 		if ($localTimestamp != 10000)
 		{
-			$result .= "X-TIMESTAMP-MAP=MPEGTS:900000,LOCAL:" . self::formatWebVTTTimeStamp($localTimestamp) . "\n\n";
+			$result .= "X-TIMESTAMP-MAP=MPEGTS:900000,LOCAL:" . self::formatWebVTTTimeStamp($localTimestamp) . "\n";
 		}
+		$result .= "\n";
 
 		foreach ($parsedCaption as $curCaption)
 		{

--- a/plugins/content/caption/base/lib/kWebVTTGenerator.php
+++ b/plugins/content/caption/base/lib/kWebVTTGenerator.php
@@ -34,9 +34,17 @@ class kWebVTTGenerator
 		$result .= "#EXT-X-MEDIA-SEQUENCE:1\r\n";
 		$result .= "#EXT-X-PLAYLIST-TYPE:VOD\r\n";
 		$segmentCount = ceil($entryDuration / $segmentDuration);
+		$lastSegmentDuration = $entryDuration - ($segmentCount - 1) * $segmentDuration;
 		for ($curIndex = 1; $curIndex <= $segmentCount; $curIndex++)
 		{
-			$result .= "#EXTINF:{$segmentDuration}.0,\r\n";
+			if ($curIndex == $segmentCount)
+			{
+				$result .= "#EXTINF:{$lastSegmentDuration}.0,\r\n";
+			}
+			else
+			{
+				$result .= "#EXTINF:{$segmentDuration}.0,\r\n";
+			}
 			$result .= "segmentIndex/{$curIndex}.vtt\r\n";
 		}
 		$result .= "#EXT-X-ENDLIST\r\n";
@@ -130,7 +138,10 @@ class kWebVTTGenerator
 		$segmentEndTime = $segmentIndex * $segmentDuration * 1000;
 
 		$result = implode('', $headerInfo);
-		$result .= "X-TIMESTAMP-MAP=MPEGTS:900000,LOCAL:" . self::formatWebVTTTimeStamp($localTimestamp) . "\n\n";
+		if ($localTimestamp != 10000)
+		{
+			$result .= "X-TIMESTAMP-MAP=MPEGTS:900000,LOCAL:" . self::formatWebVTTTimeStamp($localTimestamp) . "\n\n";
+		}
 
 		foreach ($parsedCaption as $curCaption)
 		{


### PR DESCRIPTION
- don't return EXT-X-VERSION in master m3u8 (makes some devices fail playback)
- don't return X-TIMESTAMP-MAP when possible (can cause out-of-sync in roku)
- return the correct duration of the last webvtt segment