### PR TITLE
Coherent exception message if the kalturadw DB cannot be reached

### DIFF
--- a/alpha/apps/kaltura/lib/reports/myReportsMgr.class.php
+++ b/alpha/apps/kaltura/lib/reports/myReportsMgr.class.php
@@ -1,4 +1,4 @@
-<?php
+."\n<?php
 class myReportsMgr
 {
 	const REPORT_FLAVOR_GRAPH= 1;
@@ -1329,7 +1329,7 @@ class myReportsMgr
 		
 		$error_function = $mysql_function.'_error';
 		if (!$db_selected) {
-			throw new kCoreException('Can\'t use foo : ' . $error_function($link), kCoreException::INVALID_QUERY);
+			throw new kCoreException('mysqli_select_db('. $db_config["db_name"].') failed, check settings in the reports_db_config section of configurations/local.ini', kCoreException::INVALID_QUERY);
 		}
 
 		if($mysql_function == 'mysql') $result = mysql_query($query);
@@ -1465,6 +1465,9 @@ class myReportsMgr
 		
 		$connect_function = $mysql_function.'_connect';
 		$link  = $connect_function( $host , $db_config["user"] , $db_config["password"] , null, $db_config["port"] );
+		if (mysqli_connect_errno()) {
+		        throw new kCoreException('DB connection failed: '. mysqli_connect_error()."\ncheck settings in the reports_db_config section of configurations/local.ini", kCoreException::INVALID_QUERY);
+		}
 		KalturaLog::log( "Reports query using database host: [$host] user [" . $db_config["user"] . "]" );
 		
 		return $link;

--- a/alpha/apps/kaltura/lib/reports/myReportsMgr.class.php
+++ b/alpha/apps/kaltura/lib/reports/myReportsMgr.class.php
@@ -1,4 +1,4 @@
-."\n<?php
+<?php
 class myReportsMgr
 {
 	const REPORT_FLAVOR_GRAPH= 1;

--- a/alpha/apps/kaltura/lib/reports/myReportsMgr.class.php
+++ b/alpha/apps/kaltura/lib/reports/myReportsMgr.class.php
@@ -1321,11 +1321,8 @@ class myReportsMgr
 	{
 		kApiCache::disableConditionalCache();
 		$mysql_function = 'mysqli';
-	
 		$db_config = kConf::get( "reports_db_config" );
-		
-		if($mysql_function == 'mysql') $db_selected =  mysql_select_db ( $db_config["db_name"] , $link );
-		else $db_selected =  mysqli_select_db ( $link , $db_config["db_name"] );
+		$db_selected =  mysqli_select_db ( $link , $db_config["db_name"] );
 		
 		$error_function = $mysql_function.'_error';
 		if (!$db_selected) {


### PR DESCRIPTION
- If mysqli_connect() failed, throw an exception, no point in returning $link
- If mysqli_select_db() failed, throw with a coherent message