### PR TITLE
Use OpenSSL functions if mcrypt is not available

### DIFF
--- a/alpha/apps/kaltura/lib/myPartnerRegistration.class.php
+++ b/alpha/apps/kaltura/lib/myPartnerRegistration.class.php
@@ -177,13 +177,9 @@ class myPartnerRegistration
 	 */
 	private function createNewPartner( $partner_name , $contact, $email, $ID_is_for, $SDK_terms_agreement, $description, $website_url , $password = null , $newPartner = null, $templatePartnerId = null )
 	{
-		if (function_exists('mcrypt_create_iv')) {
-		    $secret = md5(mcrypt_create_iv(16,MCRYPT_DEV_URANDOM));
-		    $admin_secret = md5(mcrypt_create_iv(16,MCRYPT_DEV_URANDOM));
-		}else{
-		    $secret = md5(openssl_random_pseudo_bytes(16));
-		    $admin_secret = md5(openssl_random_pseudo_bytes(16));
-		}
+		$myCryptor=KCryptoWrapper::getEncryptor();
+		$secret = md5($myCryptor::random_pseudo_bytes(16));
+		$admin_secret = md5($myCryptor::random_pseudo_bytes(16));
 
 		if (!$newPartner)
 			$newPartner = new Partner();

--- a/alpha/apps/kaltura/lib/myPartnerRegistration.class.php
+++ b/alpha/apps/kaltura/lib/myPartnerRegistration.class.php
@@ -177,9 +177,9 @@ class myPartnerRegistration
 	 */
 	private function createNewPartner( $partner_name , $contact, $email, $ID_is_for, $SDK_terms_agreement, $description, $website_url , $password = null , $newPartner = null, $templatePartnerId = null )
 	{
-		$myCryptor=KCryptoWrapper::getEncryptor();
-		$secret = md5($myCryptor::random_pseudo_bytes(16));
-		$admin_secret = md5($myCryptor::random_pseudo_bytes(16));
+		$kCrypto = KCryptoWrapper::getEncryptor();
+		$secret = md5($kCrypto::random_pseudo_bytes(16));
+		$admin_secret = md5($kCrypto::random_pseudo_bytes(16));
 
 		if (!$newPartner)
 			$newPartner = new Partner();

--- a/alpha/apps/kaltura/lib/myPartnerRegistration.class.php
+++ b/alpha/apps/kaltura/lib/myPartnerRegistration.class.php
@@ -177,8 +177,13 @@ class myPartnerRegistration
 	 */
 	private function createNewPartner( $partner_name , $contact, $email, $ID_is_for, $SDK_terms_agreement, $description, $website_url , $password = null , $newPartner = null, $templatePartnerId = null )
 	{
-		$secret = md5(mcrypt_create_iv(16,MCRYPT_DEV_URANDOM));
-		$admin_secret = md5(mcrypt_create_iv(16,MCRYPT_DEV_URANDOM));
+		if (function_exists('mcrypt_create_iv')) {
+		    $secret = md5(mcrypt_create_iv(16,MCRYPT_DEV_URANDOM));
+		    $admin_secret = md5(mcrypt_create_iv(16,MCRYPT_DEV_URANDOM));
+		}else{
+		    $secret = md5(openssl_random_pseudo_bytes(16, true));
+		    $admin_secret = md5(openssl_random_pseudo_bytes(16, true));
+		}
 
 		if (!$newPartner)
 			$newPartner = new Partner();

--- a/alpha/apps/kaltura/lib/myPartnerRegistration.class.php
+++ b/alpha/apps/kaltura/lib/myPartnerRegistration.class.php
@@ -181,8 +181,8 @@ class myPartnerRegistration
 		    $secret = md5(mcrypt_create_iv(16,MCRYPT_DEV_URANDOM));
 		    $admin_secret = md5(mcrypt_create_iv(16,MCRYPT_DEV_URANDOM));
 		}else{
-		    $secret = md5(openssl_random_pseudo_bytes(16, true));
-		    $admin_secret = md5(openssl_random_pseudo_bytes(16, true));
+		    $secret = md5(openssl_random_pseudo_bytes(16));
+		    $admin_secret = md5(openssl_random_pseudo_bytes(16));
 		}
 
 		if (!$newPartner)

--- a/alpha/apps/kaltura/lib/myPartnerRegistration.class.php
+++ b/alpha/apps/kaltura/lib/myPartnerRegistration.class.php
@@ -177,9 +177,8 @@ class myPartnerRegistration
 	 */
 	private function createNewPartner( $partner_name , $contact, $email, $ID_is_for, $SDK_terms_agreement, $description, $website_url , $password = null , $newPartner = null, $templatePartnerId = null )
 	{
-		$kCrypto = KCryptoWrapper::getEncryptor();
-		$secret = md5($kCrypto::random_pseudo_bytes(16));
-		$admin_secret = md5($kCrypto::random_pseudo_bytes(16));
+		$secret = md5(KCryptoWrapper::random_pseudo_bytes(16));
+		$admin_secret = md5(KCryptoWrapper::random_pseudo_bytes(16));
 
 		if (!$newPartner)
 			$newPartner = new Partner();

--- a/alpha/apps/kaltura/lib/myPartnerUtils.class.php
+++ b/alpha/apps/kaltura/lib/myPartnerUtils.class.php
@@ -756,8 +756,7 @@ class myPartnerUtils
 		$partner = PartnerPeer::retrieveByPK( $partner_id );
 		if ( !$partner ) return null;
 		
-		$kCrypto = KCryptoWrapper::getEncryptor();
-		$encrypted_data = $kCrypto::encrypt_3des($partner_id, $key);	
+		$encrypted_data = KCryptoWrapper::encrypt_3des($partner_id, $key);	
 		return $token_prefix . base64_encode( $encrypted_data );
 	}
 	

--- a/alpha/apps/kaltura/lib/myPartnerUtils.class.php
+++ b/alpha/apps/kaltura/lib/myPartnerUtils.class.php
@@ -756,8 +756,8 @@ class myPartnerUtils
 		$partner = PartnerPeer::retrieveByPK( $partner_id );
 		if ( !$partner ) return null;
 		
-		$myCryptor=KCryptoWrapper::getEncryptor();
-		$encrypted_data=$myCryptor::encrypt_3des($partner_id,$key);	
+		$kCrypto = KCryptoWrapper::getEncryptor();
+		$encrypted_data = $kCrypto::encrypt_3des($partner_id, $key);	
 		return $token_prefix . base64_encode( $encrypted_data );
 	}
 	

--- a/alpha/apps/kaltura/lib/myPartnerUtils.class.php
+++ b/alpha/apps/kaltura/lib/myPartnerUtils.class.php
@@ -756,14 +756,16 @@ class myPartnerUtils
 		$partner = PartnerPeer::retrieveByPK( $partner_id );
 		if ( !$partner ) return null;
 		
-		$input = $partner_id;
-
-	    $td = mcrypt_module_open('tripledes', '', 'ecb', '');
-	    $iv = mcrypt_create_iv (mcrypt_enc_get_iv_size($td), MCRYPT_RAND);
-	    mcrypt_generic_init($td, $key, $iv);
-	    $encrypted_data = mcrypt_generic($td, $input);
-	    mcrypt_generic_deinit($td);
-	    mcrypt_module_close($td);
+		if (function_exists('mcrypt_generic_init')) {
+		    $td = mcrypt_module_open('tripledes', '', 'ecb', '');
+		    $iv = mcrypt_create_iv (mcrypt_enc_get_iv_size($td), MCRYPT_RAND);
+		    mcrypt_generic_init($td, $key, $iv);
+		    $encrypted_data = mcrypt_generic($td, $partner_id);
+		    mcrypt_generic_deinit($td);
+		    mcrypt_module_close($td);
+		}else{
+		    $encrypted_data=openssl_encrypt($partner_id,'AES-128-ECB',$key);
+		}
 		
 		return $token_prefix . base64_encode( $encrypted_data );
 	}

--- a/alpha/apps/kaltura/lib/myPartnerUtils.class.php
+++ b/alpha/apps/kaltura/lib/myPartnerUtils.class.php
@@ -756,15 +756,25 @@ class myPartnerUtils
 		$partner = PartnerPeer::retrieveByPK( $partner_id );
 		if ( !$partner ) return null;
 		
+		$input = $partner_id;
 		if (function_exists('mcrypt_generic_init')) {
 		    $td = mcrypt_module_open('tripledes', '', 'ecb', '');
 		    $iv = mcrypt_create_iv (mcrypt_enc_get_iv_size($td), MCRYPT_RAND);
 		    mcrypt_generic_init($td, $key, $iv);
-		    $encrypted_data = mcrypt_generic($td, $partner_id);
+		    $encrypted_data = mcrypt_generic($td, $input);
 		    mcrypt_generic_deinit($td);
 		    mcrypt_module_close($td);
 		}else{
-		    $encrypted_data=openssl_encrypt($partner_id,'AES-128-ECB',$key);
+		    $blockSize = 16;
+		    $padLength = $blockSize - strlen($input) % $blockSize;
+		    $input .= str_repeat(chr(0), $padLength);
+		    $encrypted_data=openssl_encrypt(
+			    $input,
+			    'DES-EDE3',
+			    $key,
+			    OPENSSL_RAW_DATA | OPENSSL_ZERO_PADDING
+			    
+		    );
 		}
 		
 		return $token_prefix . base64_encode( $encrypted_data );

--- a/alpha/apps/kaltura/lib/myPartnerUtils.class.php
+++ b/alpha/apps/kaltura/lib/myPartnerUtils.class.php
@@ -757,7 +757,7 @@ class myPartnerUtils
 		if ( !$partner ) return null;
 		
 		$input = $partner_id;
-		if (function_exists('mcrypt_generic_init')) {
+		if (extension_loaded('mcrypt')) {
 		    $td = mcrypt_module_open('tripledes', '', 'ecb', '');
 		    $iv = mcrypt_create_iv (mcrypt_enc_get_iv_size($td), MCRYPT_RAND);
 		    mcrypt_generic_init($td, $key, $iv);

--- a/alpha/apps/kaltura/lib/myPartnerUtils.class.php
+++ b/alpha/apps/kaltura/lib/myPartnerUtils.class.php
@@ -756,27 +756,8 @@ class myPartnerUtils
 		$partner = PartnerPeer::retrieveByPK( $partner_id );
 		if ( !$partner ) return null;
 		
-		$input = $partner_id;
-		if (extension_loaded('mcrypt')) {
-		    $td = mcrypt_module_open('tripledes', '', 'ecb', '');
-		    $iv = mcrypt_create_iv (mcrypt_enc_get_iv_size($td), MCRYPT_RAND);
-		    mcrypt_generic_init($td, $key, $iv);
-		    $encrypted_data = mcrypt_generic($td, $input);
-		    mcrypt_generic_deinit($td);
-		    mcrypt_module_close($td);
-		}else{
-		    $blockSize = 16;
-		    $padLength = $blockSize - strlen($input) % $blockSize;
-		    $input .= str_repeat(chr(0), $padLength);
-		    $encrypted_data=openssl_encrypt(
-			    $input,
-			    'DES-EDE3',
-			    $key,
-			    OPENSSL_RAW_DATA | OPENSSL_ZERO_PADDING
-			    
-		    );
-		}
-		
+		$myCryptor=KCryptoWrapper::getEncryptor();
+		$encrypted_data=$myCryptor::encrypt_3des($partner_id,$key);	
 		return $token_prefix . base64_encode( $encrypted_data );
 	}
 	

--- a/alpha/apps/kaltura/lib/request/kSessionBase.class.php
+++ b/alpha/apps/kaltura/lib/request/kSessionBase.class.php
@@ -7,6 +7,7 @@
  */
 require_once(dirname(__FILE__) . '/infraRequestUtils.class.php');
 require_once(dirname(__FILE__) . '/../cache/kCacheManager.php');
+require_once(dirname(__FILE__) . '/../../../../../infra/general/KCryptoWrapper.class.php');
 
 /** 
  * @package server-infra

--- a/alpha/apps/kaltura/lib/request/kSessionBase.class.php
+++ b/alpha/apps/kaltura/lib/request/kSessionBase.class.php
@@ -489,15 +489,15 @@ class kSessionBase
 	{
 		
 		$key = substr(sha1($key, true), 0, 16);
-		$myCryptor=KCryptoWrapper::getEncryptor();
-		return $myCryptor::encrypt_aes($message,$key, self::AES_IV);
+		$kCrypto = KCryptoWrapper::getEncryptor();
+		return $kCrypto::encrypt_aes($message, $key, self::AES_IV);
 	}
 
 	protected static function aesDecrypt($key, $message)
 	{
 		$key = substr(sha1($key, true), 0, 16);
-		$myCryptor=KCryptoWrapper::getEncryptor();
-		return $myCryptor::decrypt_aes($message,$key,self::AES_IV);
+		$kCrypto = KCryptoWrapper::getEncryptor();
+		return $kCrypto::decrypt_aes($message, $key, self::AES_IV);
 	}
 
 

--- a/alpha/apps/kaltura/lib/request/kSessionBase.class.php
+++ b/alpha/apps/kaltura/lib/request/kSessionBase.class.php
@@ -489,50 +489,15 @@ class kSessionBase
 	{
 		
 		$key = substr(sha1($key, true), 0, 16);
-		if (function_exists('mcrypt_encrypt')) {
-			return mcrypt_encrypt(
-				MCRYPT_RIJNDAEL_128,
-				$key,
-				$message,
-				MCRYPT_MODE_CBC,
-				self::AES_IV // no need for a real IV since we add a random string to the message anyway
-			);
-		}else {
-			// Pad with null byte to be compatible with mcrypt PKCS#5 padding
-		        // See http://thefsb.tumblr.com/post/110749271235/using-opensslendecrypt-in-php-instead-of as reference
-			$blockSize = 16;
-			$padLength = $blockSize - strlen($message) % $blockSize;
-			$message .= str_repeat(chr(0), $padLength);
-			return openssl_encrypt(
-				$message,
-				'AES-128-CBC',
-				$key,
-				OPENSSL_RAW_DATA | OPENSSL_ZERO_PADDING,
-				self::AES_IV
-			);
-		}
+		$myCryptor=KCryptoWrapper::getEncryptor();
+		return $myCryptor::encrypt_aes($message,$key, self::AES_IV);
 	}
 
 	protected static function aesDecrypt($key, $message)
 	{
-		if (function_exists('mcrypt_decrypt')) {
-		    return mcrypt_decrypt(
-			MCRYPT_RIJNDAEL_128,
-			substr(sha1($key, true), 0, 16),
-			$message,
-			MCRYPT_MODE_CBC, 
-			self::AES_IV
-		    );
-		}else{
-		    return openssl_decrypt(
-				$message,
-				'AES-128-CBC',
-				substr(sha1($key, true), 0, 16),
-				OPENSSL_RAW_DATA | OPENSSL_ZERO_PADDING,
-				self::AES_IV
-			);
-
-		}
+		$key = substr(sha1($key, true), 0, 16);
+		$myCryptor=KCryptoWrapper::getEncryptor();
+		return $myCryptor::decrypt_aes($message,$key,self::AES_IV);
 	}
 
 

--- a/alpha/apps/kaltura/lib/request/kSessionBase.class.php
+++ b/alpha/apps/kaltura/lib/request/kSessionBase.class.php
@@ -490,15 +490,13 @@ class kSessionBase
 	{
 		
 		$key = substr(sha1($key, true), 0, 16);
-		$kCrypto = KCryptoWrapper::getEncryptor();
-		return $kCrypto::encrypt_aes($message, $key, self::AES_IV);
+		return KCryptoWrapper::encrypt_aes($message, $key, self::AES_IV);
 	}
 
 	protected static function aesDecrypt($key, $message)
 	{
 		$key = substr(sha1($key, true), 0, 16);
-		$kCrypto = KCryptoWrapper::getEncryptor();
-		return $kCrypto::decrypt_aes($message, $key, self::AES_IV);
+		return KCryptoWrapper::decrypt_aes($message, $key, self::AES_IV);
 	}
 
 

--- a/alpha/apps/kaltura/lib/request/kSessionBase.class.php
+++ b/alpha/apps/kaltura/lib/request/kSessionBase.class.php
@@ -50,6 +50,9 @@ class kSessionBase
 	const PRIVILEGES_DELIMITER = "/";
 	const PRIVILEGE_DISABLE_PARTNER_CHANGE_ACCOUNT = "disablechangeaccount";
 	const PRIVILEGE_EDIT_USER = "edituser";
+	const PRIVILEGE_EDIT_ADMIN_TAGS = 'editadmintags';
+	const PRIVILEGE_RESTRICT_EXPLICIT_LIVE_VIEW = "restrictexplicitliveview";
+
 
 	const SECRETS_CACHE_PREFIX = 'partner_secrets_ksver_';
 	

--- a/alpha/apps/kaltura/modules/system/actions/helperAction.class.php
+++ b/alpha/apps/kaltura/modules/system/actions/helperAction.class.php
@@ -21,7 +21,6 @@ class helperAction extends kalturaSystemAction
 		$algo = $this->getP ( "algo" , "wiki_decode_no_serialize" );
 		$res = "";
 		$key = null;
-		$kCrypto = KCryptoWrapper::getEncryptor();
 		
 		if ( $algo == "wiki_encode" )
 		{
@@ -42,7 +41,7 @@ class helperAction extends kalturaSystemAction
 		elseif ( $algo == "base64_3des_encode" )
 		{
 			$key = $this->getP ( "des_key" );
-	    		$encrypted_data = $kCrypto::encrypt_3des($str, $key);
+			$encrypted_data = KCryptoWrapper::encrypt_3des($str, $key);
 	    
 			$res = base64_encode($encrypted_data)		;
 			$this->des_key = $key;
@@ -51,7 +50,7 @@ class helperAction extends kalturaSystemAction
 		{
 			$key = $this->getP ( "des_key" );
 			$input = base64_decode ( $str );
-	    		$decrypted_data = $kCrypto::decrypt_3des($input, $key);
+			$decrypted_data = KCryptoWrapper::decrypt_3des($input, $key);
 	    
 			$res = ($decrypted_data )		;
 			$this->des_key = $key;

--- a/alpha/apps/kaltura/modules/system/actions/helperAction.class.php
+++ b/alpha/apps/kaltura/modules/system/actions/helperAction.class.php
@@ -21,6 +21,7 @@ class helperAction extends kalturaSystemAction
 		$algo = $this->getP ( "algo" , "wiki_decode_no_serialize" );
 		$res = "";
 		$key = null;
+		$myCryptor=KCryptoWrapper::getEncryptor();
 		
 		if ( $algo == "wiki_encode" )
 		{
@@ -41,30 +42,8 @@ class helperAction extends kalturaSystemAction
 		elseif ( $algo == "base64_3des_encode" )
 		{
 			$key = $this->getP ( "des_key" );
-			$input = $str;
-			if (extension_loaded('mcrypt')) {
-				$td = mcrypt_module_open('tripledes', '', 'ecb', '');
-				$iv = mcrypt_create_iv (mcrypt_enc_get_iv_size($td), MCRYPT_RAND);
-		        	$key = substr($key, 0, mcrypt_enc_get_key_size($td));
-	    	
-				mcrypt_generic_init($td, $key, $iv);
-				$encrypted_data = mcrypt_generic($td, $input);
-				mcrypt_generic_deinit($td);
-				mcrypt_module_close($td);
+	    		$encrypted_data = $myCryptor::encrypt_3des($str, $key);
 	    
-			}else{
-				$blockSize = 16;
-				$padLength = $blockSize - strlen($input) % $blockSize;
-				$input .= str_repeat(chr(0), $padLength);
-				$encrypted_data=openssl_encrypt(
-					$input,
-					'DES-EDE3',
-					$key,
-					OPENSSL_RAW_DATA | OPENSSL_ZERO_PADDING
-					
-				);
-
-			}
 			$res = base64_encode($encrypted_data )		;
 			$this->des_key = $key;
 		}
@@ -72,24 +51,7 @@ class helperAction extends kalturaSystemAction
 		{
 			$key = $this->getP ( "des_key" );
 			$input = base64_decode ( $str );
-			if (extension_loaded('mcrypt')) {
-			    $td = mcrypt_module_open('tripledes', '', 'ecb', '');
-			    $iv = mcrypt_create_iv (mcrypt_enc_get_iv_size($td), MCRYPT_RAND);
-			    $key = substr($key, 0, mcrypt_enc_get_key_size($td));
-		    
-			    mcrypt_generic_init($td, $key, $iv);
-			    $decrypted_data = mdecrypt_generic($td, $input);
-			    mcrypt_generic_deinit($td);
-			    mcrypt_module_close($td);
-			}else{
-				$decrypted_data=openssl_decrypt(
-					$input,
-					'DES-EDE3',
-					$key,
-					OPENSSL_RAW_DATA | OPENSSL_ZERO_PADDING
-					
-				);
-			}
+	    		$decrypted_data = $myCryptor::decrypt_3des($input,$key);
 	    
 			$res = ($decrypted_data )		;
 			$this->des_key = $key;

--- a/alpha/apps/kaltura/modules/system/actions/helperAction.class.php
+++ b/alpha/apps/kaltura/modules/system/actions/helperAction.class.php
@@ -41,8 +41,30 @@ class helperAction extends kalturaSystemAction
 		elseif ( $algo == "base64_3des_encode" )
 		{
 			$key = $this->getP ( "des_key" );
-			$encrypted_data = openssl_encrypt($str,'DES-EDE3',$key,OPENSSL_RAW_DATA | OPENSSL_ZERO_PADDING);
+			$input = $str;
+			if (function_exists('mcrypt_generic_init')){
+				$td = mcrypt_module_open('tripledes', '', 'ecb', '');
+				$iv = mcrypt_create_iv (mcrypt_enc_get_iv_size($td), MCRYPT_RAND);
+		        	$key = substr($key, 0, mcrypt_enc_get_key_size($td));
+	    	
+				mcrypt_generic_init($td, $key, $iv);
+				$encrypted_data = mcrypt_generic($td, $input);
+				mcrypt_generic_deinit($td);
+				mcrypt_module_close($td);
 	    
+			}else{
+				$blockSize = 16;
+				$padLength = $blockSize - strlen($input) % $blockSize;
+				$input .= str_repeat(chr(0), $padLength);
+				$encrypted_data=openssl_encrypt(
+					$input,
+					'DES-EDE3',
+					$key,
+					OPENSSL_RAW_DATA | OPENSSL_ZERO_PADDING
+					
+				);
+
+			}
 			$res = base64_encode($encrypted_data )		;
 			$this->des_key = $key;
 		}
@@ -50,7 +72,26 @@ class helperAction extends kalturaSystemAction
 		{
 			$key = $this->getP ( "des_key" );
 			$input = base64_decode ( $str );
-			$res = openssl_decrypt($input,'DES-EDE3',$key,OPENSSL_RAW_DATA | OPENSSL_ZERO_PADDING); 
+			if (function_exists('mcrypt_generic_init')){
+			    $td = mcrypt_module_open('tripledes', '', 'ecb', '');
+			    $iv = mcrypt_create_iv (mcrypt_enc_get_iv_size($td), MCRYPT_RAND);
+			    $key = substr($key, 0, mcrypt_enc_get_key_size($td));
+		    
+			    mcrypt_generic_init($td, $key, $iv);
+			    $decrypted_data = mdecrypt_generic($td, $input);
+			    mcrypt_generic_deinit($td);
+			    mcrypt_module_close($td);
+			}else{
+				$decrypted_data=openssl_decrypt(
+					$input,
+					'DES-EDE3',
+					$key,
+					OPENSSL_RAW_DATA | OPENSSL_ZERO_PADDING
+					
+				);
+			}
+	    
+			$res = ($decrypted_data )		;
 			$this->des_key = $key;
 		}
 		elseif ( $algo == "ks" )

--- a/alpha/apps/kaltura/modules/system/actions/helperAction.class.php
+++ b/alpha/apps/kaltura/modules/system/actions/helperAction.class.php
@@ -41,16 +41,7 @@ class helperAction extends kalturaSystemAction
 		elseif ( $algo == "base64_3des_encode" )
 		{
 			$key = $this->getP ( "des_key" );
-			echo "[$key]";
-			$input = $str ;
-			$td = mcrypt_module_open('tripledes', '', 'ecb', '');
-	    	$iv = mcrypt_create_iv (mcrypt_enc_get_iv_size($td), MCRYPT_RAND);
-	    	$key = substr($key, 0, mcrypt_enc_get_key_size($td));
-	    	
-	    	mcrypt_generic_init($td, $key, $iv);
-	    	$encrypted_data = mcrypt_generic($td, $input);
-	    	mcrypt_generic_deinit($td);
-	    	mcrypt_module_close($td);
+			$encrypted_data = openssl_encrypt($str,'AES-128-ECB',$key,OPENSSL_RAW_DATA | OPENSSL_ZERO_PADDING);
 	    
 			$res = base64_encode($encrypted_data )		;
 			$this->des_key = $key;
@@ -58,18 +49,8 @@ class helperAction extends kalturaSystemAction
 		elseif ( $algo == "base64_3des_decode" )
 		{
 			$key = $this->getP ( "des_key" );
-			echo "[$key]";
 			$input = base64_decode ( $str );
-			$td = mcrypt_module_open('tripledes', '', 'ecb', '');
-	    	$iv = mcrypt_create_iv (mcrypt_enc_get_iv_size($td), MCRYPT_RAND);
-	    	$key = substr($key, 0, mcrypt_enc_get_key_size($td));
-	    	
-	    	mcrypt_generic_init($td, $key, $iv);
-	    	$encrypted_data = mdecrypt_generic($td, $input);
-	    	mcrypt_generic_deinit($td);
-	    	mcrypt_module_close($td);
-	    
-			$res = ($encrypted_data )		;
+			$res = openssl_decrypt($input,'AES-128-ECB',$key,OPENSSL_RAW_DATA | OPENSSL_ZERO_PADDING); 
 			$this->des_key = $key;
 		}
 		elseif ( $algo == "ks" )

--- a/alpha/apps/kaltura/modules/system/actions/helperAction.class.php
+++ b/alpha/apps/kaltura/modules/system/actions/helperAction.class.php
@@ -42,7 +42,7 @@ class helperAction extends kalturaSystemAction
 		{
 			$key = $this->getP ( "des_key" );
 			$input = $str;
-			if (function_exists('mcrypt_generic_init')){
+			if (extension_loaded('mcrypt')) {
 				$td = mcrypt_module_open('tripledes', '', 'ecb', '');
 				$iv = mcrypt_create_iv (mcrypt_enc_get_iv_size($td), MCRYPT_RAND);
 		        	$key = substr($key, 0, mcrypt_enc_get_key_size($td));
@@ -72,7 +72,7 @@ class helperAction extends kalturaSystemAction
 		{
 			$key = $this->getP ( "des_key" );
 			$input = base64_decode ( $str );
-			if (function_exists('mcrypt_generic_init')){
+			if (extension_loaded('mcrypt')) {
 			    $td = mcrypt_module_open('tripledes', '', 'ecb', '');
 			    $iv = mcrypt_create_iv (mcrypt_enc_get_iv_size($td), MCRYPT_RAND);
 			    $key = substr($key, 0, mcrypt_enc_get_key_size($td));

--- a/alpha/apps/kaltura/modules/system/actions/helperAction.class.php
+++ b/alpha/apps/kaltura/modules/system/actions/helperAction.class.php
@@ -21,7 +21,7 @@ class helperAction extends kalturaSystemAction
 		$algo = $this->getP ( "algo" , "wiki_decode_no_serialize" );
 		$res = "";
 		$key = null;
-		$myCryptor=KCryptoWrapper::getEncryptor();
+		$kCrypto = KCryptoWrapper::getEncryptor();
 		
 		if ( $algo == "wiki_encode" )
 		{
@@ -42,16 +42,16 @@ class helperAction extends kalturaSystemAction
 		elseif ( $algo == "base64_3des_encode" )
 		{
 			$key = $this->getP ( "des_key" );
-	    		$encrypted_data = $myCryptor::encrypt_3des($str, $key);
+	    		$encrypted_data = $kCrypto::encrypt_3des($str, $key);
 	    
-			$res = base64_encode($encrypted_data )		;
+			$res = base64_encode($encrypted_data)		;
 			$this->des_key = $key;
 		}
 		elseif ( $algo == "base64_3des_decode" )
 		{
 			$key = $this->getP ( "des_key" );
 			$input = base64_decode ( $str );
-	    		$decrypted_data = $myCryptor::decrypt_3des($input,$key);
+	    		$decrypted_data = $kCrypto::decrypt_3des($input, $key);
 	    
 			$res = ($decrypted_data )		;
 			$this->des_key = $key;

--- a/alpha/apps/kaltura/modules/system/actions/helperAction.class.php
+++ b/alpha/apps/kaltura/modules/system/actions/helperAction.class.php
@@ -41,7 +41,7 @@ class helperAction extends kalturaSystemAction
 		elseif ( $algo == "base64_3des_encode" )
 		{
 			$key = $this->getP ( "des_key" );
-			$encrypted_data = openssl_encrypt($str,'AES-128-ECB',$key,OPENSSL_RAW_DATA | OPENSSL_ZERO_PADDING);
+			$encrypted_data = openssl_encrypt($str,'DES-EDE3',$key,OPENSSL_RAW_DATA | OPENSSL_ZERO_PADDING);
 	    
 			$res = base64_encode($encrypted_data )		;
 			$this->des_key = $key;
@@ -50,7 +50,7 @@ class helperAction extends kalturaSystemAction
 		{
 			$key = $this->getP ( "des_key" );
 			$input = base64_decode ( $str );
-			$res = openssl_decrypt($input,'AES-128-ECB',$key,OPENSSL_RAW_DATA | OPENSSL_ZERO_PADDING); 
+			$res = openssl_decrypt($input,'DES-EDE3',$key,OPENSSL_RAW_DATA | OPENSSL_ZERO_PADDING); 
 			$this->des_key = $key;
 		}
 		elseif ( $algo == "ks" )

--- a/alpha/lib/model/UserLoginData.php
+++ b/alpha/lib/model/UserLoginData.php
@@ -276,8 +276,8 @@ class UserLoginData extends BaseUserLoginData{
 	{
 		$loginDataId = $this->getId();
 		$expiryTime = time() + (kConf::get('user_login_set_password_hash_key_validity')); // now + 24 hours
-		$myCryptor=KCryptoWrapper::getEncryptor();
-		$random = sha1($myCryptor::random_pseudo_bytes(32));
+		$kCrypto = KCryptoWrapper::getEncryptor();
+		$random = sha1($kCrypto::random_pseudo_bytes(32));
 		$hashKey = base64_encode(implode('|', array($loginDataId, $expiryTime, $random)));
 		return $hashKey;
 	}

--- a/alpha/lib/model/UserLoginData.php
+++ b/alpha/lib/model/UserLoginData.php
@@ -279,7 +279,7 @@ class UserLoginData extends BaseUserLoginData{
 		if (function_exists('mcrypt_create_iv')) {
 		    $random = sha1( mcrypt_create_iv(32,MCRYPT_DEV_URANDOM) );
 		}else{
-		    $random = sha1(openssl_random_pseudo_bytes(32, true));
+		    $random = sha1(openssl_random_pseudo_bytes(32));
 		}
 		$hashKey = base64_encode(implode('|', array($loginDataId, $expiryTime, $random)));
 		return $hashKey;

--- a/alpha/lib/model/UserLoginData.php
+++ b/alpha/lib/model/UserLoginData.php
@@ -276,11 +276,8 @@ class UserLoginData extends BaseUserLoginData{
 	{
 		$loginDataId = $this->getId();
 		$expiryTime = time() + (kConf::get('user_login_set_password_hash_key_validity')); // now + 24 hours
-		if (function_exists('mcrypt_create_iv')) {
-		    $random = sha1( mcrypt_create_iv(32,MCRYPT_DEV_URANDOM) );
-		}else{
-		    $random = sha1(openssl_random_pseudo_bytes(32));
-		}
+		$myCryptor=KCryptoWrapper::getEncryptor();
+		$random = sha1($myCryptor::random_pseudo_bytes(32));
 		$hashKey = base64_encode(implode('|', array($loginDataId, $expiryTime, $random)));
 		return $hashKey;
 	}

--- a/alpha/lib/model/UserLoginData.php
+++ b/alpha/lib/model/UserLoginData.php
@@ -276,7 +276,11 @@ class UserLoginData extends BaseUserLoginData{
 	{
 		$loginDataId = $this->getId();
 		$expiryTime = time() + (kConf::get('user_login_set_password_hash_key_validity')); // now + 24 hours
-		$random = sha1( mcrypt_create_iv(32,MCRYPT_DEV_URANDOM) );
+		if (function_exists('mcrypt_create_iv')) {
+		    $random = sha1( mcrypt_create_iv(32,MCRYPT_DEV_URANDOM) );
+		}else{
+		    $random = sha1(openssl_random_pseudo_bytes(32, true));
+		}
 		$hashKey = base64_encode(implode('|', array($loginDataId, $expiryTime, $random)));
 		return $hashKey;
 	}

--- a/alpha/lib/model/UserLoginData.php
+++ b/alpha/lib/model/UserLoginData.php
@@ -276,8 +276,7 @@ class UserLoginData extends BaseUserLoginData{
 	{
 		$loginDataId = $this->getId();
 		$expiryTime = time() + (kConf::get('user_login_set_password_hash_key_validity')); // now + 24 hours
-		$kCrypto = KCryptoWrapper::getEncryptor();
-		$random = sha1($kCrypto::random_pseudo_bytes(32));
+		$random = sha1(KCryptoWrapper::random_pseudo_bytes(32));
 		$hashKey = base64_encode(implode('|', array($loginDataId, $expiryTime, $random)));
 		return $hashKey;
 	}

--- a/configurations/base.ini
+++ b/configurations/base.ini
@@ -185,10 +185,6 @@ disable_url_hashing = true
 ; whether to report partner registration
 report_partner_registration = false
 
-; which PHP extension to use for encryption and decryption. Options are: 'mcrypt' or 'openssl'
-php_crypto_ext = 'mcrypt'
-
-	
 usage_tracking_url = http://corp.kaltura.com/index.php/events/usage_tracking
 	
 no_save_of_last_login_partner_for_partner_ids[] = 0	

--- a/configurations/base.ini
+++ b/configurations/base.ini
@@ -184,6 +184,10 @@ disable_url_hashing = true
 
 ; whether to report partner registration
 report_partner_registration = false
+
+; which PHP extension to use for encryption and decryption. Options are: 'mcrypt' or 'openssl'
+php_crypto_ext = 'mcrypt'
+
 	
 usage_tracking_url = http://corp.kaltura.com/index.php/events/usage_tracking
 	

--- a/infra/general/KCryptoWrapper.class.php
+++ b/infra/general/KCryptoWrapper.class.php
@@ -2,14 +2,26 @@
 
 class KCryptoWrapper
 {
-    public static function getEncryptor()
-    {
-	if (extension_loaded('mcrypt')){
-	    return new McryptWrapper();
-	}else{
-	    return new OpenSSLWrapper();
-	}
-    }
+        public static function getEncryptorClassName()
+        {
+                if (extension_loaded('mcrypt')){
+		    return 'McryptWrapper';
+                }else{
+		    return 'OpenSSLWrapper';
+                }
+        }
+
+        public static function __callStatic($func, $args)
+        {
+                $encryptorClass = self::getEncryptorClassName();
+                return call_user_func_array(array($encryptorClass, $func), $args);
+        }
+
+        public static function getEncryptor()
+        {
+                $encryptorClass = self::getEncryptorClassName();
+                return new $encryptorClass();
+        }
 
 }
 

--- a/infra/general/KCryptoWrapper.class.php
+++ b/infra/general/KCryptoWrapper.class.php
@@ -56,6 +56,9 @@ class OpenSSLWrapper
     }
     public static function encrypt_aes($str, $key,$iv)
     {
+
+	    // Pad with null byte to be compatible with mcrypt PKCS#5 padding
+	    // See http://thefsb.tumblr.com/post/110749271235/using-opensslendecrypt-in-php-instead-of as 
 	    $padLength = self::BLOCK_SIZE - strlen($str) % self::BLOCK_SIZE;
 	    $str .= str_repeat(chr(0), $padLength);
 	    return openssl_encrypt(

--- a/infra/general/KCryptoWrapper.class.php
+++ b/infra/general/KCryptoWrapper.class.php
@@ -92,7 +92,7 @@ class McryptWrapper
 	    $td = mcrypt_module_open('tripledes', '', 'ecb', ''); 
 	    $key = substr($key, 0, mcrypt_enc_get_key_size($td));
 
-	    mcrypt_generic_init($td, $key, str_repeat(chr("\0"), 8));
+	    mcrypt_generic_init($td, $key, str_repeat("\0", 8));
 	    $encrypted_data = mcrypt_generic($td, $str);
 	    mcrypt_generic_deinit($td);
 	    mcrypt_module_close($td);
@@ -104,7 +104,7 @@ class McryptWrapper
 	    $td = mcrypt_module_open('tripledes', '', 'ecb', '');
 	    $key = substr($key, 0, mcrypt_enc_get_key_size($td));
 
-	    mcrypt_generic_init($td, $key, str_repeat(chr("\0"), 8));
+	    mcrypt_generic_init($td, $key, str_repeat("\0", 8));
 	    $decrypted_data = mdecrypt_generic($td, $str);
 	    mcrypt_generic_deinit($td);
 	    mcrypt_module_close($td);

--- a/infra/general/KCryptoWrapper.class.php
+++ b/infra/general/KCryptoWrapper.class.php
@@ -20,9 +20,9 @@ class OpenSSLWrapper
     const AES_METHOD = 'AES-128-CBC';
     const DES3_METHOD = 'DES-EDE3';
 
-    public static function random_pseudo_bytes($bytes)
+    public static function random_pseudo_bytes($length)
     {
-	    return openssl_random_pseudo_bytes($bytes);
+	    return openssl_random_pseudo_bytes($length);
     }
 
     public static function encrypt_3des($str, $key)
@@ -82,9 +82,9 @@ class OpenSSLWrapper
 
 class McryptWrapper
 {
-    public static function random_pseudo_bytes($bytes)
+    public static function random_pseudo_bytes($length)
     {
-	    return mcrypt_create_iv($bytes,MCRYPT_DEV_URANDOM);
+	    return mcrypt_create_iv($length,MCRYPT_DEV_URANDOM);
     }
 
     public static function encrypt_3des($str, $key)

--- a/infra/general/KCryptoWrapper.class.php
+++ b/infra/general/KCryptoWrapper.class.php
@@ -6,17 +6,11 @@ class KCryptoWrapper
 {
     public static function getEncryptor()
     {
-	    if(kConf::hasParam('php_crypto_ext')){
-		    $crypto_ext=kConf::get('php_crypto_ext');
-	    }else{
-		    $crypto_ext='mcrypt';
-	    }
-	    if ($crypto_ext === 'openssl'){
-		    return new OpenSSLWrapper();
-	    }elseif($crypto_ext === 'mcrypt'){
-		    return new McryptWrapper();
-	    }
-
+	if (extension_loaded('mcrypt')){
+	    return new McryptWrapper();
+	}else{
+	    return new OpenSSLWrapper();
+	}
     }
 
 }
@@ -35,7 +29,7 @@ class OpenSSLWrapper
     public static function encrypt_3des($str, $key)
     {
 	    $padLength = self::BLOCK_SIZE - strlen($str) % self::BLOCK_SIZE;
-	    $str .= str_repeat(chr(0), $padLength);
+	    $str .= str_repeat(chr('\0'), $padLength);
 	    return openssl_encrypt(
 		    $str,
 		    self::DES3_METHOD,
@@ -52,13 +46,13 @@ class OpenSSLWrapper
 		    OPENSSL_RAW_DATA | OPENSSL_ZERO_PADDING
 	    );
     }
-    public static function encrypt_aes($str, $key,$iv)
+    public static function encrypt_aes($str, $key, $iv)
     {
 
 	    // Pad with null byte to be compatible with mcrypt PKCS#5 padding
 	    // See http://thefsb.tumblr.com/post/110749271235/using-opensslendecrypt-in-php-instead-of as 
 	    $padLength = self::BLOCK_SIZE - strlen($str) % self::BLOCK_SIZE;
-	    $str .= str_repeat(chr(0), $padLength);
+	    $str .= str_repeat(chr('\0'), $padLength);
 	    return openssl_encrypt(
 		    $str,
 		    self::AES_METHOD,

--- a/infra/general/KCryptoWrapper.class.php
+++ b/infra/general/KCryptoWrapper.class.php
@@ -29,7 +29,7 @@ class OpenSSLWrapper
     public static function encrypt_3des($str, $key)
     {
 	    $padLength = self::BLOCK_SIZE - strlen($str) % self::BLOCK_SIZE;
-	    $str .= str_repeat(chr('\0'), $padLength);
+	    $str .= str_repeat(chr("\0"), $padLength);
 	    return openssl_encrypt(
 		    $str,
 		    self::DES3_METHOD,
@@ -52,7 +52,7 @@ class OpenSSLWrapper
 	    // Pad with null byte to be compatible with mcrypt PKCS#5 padding
 	    // See http://thefsb.tumblr.com/post/110749271235/using-opensslendecrypt-in-php-instead-of as 
 	    $padLength = self::BLOCK_SIZE - strlen($str) % self::BLOCK_SIZE;
-	    $str .= str_repeat(chr('\0'), $padLength);
+	    $str .= str_repeat(chr("\0"), $padLength);
 	    return openssl_encrypt(
 		    $str,
 		    self::AES_METHOD,

--- a/infra/general/KCryptoWrapper.class.php
+++ b/infra/general/KCryptoWrapper.class.php
@@ -1,7 +1,5 @@
 <?php
 
-require_once('/opt/kaltura/app/alpha/config/kConf.php');
-
 class KCryptoWrapper
 {
     public static function getEncryptor()

--- a/infra/general/KCryptoWrapper.class.php
+++ b/infra/general/KCryptoWrapper.class.php
@@ -29,7 +29,7 @@ class OpenSSLWrapper
     {
 	    if (strlen($str) % self::DES3_BLOCK_SIZE) {
 		$padLength = self::DES3_BLOCK_SIZE - strlen($str) % self::DES3_BLOCK_SIZE;
-		$str .= str_repeat(chr("\0"), $padLength);
+		$str .= str_repeat("\0", $padLength);
 	    }
 	    return openssl_encrypt(
 		    $str,
@@ -54,7 +54,7 @@ class OpenSSLWrapper
 	    // See http://thefsb.tumblr.com/post/110749271235/using-opensslendecrypt-in-php-instead-of as 
 	    if (strlen($str) % self::AES_BLOCK_SIZE) {
 		$padLength = self::AES_BLOCK_SIZE - strlen($str) % self::AES_BLOCK_SIZE;
-		$str .= str_repeat(chr("\0"), $padLength);
+		$str .= str_repeat("\0", $padLength);
 	    }
 	    return openssl_encrypt(
 		    $str,

--- a/infra/general/KCryptoWrapper.class.php
+++ b/infra/general/KCryptoWrapper.class.php
@@ -1,0 +1,138 @@
+<?php
+
+require_once('/opt/kaltura/app/alpha/config/kConf.php');
+
+class KCryptoWrapper
+{
+    public static function getEncryptor()
+    {
+	    if(kConf::hasParam('php_crypto_ext')){
+		    $crypto_ext=kConf::get('php_crypto_ext');
+	    }else{
+		    $crypto_ext='mcrypt';
+	    }
+	    if ($crypto_ext === 'openssl'){
+		    error_log("$crypto_ext\n",3,'/tmp/ext');
+		    return new OpenSSLWrapper();
+	    }elseif($crypto_ext === 'mcrypt'){
+		    error_log("$crypto_ext\n",3,'/tmp/ext');
+		    return new McryptWrapper();
+	    }
+
+    }
+
+}
+
+class OpenSSLWrapper
+{
+    const BLOCK_SIZE = 16;
+    const AES_METHOD = 'AES-128-CBC';
+    const DES3_METHOD = 'DES-EDE3';
+
+    public static function random_pseudo_bytes($bytes)
+    {
+	    return openssl_random_pseudo_bytes($bytes);
+    }
+
+    public static function encrypt_3des($str, $key)
+    {
+	    $padLength = self::BLOCK_SIZE - strlen($str) % self::BLOCK_SIZE;
+	    $str .= str_repeat(chr(0), $padLength);
+	    return openssl_encrypt(
+		    $str,
+		    self::DES3_METHOD,
+		    $key,
+		    OPENSSL_RAW_DATA | OPENSSL_ZERO_PADDING
+	    );
+    }
+    public static function decrypt_3des($str, $key)
+    {
+	    return openssl_decrypt(
+		    $str,
+		    self::DES3_METHOD,
+		    $key,
+		    OPENSSL_RAW_DATA | OPENSSL_ZERO_PADDING
+	    );
+    }
+    public static function encrypt_aes($str, $key,$iv)
+    {
+	    $padLength = self::BLOCK_SIZE - strlen($str) % self::BLOCK_SIZE;
+	    $str .= str_repeat(chr(0), $padLength);
+	    return openssl_encrypt(
+		    $str,
+		    self::AES_METHOD,
+		    $key,
+		    OPENSSL_RAW_DATA | OPENSSL_ZERO_PADDING,
+		    $iv
+	    );  
+    }
+    
+    public static function decrypt_aes($str, $key, $iv)
+    {
+	    return openssl_decrypt(
+		    $str,
+		    self::AES_METHOD,
+		    $key,
+		    OPENSSL_RAW_DATA | OPENSSL_ZERO_PADDING,
+		    $iv
+	    );
+    }
+
+
+
+}
+
+class McryptWrapper
+{
+    public static function random_pseudo_bytes($bytes)
+    {
+	    return mcrypt_create_iv($bytes,MCRYPT_DEV_URANDOM);
+    }
+
+    public static function encrypt_3des($str, $key)
+    {
+	    $td = mcrypt_module_open('tripledes', '', 'ecb', ''); 
+	    $key = substr($key, 0, mcrypt_enc_get_key_size($td));
+
+	    mcrypt_generic_init($td, $key, null);
+	    $encrypted_data = mcrypt_generic($td, $str);
+	    mcrypt_generic_deinit($td);
+	    mcrypt_module_close($td);
+	    return $encrypted_data;
+    }
+
+    public static function decrypt_3des($str, $key)
+    {
+	    $td = mcrypt_module_open('tripledes', '', 'ecb', '');
+	    $key = substr($key, 0, mcrypt_enc_get_key_size($td));
+
+	    mcrypt_generic_init($td, $key, null);
+	    $decrypted_data = mdecrypt_generic($td, $str);
+	    mcrypt_generic_deinit($td);
+	    mcrypt_module_close($td);
+	    return $decrypted_data;
+    }
+
+    public static function encrypt_aes($str, $key, $iv)
+    {
+	    return mcrypt_encrypt(
+		    MCRYPT_RIJNDAEL_128,
+		    $key,
+		    $str,
+		    MCRYPT_MODE_CBC,
+		    $iv 
+	    ); 
+    }
+
+    public static function decrypt_aes($str, $key, $iv)
+    {
+	    return mcrypt_decrypt(
+		    MCRYPT_RIJNDAEL_128,
+		    $key,
+		    $str,
+		    MCRYPT_MODE_CBC,
+		    $iv	
+	    );
+
+    }
+}

--- a/infra/general/KCryptoWrapper.class.php
+++ b/infra/general/KCryptoWrapper.class.php
@@ -12,10 +12,8 @@ class KCryptoWrapper
 		    $crypto_ext='mcrypt';
 	    }
 	    if ($crypto_ext === 'openssl'){
-		    error_log("$crypto_ext\n",3,'/tmp/ext');
 		    return new OpenSSLWrapper();
 	    }elseif($crypto_ext === 'mcrypt'){
-		    error_log("$crypto_ext\n",3,'/tmp/ext');
 		    return new McryptWrapper();
 	    }
 

--- a/plugins/admin_console/kaltura_internal_tools/admin/KalturaInternalToolsSystemHelperAction.php
+++ b/plugins/admin_console/kaltura_internal_tools/admin/KalturaInternalToolsSystemHelperAction.php
@@ -63,31 +63,37 @@ class KalturaInternalToolsPluginSystemHelperAction extends KalturaApplicationPlu
 		}
 		elseif ( $algo == "base64_3des_encode" )
 		{
-			$input = $str ;
-			$td = mcrypt_module_open('tripledes', '', 'ecb', '');
-	    	$iv = mcrypt_create_iv (mcrypt_enc_get_iv_size($td), MCRYPT_RAND);
-	    	$key = substr($key, 0, mcrypt_enc_get_key_size($td));
+			if (function_exists('mcrypt_generic_init')){
+				$td = mcrypt_module_open('tripledes', '', 'ecb', '');
+				$iv = mcrypt_create_iv (mcrypt_enc_get_iv_size($td), MCRYPT_RAND);
+		        	$key = substr($key, 0, mcrypt_enc_get_key_size($td));
 	    	
-	    	mcrypt_generic_init($td, $key, $iv);
-	    	$encrypted_data = mcrypt_generic($td, $input);
-	    	mcrypt_generic_deinit($td);
-	    	mcrypt_module_close($td);
+				mcrypt_generic_init($td, $key, $iv);
+				$encrypted_data = mcrypt_generic($td, $str);
+				mcrypt_generic_deinit($td);
+				mcrypt_module_close($td);
 	    
+			}else{
+			    $encrypted_data = openssl_encrypt($str,'AES-128-ECB',$key,OPENSSL_RAW_DATA | OPENSSL_ZERO_PADDING);
+			}
 			$res = base64_encode($encrypted_data )		;
 			$this->des_key = $key;
 		}
 		elseif ( $algo == "base64_3des_decode" )
 		{
-			//echo "[$key]";
 			$input = base64_decode ( $str );
-			$td = mcrypt_module_open('tripledes', '', 'ecb', '');
-	    	$iv = mcrypt_create_iv (mcrypt_enc_get_iv_size($td), MCRYPT_RAND);
-	    	$key = substr($key, 0, mcrypt_enc_get_key_size($td));
-	    	
-	    	mcrypt_generic_init($td, $key, $iv);
-	    	$encrypted_data = mdecrypt_generic($td, $input);
-	    	mcrypt_generic_deinit($td);
-	    	mcrypt_module_close($td);
+			if (function_exists('mcrypt_generic_init')){
+			    $td = mcrypt_module_open('tripledes', '', 'ecb', '');
+			    $iv = mcrypt_create_iv (mcrypt_enc_get_iv_size($td), MCRYPT_RAND);
+			    $key = substr($key, 0, mcrypt_enc_get_key_size($td));
+		    
+			    mcrypt_generic_init($td, $key, $iv);
+			    $encrypted_data = mdecrypt_generic($td, $input);
+			    mcrypt_generic_deinit($td);
+			    mcrypt_module_close($td);
+			}else{
+			    $encrypted_data = openssl_decrypt($input,'AES-128-ECB',$key,OPENSSL_RAW_DATA | OPENSSL_ZERO_PADDING); 
+			}
 	    
 			$res = ($encrypted_data )		;
 			$this->des_key = $key;

--- a/plugins/admin_console/kaltura_internal_tools/admin/KalturaInternalToolsSystemHelperAction.php
+++ b/plugins/admin_console/kaltura_internal_tools/admin/KalturaInternalToolsSystemHelperAction.php
@@ -64,7 +64,7 @@ class KalturaInternalToolsPluginSystemHelperAction extends KalturaApplicationPlu
 		elseif ( $algo == "base64_3des_encode" )
 		{
 			$input = $str;
-			if (function_exists('mcrypt_generic_init')){
+			if (extension_loaded('mcrypt')){
 				$td = mcrypt_module_open('tripledes', '', 'ecb', '');
 				$iv = mcrypt_create_iv (mcrypt_enc_get_iv_size($td), MCRYPT_RAND);
 		        	$key = substr($key, 0, mcrypt_enc_get_key_size($td));
@@ -93,7 +93,7 @@ class KalturaInternalToolsPluginSystemHelperAction extends KalturaApplicationPlu
 		elseif ( $algo == "base64_3des_decode" )
 		{
 			$input = base64_decode ( $str );
-			if (function_exists('mcrypt_generic_init')){
+			if (extension_loaded('mcrypt')){
 			    $td = mcrypt_module_open('tripledes', '', 'ecb', '');
 			    $iv = mcrypt_create_iv (mcrypt_enc_get_iv_size($td), MCRYPT_RAND);
 			    $key = substr($key, 0, mcrypt_enc_get_key_size($td));

--- a/plugins/admin_console/kaltura_internal_tools/admin/KalturaInternalToolsSystemHelperAction.php
+++ b/plugins/admin_console/kaltura_internal_tools/admin/KalturaInternalToolsSystemHelperAction.php
@@ -34,7 +34,6 @@ class KalturaInternalToolsPluginSystemHelperAction extends KalturaApplicationPlu
 		
 		$SystemHelperForm = new Form_SystemHelper();
 		$SystemHelperFormResult = new Form_SystemHelperResult();
-		$kCrypto = KCryptoWrapper::getEncryptor();
 		
 		$algo ="";
 		$secret = "";
@@ -63,14 +62,14 @@ class KalturaInternalToolsPluginSystemHelperAction extends KalturaApplicationPlu
 		}
 		elseif ( $algo == "base64_3des_encode" )
 		{
-			$encrypted_data = $kCrypto::encrypt_3des($str, $key);
+			$encrypted_data = KCryptoWrapper::encrypt_3des($str, $key);
 			$res = base64_encode($encrypted_data)		;
 			$this->des_key = $key;
 		}
 		elseif ( $algo == "base64_3des_decode" )
 		{
 			$input = base64_decode ($str);
-	   		$decrypted_data = $kCrypto::decrypt_3des($input, $key);
+	   		$decrypted_data = KCryptoWrapper::decrypt_3des($input, $key);
 			$res = ($decrypted_data);
 			$this->des_key = $key;
 		}

--- a/plugins/admin_console/kaltura_internal_tools/admin/KalturaInternalToolsSystemHelperAction.php
+++ b/plugins/admin_console/kaltura_internal_tools/admin/KalturaInternalToolsSystemHelperAction.php
@@ -34,7 +34,7 @@ class KalturaInternalToolsPluginSystemHelperAction extends KalturaApplicationPlu
 		
 		$SystemHelperForm = new Form_SystemHelper();
 		$SystemHelperFormResult = new Form_SystemHelperResult();
-		$myCryptor=KCryptoWrapper::getEncryptor();
+		$kCrypto = KCryptoWrapper::getEncryptor();
 		
 		$algo ="";
 		$secret = "";
@@ -63,14 +63,14 @@ class KalturaInternalToolsPluginSystemHelperAction extends KalturaApplicationPlu
 		}
 		elseif ( $algo == "base64_3des_encode" )
 		{
-			$encrypted_data = $myCryptor::encrypt_3des($str,$key);
+			$encrypted_data = $kCrypto::encrypt_3des($str, $key);
 			$res = base64_encode($encrypted_data)		;
 			$this->des_key = $key;
 		}
 		elseif ( $algo == "base64_3des_decode" )
 		{
 			$input = base64_decode ($str);
-	   		$decrypted_data = $myCryptor::decrypt_3des($input,$key);
+	   		$decrypted_data = $kCrypto::decrypt_3des($input, $key);
 			$res = ($decrypted_data);
 			$this->des_key = $key;
 		}

--- a/plugins/admin_console/kaltura_internal_tools/admin/KalturaInternalToolsSystemHelperAction.php
+++ b/plugins/admin_console/kaltura_internal_tools/admin/KalturaInternalToolsSystemHelperAction.php
@@ -63,18 +63,29 @@ class KalturaInternalToolsPluginSystemHelperAction extends KalturaApplicationPlu
 		}
 		elseif ( $algo == "base64_3des_encode" )
 		{
+			$input = $str;
 			if (function_exists('mcrypt_generic_init')){
 				$td = mcrypt_module_open('tripledes', '', 'ecb', '');
 				$iv = mcrypt_create_iv (mcrypt_enc_get_iv_size($td), MCRYPT_RAND);
 		        	$key = substr($key, 0, mcrypt_enc_get_key_size($td));
 	    	
 				mcrypt_generic_init($td, $key, $iv);
-				$encrypted_data = mcrypt_generic($td, $str);
+				$encrypted_data = mcrypt_generic($td, $input);
 				mcrypt_generic_deinit($td);
 				mcrypt_module_close($td);
 	    
 			}else{
-			    $encrypted_data = openssl_encrypt($str,'DES-EDE3',$key,OPENSSL_RAW_DATA | OPENSSL_ZERO_PADDING);
+				$blockSize = 16;
+				$padLength = $blockSize - strlen($input) % $blockSize;
+				$input .= str_repeat(chr(0), $padLength);
+				$encrypted_data=openssl_encrypt(
+					$input,
+					'DES-EDE3',
+					$key,
+					OPENSSL_RAW_DATA | OPENSSL_ZERO_PADDING
+					
+				);
+
 			}
 			$res = base64_encode($encrypted_data )		;
 			$this->des_key = $key;
@@ -88,14 +99,20 @@ class KalturaInternalToolsPluginSystemHelperAction extends KalturaApplicationPlu
 			    $key = substr($key, 0, mcrypt_enc_get_key_size($td));
 		    
 			    mcrypt_generic_init($td, $key, $iv);
-			    $encrypted_data = mdecrypt_generic($td, $input);
+			    $decrypted_data = mdecrypt_generic($td, $input);
 			    mcrypt_generic_deinit($td);
 			    mcrypt_module_close($td);
 			}else{
-			    $encrypted_data = openssl_decrypt($input,'DES-EDE3',$key,OPENSSL_RAW_DATA | OPENSSL_ZERO_PADDING); 
+				$decrypted_data=openssl_decrypt(
+					$input,
+					'DES-EDE3',
+					$key,
+					OPENSSL_RAW_DATA | OPENSSL_ZERO_PADDING
+					
+				);
 			}
 	    
-			$res = ($encrypted_data )		;
+			$res = ($decrypted_data )		;
 			$this->des_key = $key;
 		}
 		elseif ( $algo == "ks" )

--- a/plugins/admin_console/kaltura_internal_tools/admin/KalturaInternalToolsSystemHelperAction.php
+++ b/plugins/admin_console/kaltura_internal_tools/admin/KalturaInternalToolsSystemHelperAction.php
@@ -74,7 +74,7 @@ class KalturaInternalToolsPluginSystemHelperAction extends KalturaApplicationPlu
 				mcrypt_module_close($td);
 	    
 			}else{
-			    $encrypted_data = openssl_encrypt($str,'AES-128-ECB',$key,OPENSSL_RAW_DATA | OPENSSL_ZERO_PADDING);
+			    $encrypted_data = openssl_encrypt($str,'DES-EDE3',$key,OPENSSL_RAW_DATA | OPENSSL_ZERO_PADDING);
 			}
 			$res = base64_encode($encrypted_data )		;
 			$this->des_key = $key;
@@ -92,7 +92,7 @@ class KalturaInternalToolsPluginSystemHelperAction extends KalturaApplicationPlu
 			    mcrypt_generic_deinit($td);
 			    mcrypt_module_close($td);
 			}else{
-			    $encrypted_data = openssl_decrypt($input,'AES-128-ECB',$key,OPENSSL_RAW_DATA | OPENSSL_ZERO_PADDING); 
+			    $encrypted_data = openssl_decrypt($input,'DES-EDE3',$key,OPENSSL_RAW_DATA | OPENSSL_ZERO_PADDING); 
 			}
 	    
 			$res = ($encrypted_data )		;

--- a/plugins/drm/providers/playready/admin/forms/scripts/play-ready-provider-configure-action.phtml
+++ b/plugins/drm/providers/playready/admin/forms/scripts/play-ready-provider-configure-action.phtml
@@ -1,8 +1,8 @@
 <script type="text/javascript">
 
 function generateKeySeed() {
-	<?php $myCryptor=KCryptoWrapper::getEncryptor();?>
-	var keySeedGen = '<?php echo bin2hex($myCryptor::random_pseudo_bytes(30)) ?>';
+	<?php $kCrypto = KCryptoWrapper::getEncryptor();?>
+	var keySeedGen = '<?php echo bin2hex($kCrypto::random_pseudo_bytes(30)) ?>';
 	jQuery('#extensionSubForm-keySeed').val(keySeedGen);
 }
 

--- a/plugins/drm/providers/playready/admin/forms/scripts/play-ready-provider-configure-action.phtml
+++ b/plugins/drm/providers/playready/admin/forms/scripts/play-ready-provider-configure-action.phtml
@@ -1,11 +1,8 @@
 <script type="text/javascript">
 
 function generateKeySeed() {
-	<?php if(function_exists('mcrypt_create_iv')){ ?>
-		var keySeedGen = '<?php echo bin2hex(mcrypt_create_iv(30, MCRYPT_DEV_URANDOM)); ?>';
-	<?php }else{ ?>
-		var keySeedGen = '<?php echo bin2hex(openssl_random_pseudo_bytes(30)); ?>';
-	<?php } ?>
+	<?php $myCryptor=KCryptoWrapper::getEncryptor();?>
+	var keySeedGen = '<?php echo bin2hex($myCryptor::random_pseudo_bytes(30)) ?>';
 	jQuery('#extensionSubForm-keySeed').val(keySeedGen);
 }
 

--- a/plugins/drm/providers/playready/admin/forms/scripts/play-ready-provider-configure-action.phtml
+++ b/plugins/drm/providers/playready/admin/forms/scripts/play-ready-provider-configure-action.phtml
@@ -1,8 +1,7 @@
 <script type="text/javascript">
 
 function generateKeySeed() {
-	<?php $kCrypto = KCryptoWrapper::getEncryptor();?>
-	var keySeedGen = '<?php echo bin2hex($kCrypto::random_pseudo_bytes(30)) ?>';
+	var keySeedGen = '<?php echo bin2hex(KCryptoWrapper::random_pseudo_bytes(30)) ?>';
 	jQuery('#extensionSubForm-keySeed').val(keySeedGen);
 }
 

--- a/plugins/drm/providers/playready/admin/forms/scripts/play-ready-provider-configure-action.phtml
+++ b/plugins/drm/providers/playready/admin/forms/scripts/play-ready-provider-configure-action.phtml
@@ -4,7 +4,7 @@ function generateKeySeed() {
 	<?php if(function_exists('mcrypt_create_iv')){ ?>
 		var keySeedGen = '<?php echo bin2hex(mcrypt_create_iv(30, MCRYPT_DEV_URANDOM)); ?>';
 	<?php }else{ ?>
-		var keySeedGen = '<?php echo bin2hex(openssl_random_pseudo_bytes(30, true)); ?>';
+		var keySeedGen = '<?php echo bin2hex(openssl_random_pseudo_bytes(30)); ?>';
 	<?php } ?>
 	jQuery('#extensionSubForm-keySeed').val(keySeedGen);
 }

--- a/plugins/drm/providers/playready/admin/forms/scripts/play-ready-provider-configure-action.phtml
+++ b/plugins/drm/providers/playready/admin/forms/scripts/play-ready-provider-configure-action.phtml
@@ -1,7 +1,11 @@
 <script type="text/javascript">
 
 function generateKeySeed() {
-	var keySeedGen = '<?php echo bin2hex(mcrypt_create_iv(30, MCRYPT_DEV_URANDOM)); ?>';
+	<?php if(function_exists('mcrypt_create_iv')){ ?>
+		var keySeedGen = '<?php echo bin2hex(mcrypt_create_iv(30, MCRYPT_DEV_URANDOM)); ?>';
+	<?php }else{ ?>
+		var keySeedGen = '<?php echo bin2hex(openssl_random_pseudo_bytes(30, true)); ?>';
+	<?php } ?>
 	jQuery('#extensionSubForm-keySeed').val(keySeedGen);
 }
 

--- a/plugins/event_notification/providers/push/lib/model/registerNotificationPostProcessor.php
+++ b/plugins/event_notification/providers/push/lib/model/registerNotificationPostProcessor.php
@@ -37,11 +37,11 @@ class registerNotificationPostProcessor
 	
 	private function encode($data)
 	{
-		$myCryptor=KCryptoWrapper::getEncryptor();
+		$kCrypto = KCryptoWrapper::getEncryptor();
 		$secret = kConf::get("push_server_secret");
 		$iv = kConf::get("push_server_secret_iv");
 	
-		$cipherData = $myCryptor::encrypt_aes($data,$secret,$iv); 
+		$cipherData = $kCrypto::encrypt_aes($data, $secret, $iv); 
 	
 		return bin2hex($cipherData);
 	}

--- a/plugins/event_notification/providers/push/lib/model/registerNotificationPostProcessor.php
+++ b/plugins/event_notification/providers/push/lib/model/registerNotificationPostProcessor.php
@@ -37,19 +37,11 @@ class registerNotificationPostProcessor
 	
 	private function encode($data)
 	{
-		// use a 128 Rijndael encyrption algorithm with Cipher-block chaining (CBC) as mode of AES encryption
-		$cipher = mcrypt_module_open(MCRYPT_RIJNDAEL_128, '', MCRYPT_MODE_CBC, '');
+		$myCryptor=KCryptoWrapper::getEncryptor();
 		$secret = kConf::get("push_server_secret");
 		$iv = kConf::get("push_server_secret_iv");
 	
-		// pad the rest of the block to suit Node crypto functions padding scheme (PKCS5)
-		$blocksize = 16;
-		$pad = $blocksize - (strlen($data) % $blocksize);
-		$data = $data . str_repeat(chr($pad), $pad);
-	
-		mcrypt_generic_init($cipher, $secret, $iv);
-		$cipherData = mcrypt_generic($cipher, $data);
-		mcrypt_generic_deinit($cipher);
+		$cipherData = $myCryptor::encrypt_aes($data,$secret,$iv); 
 	
 		return bin2hex($cipherData);
 	}

--- a/plugins/event_notification/providers/push/lib/model/registerNotificationPostProcessor.php
+++ b/plugins/event_notification/providers/push/lib/model/registerNotificationPostProcessor.php
@@ -37,11 +37,10 @@ class registerNotificationPostProcessor
 	
 	private function encode($data)
 	{
-		$kCrypto = KCryptoWrapper::getEncryptor();
 		$secret = kConf::get("push_server_secret");
 		$iv = kConf::get("push_server_secret_iv");
 	
-		$cipherData = $kCrypto::encrypt_aes($data, $secret, $iv); 
+		$cipherData = KCryptoWrapper::encrypt_aes($data, $secret, $iv); 
 	
 		return bin2hex($cipherData);
 	}


### PR DESCRIPTION
This is the server side follow up of https://github.com/kaltura/clients-generator/pull/278

Starting from PHP 7.1, the Mcrypt extension is deprecated.
There is a good underlying reason for that, to wit: libmcrypt's last update was back in 2007. This is bad for any piece of code but especially troubling for security sensitive ones.

The pulls above will ensure compatibility with KS strings generated using Mcrypt because we set the OPENSSL_ZERO_PADDING bit and do our own padding thus making it compatible with mcrypt's PKCS#5 padding, as opposed to OpenSSL's default which is PKCS#7.

More info about this can be found here:
http://thefsb.tumblr.com/post/110749271235/using-opensslendecrypt-in-php-instead-of
and in particular under the "Encoding, padding and OPENSSL_RAW_DATA vs.
OPENSSL_ZERO_PADDING" section.
