### PR TITLE
live reports csv - support kava

### DIFF
--- a/api_v3/lib/types/liveReports/WSLiveReportsClient.class.php
+++ b/api_v3/lib/types/liveReports/WSLiveReportsClient.class.php
@@ -81,6 +81,7 @@ class WSLiveReportsClient extends nusoap_client
 		$soapAction = '';
 		$headers = array();
 		$headers["KALTURA_SESSION_ID"] = (string)(new UniqueId());
+		$this->setDebugLevel(0);
 		
 		$result = $this->call($operation, $params, $namespace, $soapAction, $headers);
 		$this->throwError($result);

--- a/api_v3/services/LiveReportsService.php
+++ b/api_v3/services/LiveReportsService.php
@@ -88,7 +88,7 @@ class LiveReportsService extends KalturaBaseService
 		
 		try
 		{
-			$items = call_user_func(array('kKavaLiveReportsMgr', $methodName), $this->getPartnerId(), $filter);
+			$items = call_user_func(array('kKavaLiveReportsMgr', $methodName), $this->getPartnerId(), $filter, $pager->pageSize);
 		}
 		catch (kKavaNoResultsException $e)
 		{
@@ -208,6 +208,8 @@ class LiveReportsService extends KalturaBaseService
 			return $this->getReportKava($reportType, $filter, $pager);			
 		}
 		
+		ini_set('memory_limit', '700M');
+
 		$client = new WSLiveReportsClient();
 		$wsFilter = $filter->getWSObject();
 		$wsFilter->partnerId = kCurrentContext::getCurrentPartnerId();


### PR DESCRIPTION
avoid using a pager
- increase request limit to 10k
- use smaller chunks (5 min)
- disable nu soap debug (to reduce mem usage)
- increase memory limit