### PR TITLE
temporarily revert kava contrib reports

### DIFF
--- a/api_v3/services/ReportService.php
+++ b/api_v3/services/ReportService.php
@@ -24,8 +24,6 @@ class ReportService extends KalturaBaseService
 		KalturaReportType::LIVE,
 		KalturaReportType::TOP_PLAYBACK_CONTEXT,
 		KalturaReportType::VPAAS_USAGE,
-		KalturaReportType::TOP_CONTRIBUTORS,
-		KalturaReportType::CONTENT_CONTRIBUTIONS,
 	);
 
 	public function initService($serviceId, $serviceName, $actionName)
@@ -70,6 +68,9 @@ class ReportService extends KalturaBaseService
 		
 		$stmt = PartnerPeer::doSelectStmt($c);
 		$partnerIds = $stmt->fetchAll(PDO::FETCH_COLUMN);
+		if (!$partnerIds)
+			return Partner::PARTNER_THAT_DOWS_NOT_EXIST;
+
 		return implode(',', $partnerIds); 
 	}
 		


### PR DESCRIPTION
also fixed - when sending invalid partner id to partner usage/var usage reports, it returned the usage of all partners