### PR TITLE
sphinx_log.type is missing from the schema creation

### DIFF
--- a/deployment/base/sql/01.kaltura_sphinx_ce_tables.sql
+++ b/deployment/base/sql/01.kaltura_sphinx_ce_tables.sql
@@ -10,6 +10,7 @@ CREATE TABLE IF NOT EXISTS `sphinx_log` (
   `dc` int(11) DEFAULT NULL,
   `sql` longtext,
   `created_at` datetime DEFAULT NULL,
+  `type` int(11) DEFAULT NULL,
   PRIMARY KEY (`id`),
   KEY `entry_id` (`entry_id`),
   KEY `creatd_at` (`created_at`),


### PR DESCRIPTION
sphinx_log.type was was added to updates here deployment/updates/sql/2017_05_15_add_type_column_sphinx_log.sql on
2017_05_15 but was not added to the schema creation.

Currently this breaks the upload process, resulting in:
[BasePeer::doInsert] ERR: Exception: SQLSTATE[42S22]: Column not found:
1054 Unknown column 'TYPE' in 'field list' in
/opt/kaltura/app/infra/log/KalturaLog.php:83