### PR TITLE
PLAT-7635: during cross kaltura distribution update of asset ids is o…

### DIFF
--- a/plugins/content_distribution/providers/cross_kaltura/lib/batch/CrossKalturaDistributionEngine.php
+++ b/plugins/content_distribution/providers/cross_kaltura/lib/batch/CrossKalturaDistributionEngine.php
@@ -1053,7 +1053,7 @@ class CrossKalturaDistributionEngine extends DistributionEngine implements
 			{
 				/* @var $cuePoint KalturaThumbCuePoint */
 				$thumbCuePoint->entryId = $targetEntryId;
-				$thumbCuePoint->assetId = null;
+				$thumbCuePoint->assetId = "";
 			}
 			$targetCuePointClient = KalturaCuePointClientPlugin::get($this->targetClient);
 			$syncedObjects->thumbCuePoints = $this->syncTargetEntryObjects(


### PR DESCRIPTION
…verlooked since it's null, should be empty string