### PR TITLE
Change input element storagePassword back to 'text'

### DIFF
--- a/admin_console/forms/Partner/StorageConfiguration.php
+++ b/admin_console/forms/Partner/StorageConfiguration.php
@@ -34,7 +34,7 @@ class Form_Partner_StorageConfiguration extends Form_Partner_BaseStorageConfigur
 		));
 		$this->addElementToDisplayGroup('storage_info', 'storageUsername');
 		 
-		$this->addElement('password', 'storagePassword', array(
+		$this->addElement('text', 'storagePassword', array(
 			'label'			=> 'Storage Password:',
 			'filters'		=> array('StringTrim'),
 		));


### PR DESCRIPTION
While storagePassword should be of type password, it currently causes a
bug when the frmStorageConfig form [Form_Partner_StorageConfiguration]
is used in update context.

Flow:
When the form is loaded, text input elements are auto populated with the
existing properties of the StorageProfile object but password elements
are not. Therefore, upon saving, unless a password was inputted,
storageProfile->update() gets an empty string as password and the record
is updated accordingly.

This can be solved by explicitly updating the storagePassword element so
that, while the user will not be able to see the current password, it
will still be passed to the update() method. Regardless, I think empty
passwords should not be allowed here and that this should be validated on both
client and server sides.