### PR TITLE
CURLOPT_SSL_VERIFYHOST no longer accepts the value 1

### DIFF
--- a/alpha/apps/kaltura/lib/s3/S3.php
+++ b/alpha/apps/kaltura/lib/s3/S3.php
@@ -1228,7 +1228,7 @@ final class S3Request {
 		curl_setopt($curl, CURLOPT_USERAGENT, 'S3/php');
 
 		if (S3::$useSSL) {
-			curl_setopt($curl, CURLOPT_SSL_VERIFYHOST, 1);
+			curl_setopt($curl, CURLOPT_SSL_VERIFYHOST, 2);
 			curl_setopt($curl, CURLOPT_SSL_VERIFYPEER, 1);
 		}
 

--- a/alpha/apps/kaltura/lib/s3/S3.php
+++ b/alpha/apps/kaltura/lib/s3/S3.php
@@ -1228,7 +1228,7 @@ final class S3Request {
 		curl_setopt($curl, CURLOPT_USERAGENT, 'S3/php');
 
 		if (S3::$useSSL) {
-			curl_setopt($curl, CURLOPT_SSL_VERIFYHOST, 2);
+			curl_setopt($curl, CURLOPT_SSL_VERIFYHOST, KCurlWrapper::getSslVerifyHostValue());
 			curl_setopt($curl, CURLOPT_SSL_VERIFYPEER, 1);
 		}
 

--- a/infra/general/KCurlWrapper.class.php
+++ b/infra/general/KCurlWrapper.class.php
@@ -225,7 +225,7 @@ class KCurlWrapper
 		if(!$params || !isset($params->curlVerifySSL) || !$params->curlVerifySSL)
 		{
 			curl_setopt($this->ch, CURLOPT_SSL_VERIFYPEER, false);
-			curl_setopt($this->ch, CURLOPT_SSL_VERIFYHOST, 2);
+			curl_setopt($this->ch, CURLOPT_SSL_VERIFYHOST, self::getSslVerifyHostValue());
 		}
 	}
 
@@ -612,6 +612,17 @@ class KCurlWrapper
 		curl_close($ch);
 		
 		return $content;
+	}
+
+	public static function getSslVerifyHostValue()
+	{
+		$curl_version = curl_version();
+		if($curl_version['version_number'] >= 0x071c01 ) // check if curl version is 7.28.1 or higher
+		{
+			return 2;
+		}
+
+		return 1;
 	}
 }
 

--- a/infra/general/KCurlWrapper.class.php
+++ b/infra/general/KCurlWrapper.class.php
@@ -225,7 +225,7 @@ class KCurlWrapper
 		if(!$params || !isset($params->curlVerifySSL) || !$params->curlVerifySSL)
 		{
 			curl_setopt($this->ch, CURLOPT_SSL_VERIFYPEER, false);
-			curl_setopt($this->ch, CURLOPT_SSL_VERIFYHOST, 1);
+			curl_setopt($this->ch, CURLOPT_SSL_VERIFYHOST, 2);
 		}
 	}
 

--- a/infra/general/S3.php
+++ b/infra/general/S3.php
@@ -1751,7 +1751,7 @@ final class S3Request
 		if (S3::$useSSL)
 		{
 			// SSL Validation can now be optional for those with broken OpenSSL installations
-			curl_setopt($curl, CURLOPT_SSL_VERIFYHOST, S3::$useSSLValidation ? 1 : 0);
+			curl_setopt($curl, CURLOPT_SSL_VERIFYHOST, S3::$useSSLValidation ? 2 : 0);
 			curl_setopt($curl, CURLOPT_SSL_VERIFYPEER, S3::$useSSLValidation ? 1 : 0);
 
 			if (S3::$sslKey !== null) curl_setopt($curl, CURLOPT_SSLKEY, S3::$sslKey);

--- a/infra/general/S3.php
+++ b/infra/general/S3.php
@@ -1751,7 +1751,7 @@ final class S3Request
 		if (S3::$useSSL)
 		{
 			// SSL Validation can now be optional for those with broken OpenSSL installations
-			curl_setopt($curl, CURLOPT_SSL_VERIFYHOST, S3::$useSSLValidation ? 2 : 0);
+			curl_setopt($curl, CURLOPT_SSL_VERIFYHOST, S3::$useSSLValidation ? KCurlWrapper::getSslVerifyHostValue() : 0);
 			curl_setopt($curl, CURLOPT_SSL_VERIFYPEER, S3::$useSSLValidation ? 1 : 0);
 
 			if (S3::$sslKey !== null) curl_setopt($curl, CURLOPT_SSLKEY, S3::$sslKey);


### PR DESCRIPTION
As documented here http://php.net/manual/en/function.curl-setopt.php:
1 used to mean check the existence of a common name in the SSL peer certificate.
2 will check the existence of a common name and also verify that it matches
the hostname provided. 0 will not check the names.

Support for value 1 was removed in cURL 7.28.1.
That means that all machines that have libcurl of version 7.28.1 or
higher will effectively behave as if this value was set to 2.

7.28.1 is very old and no current Linux distro version includes it.
Just by way of reference, RHEL/CentOS 7 has 7.29.0, Ubuntu 14.04 has
7.35.0 and Ubuntu 16.04 has 7.47.0.