### PR TITLE
PHP Strict Standards

### DIFF
--- a/plugins/bulk_upload/xml/batch/BulkUploadEngineXml.php
+++ b/plugins/bulk_upload/xml/batch/BulkUploadEngineXml.php
@@ -2371,7 +2371,7 @@ class BulkUploadEngineXml extends KBulkUploadEngine
 		return $bulkUploadResult;
 	}
 	
-	protected function updateObjectsResults($requestResults, $bulkUploadResults)
+	protected function updateObjectsResults(array $requestResults, array $bulkUploadResults)
 	{
 	    KBatchBase::$kClient->startMultiRequest();
 		KalturaLog::info("Updating " . count($requestResults) . " results");


### PR DESCRIPTION
Declaration of BulkUploadEngineXml::updateObjectsResults() should be compatible with
KBulkUploadEngine::updateObjectsResults(array $requestResults, array
$bulkUploadResults)