### PR TITLE
fix bugs introduced by custom reports changes

### DIFF
--- a/alpha/apps/kaltura/lib/reports/kKavaReportsMgr.class.php
+++ b/alpha/apps/kaltura/lib/reports/kKavaReportsMgr.class.php
@@ -1003,17 +1003,18 @@ class kKavaReportsMgr extends kKavaBase
 			$dimension = array($dimension);
 		}
 
-		reset($dimension);
+		$first_dim = reset($dimension);
 		$row_mapping = array();
 		foreach ($dimension_headers as $dim_header)
 		{
 			if (in_array($dim_header, $enriched_fields))
 			{
-				$row_mapping[] = null;		// a placeholder that will be replaced during enrichment
+				$row_mapping[] = $first_dim;		// a placeholder that will be replaced during enrichment
 			}
 			else
 			{
-				$row_mapping[] = current($dimension);
+				$current_dim = current($dimension);
+				$row_mapping[] = $current_dim ? $current_dim : $first_dim;
 				next($dimension);
 			}
 		}


### PR DESCRIPTION
- use the first dim instead of null for enriched dims, report type 12 has the entry name as first dimension, without entry id
- use the first dim when the dimensions arrays is exhausted - required for report type 6, which has object_id and domain_name as dimensions (both should get the domain name)