### PR TITLE
It is not possible to unset $this inside an object method since PHP 5.

### DIFF
--- a/infra/cdl/kdl/KDLFlavor.php
+++ b/infra/cdl/kdl/KDLFlavor.php
@@ -72,7 +72,6 @@ class KDLFlavor extends KDLMediaDataSet {
 		parent::__construct();
 	}
 	public function __destruct() {
-		unset($this);
 	}
 	public function __clone() {
 		if(!is_null($this->_container)) $this->_container = clone $this->_container;

--- a/infra/cdl/kdl/KDLMediaDataSet.php
+++ b/infra/cdl/kdl/KDLMediaDataSet.php
@@ -28,7 +28,6 @@ class KDLMediaDataSet  {
 		;
 	}
 	public function __destruct() {
-		unset($this);
 	}
 
 	/* ------------------------------

--- a/infra/cdl/kdl/KDLProcessor.php
+++ b/infra/cdl/kdl/KDLProcessor.php
@@ -17,7 +17,6 @@
 			$this->_srcDataSet = new KDLMediaDataSet();
 		}
 		public function __destruct() {
-			unset($this);
 		}
 
 		/* ----------------------


### PR DESCRIPTION
See http://php.net/manual/en/function.unset.php:

However, before PHP 7, this did not trigger a FATAL error, now it does:
> PHP Fatal error:  Cannot unset $this 