### PR TITLE
Remove protocol from DeliveryProfile url

### DIFF
--- a/deployment/base/scripts/init_data/07.DeliveryProfileAkamaiAppleHttpDirect.template.ini
+++ b/deployment/base/scripts/init_data/07.DeliveryProfileAkamaiAppleHttpDirect.template.ini
@@ -9,4 +9,4 @@ streamerType=applehttp
 isDefault=0
 parentId=0
 status=0
-url="http://@WWW_HOST@"
+url="@WWW_HOST@"

--- a/deployment/base/scripts/init_data/07.DeliveryProfileAkamaiHttp.template.ini
+++ b/deployment/base/scripts/init_data/07.DeliveryProfileAkamaiHttp.template.ini
@@ -9,4 +9,4 @@ streamerType=http
 isDefault=1
 parentId=0
 status=0
-url="http://@WWW_HOST@"
+url="@WWW_HOST@"

--- a/deployment/base/scripts/init_data/07.DeliveryProfileLivePackagerDash.template.ini
+++ b/deployment/base/scripts/init_data/07.DeliveryProfileLivePackagerDash.template.ini
@@ -8,4 +8,4 @@ streamerType=mpegdash
 isDefault=1
 parentId=0
 status=0
-url="http://@LIVE_PACKAGER_HOST@:@LIVE_PACKAGER_PORT@/live/dash"
+url="@LIVE_PACKAGER_HOST@:@LIVE_PACKAGER_PORT@/live/dash"

--- a/deployment/base/scripts/init_data/07.DeliveryProfileLivePackagerHds.template.ini
+++ b/deployment/base/scripts/init_data/07.DeliveryProfileLivePackagerHds.template.ini
@@ -8,4 +8,4 @@ streamerType=hds
 isDefault=1
 parentId=0
 status=0
-url="http://@LIVE_PACKAGER_HOST@:@LIVE_PACKAGER_PORT@/live/hds"
+url="@LIVE_PACKAGER_HOST@:@LIVE_PACKAGER_PORT@/live/hds"

--- a/deployment/base/scripts/init_data/07.DeliveryProfileLivePackagerHls.template.ini
+++ b/deployment/base/scripts/init_data/07.DeliveryProfileLivePackagerHls.template.ini
@@ -8,4 +8,4 @@ streamerType=applehttp
 isDefault=1
 parentId=0
 status=0
-url="http://@LIVE_PACKAGER_HOST@:@LIVE_PACKAGER_PORT@/live/hls"
+url="@LIVE_PACKAGER_HOST@:@LIVE_PACKAGER_PORT@/live/hls"

--- a/deployment/base/scripts/init_data/07.DeliveryProfileLivePackagerMss.template.ini
+++ b/deployment/base/scripts/init_data/07.DeliveryProfileLivePackagerMss.template.ini
@@ -8,4 +8,4 @@ streamerType=sl
 isDefault=1
 parentId=0
 status=0
-url="http://@LIVE_PACKAGER_HOST@:@LIVE_PACKAGER_PORT@/live/mss"
+url="@LIVE_PACKAGER_HOST@:@LIVE_PACKAGER_PORT@/live/mss"

--- a/deployment/base/scripts/init_data/07.DeliveryProfileVodPackagerDash.template.ini
+++ b/deployment/base/scripts/init_data/07.DeliveryProfileVodPackagerDash.template.ini
@@ -9,4 +9,4 @@ streamerType=mpegdash
 isDefault=1
 parentId=0
 status=0
-url="http://@VOD_PACKAGER_HOST@:@VOD_PACKAGER_PORT@/dash"
+url="@VOD_PACKAGER_HOST@:@VOD_PACKAGER_PORT@/dash"

--- a/deployment/base/scripts/init_data/07.DeliveryProfileVodPackagerHds.template.ini
+++ b/deployment/base/scripts/init_data/07.DeliveryProfileVodPackagerHds.template.ini
@@ -9,4 +9,4 @@ streamerType=hdnetworkmanifest
 isDefault=1
 parentId=0
 status=0
-url="http://@VOD_PACKAGER_HOST@:@VOD_PACKAGER_PORT@/hds"
+url="@VOD_PACKAGER_HOST@:@VOD_PACKAGER_PORT@/hds"

--- a/deployment/base/scripts/init_data/07.DeliveryProfileVodPackagerHls.template.ini
+++ b/deployment/base/scripts/init_data/07.DeliveryProfileVodPackagerHls.template.ini
@@ -9,4 +9,4 @@ streamerType=applehttp
 isDefault=1
 parentId=0
 status=0
-url="http://@VOD_PACKAGER_HOST@:@VOD_PACKAGER_PORT@/hls"
+url="@VOD_PACKAGER_HOST@:@VOD_PACKAGER_PORT@/hls"


### PR DESCRIPTION
It is overridden anyhow as the protocol is dynamically determined based
on what was passed to playManifest. So this is just confusing...