### PR TITLE
preg_replace(): The /e modifier is no longer supported

### DIFF
--- a/vendor/symfony/controller/sfRouting.class.php
+++ b/vendor/symfony/controller/sfRouting.class.php
@@ -457,7 +457,7 @@ class sfRouting
 
     $params = array_merge($defaults, $params);
 
-    $real_url = preg_replace('/\:([^\/]+)/e', 'urlencode($params["\\1"])', $url);
+    $real_url=preg_replace_callback('/\:([^\/]+)/',function ($matches) use ($params){return urlencode($params[$matches[1]]);},$url);
 
     // we add all other params if *
     if (strpos($real_url, '*'))


### PR DESCRIPTION
In PHP 5.4 and above, the current code will fail with:
[Wed Jun 07 13:47:10.719555 2017] [:error] [pid 21226] [client
10.0.63.53:34243] PHP Warning:  preg_replace(): The /e modifier is no
longer supported, use preg_replace_callback instead in
/opt/kaltura/app/vendor/symfony/controller/sfRouting.class.php on line
460, referer: http://ce-ubuntu0.dev.kaltura.com/start/index.php