### PR TITLE
KMS15412: fix FPDF constructors for php7 support

### DIFF
--- a/infra/general/PdfGenerator.php
+++ b/infra/general/PdfGenerator.php
@@ -39,7 +39,7 @@ class PdfGenerator extends FPDF
                                 $unit='mm', $size='A4')
     {
 
-        $this->FPDF($orientation,$unit,$size);
+        parent::__construct($orientation,$unit,$size);
 
         if (isset($sig) && is_string($sig))
         {

--- a/vendor/fpdf/fpdf.php
+++ b/vendor/fpdf/fpdf.php
@@ -73,7 +73,7 @@ var $PDFVersion;         // PDF version number
 *                               Public methods                                 *
 *                                                                              *
 *******************************************************************************/
-function FPDF($orientation='P', $unit='mm', $size='A4')
+function __construct($orientation='P', $unit='mm', $size='A4')
 {
 	// Some checks
 	$this->_dochecks();


### PR DESCRIPTION
Methods with the same name as their class will not be constructors in a future version of PHP