### PR TITLE
kava live - city coordinates fix (SUP-13330)

### DIFF
--- a/alpha/apps/kaltura/lib/reports/kKavaLiveReportsMgr.class.php
+++ b/alpha/apps/kaltura/lib/reports/kKavaLiveReportsMgr.class.php
@@ -15,6 +15,7 @@ class kKavaLiveReportsMgr extends kKavaBase
 	const OUTPUT_ENTRY_ID = 'entryId';
 	const OUTPUT_TIMESTAMP = 'timestamp';
 	const OUTPUT_CITY_NAME = 'cityName';
+	const OUTPUT_REGION_NAME = 'regionName';
 	const OUTPUT_COUNTRY_NAME = 'countryName';
 	const OUTPUT_SEC_VIEWED = 'secondsViewed';
 	const OUTPUT_AUDIENCE = 'audience';
@@ -423,6 +424,7 @@ class kKavaLiveReportsMgr extends kKavaBase
 		$dimensions = array(
 			self::DIMENSION_ENTRY_ID => self::OUTPUT_ENTRY_ID,
 			self::DIMENSION_LOCATION_CITY => self::OUTPUT_CITY_NAME,
+			self::DIMENSION_LOCATION_REGION => self::OUTPUT_REGION_NAME,
 			self::DIMENSION_LOCATION_COUNTRY => self::OUTPUT_COUNTRY_NAME,
 		);
 

--- a/alpha/scripts/utils/loadGeoCoordinates.php
+++ b/alpha/scripts/utils/loadGeoCoordinates.php
@@ -22,7 +22,7 @@ function loadFile($fileName, $keyCount, $cache)
 			break;
 		}
 		
-		if (count($data) != $keyCount + 2 || in_array('-', $data))
+		if (count($data) < $keyCount + 2 || in_array('-', $data))
 		{
 			continue;
 		}
@@ -30,7 +30,7 @@ function loadFile($fileName, $keyCount, $cache)
 		$key = array_slice($data, 0, $keyCount);
 		$key = 'coord_' . normalizeKey(implode('_', $key));
 		
-		$value = array_slice($data, -2);
+		$value = array_slice($data, $keyCount, 2);
 		$value = implode('/', $value);
 
 		if (!$cache->set($key, $value))
@@ -57,5 +57,5 @@ if (!$cache->connect($argv[1], $argv[2]))
 }
 
 loadFile("countriesCoordinates.txt", 1, $cache);
-loadFile("citiesCoordinates.txt", 2, $cache);
+loadFile("citiesCoordinates.txt", 3, $cache);
 echo "done\n";

--- a/api_v3/services/LiveReportsService.php
+++ b/api_v3/services/LiveReportsService.php
@@ -48,7 +48,7 @@ class LiveReportsService extends KalturaBaseService
 		list($dest->latitude, $dest->longitude) = array_map('floatval', explode('/', $coords));
 	}
 	
-	protected function setGeoCoordinates($item, $countryName, $cityName)
+	protected function setGeoCoordinates($item, $countryName, $regionName, $cityName)
 	{
 		$item->country = new KalturaCoordinate();
 		$item->country->name = strtoupper($countryName);
@@ -56,7 +56,7 @@ class LiveReportsService extends KalturaBaseService
 
 		$item->city = new KalturaCoordinate();
 		$item->city->name = strtoupper($cityName);
-		$this->getCoordinates($item->city, $countryName . '_' . $cityName);
+		$this->getCoordinates($item->city, $countryName . '_' . $regionName . '_' . $cityName);
 	}
 	
 	protected function getReportKava($reportType,
@@ -103,10 +103,13 @@ class LiveReportsService extends KalturaBaseService
 				$countryName = $item->countryName;
 				unset($item->countryName);
 				
+				$regionName = $item->regionName;
+				unset($item->regionName);
+
 				$cityName = $item->cityName;
 				unset($item->cityName);
-								
-				$this->setGeoCoordinates($item, $countryName, $cityName);
+
+				$this->setGeoCoordinates($item, $countryName, $regionName, $cityName);
 			}
 		}
 		


### PR DESCRIPTION
city+country is not unique enough in order to find geo coordinates.
there can be several cities with the same name in the same country.
need to use the region as well.