### PR TITLE
uiconf->get() requires a KS

### DIFF
--- a/api_v3/services/UiConfService.php
+++ b/api_v3/services/UiConfService.php
@@ -100,7 +100,6 @@ class UiConfService extends KalturaBaseService
 	 * @action get
 	 * @param int $id 
 	 * @return KalturaUiConf
-	 * @ksIgnored
 	 *
 	 * @throws APIErrors::INVALID_UI_CONF_ID
 	 */		


### PR DESCRIPTION
When no KS is passed, INVALID_UI_CONF_ID will be thrown.