### PR TITLE
The /kmc alias is not only unnecessary but also triggers errors

### DIFF
--- a/configurations/apache/conf.d/apps.conf.template
+++ b/configurations/apache/conf.d/apps.conf.template
@@ -1,19 +1,3 @@
-
-Alias /kmc "@APP_DIR@/kmc/web"
-<Directory "@APP_DIR@/kmc/web">
-    DirectoryIndex index.php
-    Options Indexes FollowSymLinks Includes
-    <IfVersion <= 2.2>
-        AllowOverride All
-    </IfVersion>
-
-    Order allow,deny
-    Allow from all
-    <IfVersion >= 2.4>
-	Require all granted
-    </IfVersion>
-</Directory>
-
 Alias /hosted_pages "@BASE_DIR@/apps/hosted_pages/web"
 <Directory "@BASE_DIR@/apps/hosted_pages/web">
     DirectoryIndex index.php


### PR DESCRIPTION
[Wed Jun 07 13:12:15.676303 2017] [authz_core:error] [pid 26155] [client
10.0.63.53:33634] AH01630: client denied by server configuration:
/opt/kaltura/app/kmc, referer:
http://ce-ubuntu0.dev.kaltura.com/index.php/kmc/kmc4

Since /opt/kaltura/app/kmc does not exist.