### PR TITLE
Shuffle the $deliveryNodes array to randomize the assigned KES

### DIFF
--- a/alpha/lib/model/DeliveryProfile.php
+++ b/alpha/lib/model/DeliveryProfile.php
@@ -477,7 +477,10 @@ abstract class DeliveryProfile extends BaseDeliveryProfile implements IBaseObjec
 			KalturaLog::debug("No active delivery nodes found among the requested edge list: " . print_r($deliveryNodeIds, true));
 			return null;
 		}
-		
+	
+	        /* Shuffle the array to randomize the assigned KES, if more than one in the same rule */
+		shuffle($deliveryNodes);
+	
 		$deliveryNode = null;
 		foreach ($deliveryNodes as $node)
 		{


### PR DESCRIPTION
When more than one KES is assigned as primary, you will always get only the first one. This allows to randomize the $deliveryNodes array and eventually get different KES.

In some cases, you want to have more than one KES assigned and you usually need to use the same playback domain for all of them and then create a DNS round robin for it. This change, although its not round robin, will allow some balancing between nodes.

Thanks,