### PR TITLE
fix PHP Strict Standards

### DIFF
--- a/alpha/apps/kaltura/modules/extwidget/actions/embedPlaykitJsAction.class.php
+++ b/alpha/apps/kaltura/modules/extwidget/actions/embedPlaykitJsAction.class.php
@@ -447,6 +447,9 @@ class embedPlaykitJsAction extends sfAction
 		if (!$this->uiConf)
 			KExternalErrors::dieError(KExternalErrors::UI_CONF_NOT_FOUND);
 		$this->playerConfig = json_decode($this->uiConf->getConfig());
+		if (!$this->playerConfig) {
+			$this->playerConfig = new stdClass();
+		}
 		$this->uiConfUpdatedAt = $this->uiConf->getUpdatedAt(null);
 		
 		//Get bundle configuration stored in conf_vars


### PR DESCRIPTION
set `playerConfig` as empty object is it doesn't exist