### PR TITLE
Broken Apache config

### DIFF
--- a/configurations/apache/conf.d/apps.conf.template
+++ b/configurations/apache/conf.d/apps.conf.template
@@ -38,7 +38,7 @@ Alias /apps "@BASE_DIR@/apps"
 Alias /apps/kea "@BASE_DIR@/apps/kea"
 <Directory "@BASE_DIR@/apps/kea">
     DirectoryIndex index.php
-    Options ExecCGI -Indexes FollowSymLinks Includes
+    Options -Indexes +FollowSymLinks +Includes
     Order allow,deny
     Allow from all
     AllowOverride all


### PR DESCRIPTION
In Apache >= 2.4, this will result in a fatal error:
AH00526: Syntax error on line 41 of
/etc/apache2/sites-enabled/apps.conf:
Either all Options must start with + or -, or no Option may.

Also, you do not need ExecCGI for KEA [or anything else here for that
matter].