### PR TITLE
fix playkit config namespace and setup

### DIFF
--- a/alpha/apps/kaltura/modules/extwidget/actions/embedPlaykitJsAction.class.php
+++ b/alpha/apps/kaltura/modules/extwidget/actions/embedPlaykitJsAction.class.php
@@ -150,11 +150,11 @@ class embedPlaykitJsAction extends sfAction
 		// Default Kaltura CDN url:
 		$cdnUrl = requestUtils::getCdnHost($protocol);
 		// Default Stats URL
-		$statsServiceUrl = ($protocol == "https") ? $this->buildUrl($protocol,"stats_host_https") : $this->buildUrl($protocol,"stats_host");
+		$statsServiceUrl = $this->buildUrl($protocol,"stats_host");
 		// Default Live Stats URL
-		$liveStatsServiceUrl = ($protocol == "https") ? $this->buildUrl($protocol,"live_stats_host_https") : $this->buildUrl($protocol,"live_stats_host");
+		$liveStatsServiceUrl = $this->buildUrl($protocol,"live_stats_host");
 		// Default Kaltura Analytics URL
-		$analyticsServiceUrl = ($protocol == "https") ? $this->buildUrl($protocol,"analytics_host_https") : $this->buildUrl($protocol,"analytics_host");
+		$analyticsServiceUrl = $this->buildUrl($protocol,"analytics_host");
 		// Get Kaltura Supported API Features
 		$apiFeatures = $this->getFromConfig('features');
 
@@ -179,6 +179,10 @@ class embedPlaykitJsAction extends sfAction
 
 	private function buildUrl($protocol, $key)
 	{
+	    if ($protocol == "https")
+	    {
+	        $key .= "_https";
+	    }
 		$configValue = $this->getFromConfig($key);
 		$port = (($_SERVER['SERVER_PORT']) != '80' && $_SERVER['SERVER_PORT'] != '443')?':'.$_SERVER['SERVER_PORT']:'';
 		if( $key && $configValue)

--- a/alpha/apps/kaltura/modules/extwidget/actions/embedPlaykitJsAction.class.php
+++ b/alpha/apps/kaltura/modules/extwidget/actions/embedPlaykitJsAction.class.php
@@ -159,12 +159,12 @@ class embedPlaykitJsAction extends sfAction
 		$apiFeatures = $this->getFromConfig('features');
 
 		$envConfig = array(
-			"ServiceUrl" => $serviceUrl,
-			"CDNUrl" => $cdnUrl,
-			"StatsServiceUrl" => $statsServiceUrl,
-			"LiveStatsServiceUrl" => $liveStatsServiceUrl,
-			"AnalyticsServiceUrl" => $analyticsServiceUrl,
-			"ApiFeatures" => $apiFeatures
+			"serviceUrl" => $serviceUrl,
+			"cdnUrl" => $cdnUrl,
+			"statsServiceUrl" => $statsServiceUrl,
+			"liveStatsServiceUrl" => $liveStatsServiceUrl,
+			"analyticsServiceUrl" => $analyticsServiceUrl,
+			"apiFeatures" => $apiFeatures
 		);
 		return $envConfig;
 	}


### PR DESCRIPTION
Tidy up the kaltura player configuration:
- set a namespace under window object `window. __kalturaplayerdata`
- fix uiconf object to get a proper uiconf key and simplify object nesting from
```javascript
UIConf[1234] = {config: {...}}
```
to 
```javascript
UIConf[1234] = {...}
```

I think 13.8.0 is already on freeze, but opening this already to get review