### PR TITLE
Fix typo

### DIFF
--- a/alpha/apps/kaltura/lib/config/kConfigTable.class.php
+++ b/alpha/apps/kaltura/lib/config/kConfigTable.class.php
@@ -265,7 +265,7 @@ class kConfigTable
 	
 	private function addComment ( $line )
 	{
-		if ( $this->comment ) $this->commnet .= "\n";
+		if ( $this->comment ) $this->comment .= "\n";
 		$this->comment .= $line;
 	}
 	


### PR DESCRIPTION
Fix typo that throws Notices during reload of config