### PR TITLE
fix deletion of caption file syncs

### DIFF
--- a/plugins/content/caption/search/lib/kCaptionSearchFlowManager.php
+++ b/plugins/content/caption/search/lib/kCaptionSearchFlowManager.php
@@ -137,6 +137,7 @@ class kCaptionSearchFlowManager implements kObjectDataChangedEventConsumer, kObj
 		$entry->setUpdatedAt(time());
 		$entry->save();
 		$entry->indexToSearchIndex();
+		return true;
 	}
 
 	/* (non-PHPdoc)


### PR DESCRIPTION
objectDeleted has to return true, otherwise the events manager considers the event as paused, and does not relay it to subsequent consumers