### PR TITLE
PLAT-8804: when a live entry_server_node exists for more than a week …

### DIFF
--- a/alpha/lib/model/LiveEntryServerNode.php
+++ b/alpha/lib/model/LiveEntryServerNode.php
@@ -195,7 +195,7 @@ class LiveEntryServerNode extends EntryServerNode
 				return;
 			}
 			
-			if(!myEntryUtils::shouldServeVodFromLive($recordedEntry, false) && $recordedEntry->getRecordedLengthInMsecs() == 0)
+			if( (!myEntryUtils::shouldServeVodFromLive($recordedEntry, false) && $recordedEntry->getRecordedLengthInMsecs() == 0) || (time() - $this->getUpdatedAt(null)) > kConf::get('marked_for_deletion_entry_server_node_timeout'))
 			{
 				KalturaLog::debug("Recorded entry with id [{$this->getEntryId()}] found and ready or recorded is of old source type, clearing entry server node from db");
 				$this->delete();

--- a/configurations/base.ini
+++ b/configurations/base.ini
@@ -138,6 +138,8 @@ kaltura_email_hash = admin
 
 default_batch_version = 1
 
+marked_for_deletion_entry_server_node_timeout = 604800
+
 event_consumers[] = kFlowManager
 event_consumers[] = kStorageExporter
 event_consumers[] = kObjectCreatedHandler


### PR DESCRIPTION
…we probably had some issue in uploading the recording and leaving it in the system mucks up the validateMediaServers API

SHOULD BE MERGED TO NEXT BRANCH