### PR TITLE
PLAT-7663: shouldn't use recorderLengthInMsecs if entry is no longer …

### DIFF
--- a/api_v3/lib/types/entry/KalturaPlayableEntry.php
+++ b/api_v3/lib/types/entry/KalturaPlayableEntry.php
@@ -111,7 +111,7 @@ class KalturaPlayableEntry extends KalturaBaseEntry
 	{
 		parent::doFromObject($sourceObject, $responseProfile);
 		$recordedLengthInMs = $sourceObject->getRecordedLengthInMsecs();
-		if ($sourceObject->getIsRecordedEntry() && $recordedLengthInMs > 0)
+		if ($sourceObject->getIsRecordedEntry() && $recordedLengthInMs > 0 && myEntryUtils::shouldServeVodFromLive($sourceObject))
 		{
 			$this->msDuration = $recordedLengthInMs;
 			$this->duration = (int)round($recordedLengthInMs / 1000);


### PR DESCRIPTION
…served from live