### PR TITLE
PLAT-8827: change serveWebVTT to use delivery profile hostname

### DIFF
--- a/alpha/apps/kaltura/lib/kManifestRenderers.php
+++ b/alpha/apps/kaltura/lib/kManifestRenderers.php
@@ -101,11 +101,6 @@ abstract class kManifestRenderer
 		return "\n";
 	}
 
-	// allow to replace {deliveryCode} place holder with the deliveryCode parameter passed to the action
-	// a publisher with a rtmpUrl set to {deliveryCode}.example.com/ondemand will be able to use different
-	// cdn configuration for different sub publishers by passing a different deliveryCode to the KDP
-	abstract protected function replaceDeliveryCode();
-	
 	abstract protected function tokenizeUrls();
 	
 	abstract protected function applyDomainPrefix();
@@ -244,9 +239,6 @@ abstract class kManifestRenderer
 	{
 		$this->prepareFlavors();
 		
-		if ($this->deliveryCode)
-			$this->replaceDeliveryCode();
-
 		$this->replacePlayServerSessionId();
 		
 		$this->tokenizeUrls();
@@ -285,7 +277,10 @@ abstract class kManifestRenderer
 		}
 		$content .= implode($separator, $flavors);
 		$content .= $separator . $footer;
-		
+
+		if($this->deliveryCode)
+			$content = str_replace("{deliveryCode}", $this->deliveryCode, $content);
+
 		header('Content-Length: ' . strlen($content));		// avoid chunked encoding
 		
 		echo $content;
@@ -372,13 +367,7 @@ class kSingleUrlManifestRenderer extends kManifestRenderer
 		$this->flavor = reset($flavors);	
 		$this->entryId = $entryId;
 	}
-	
-	protected function replaceDeliveryCode()
-	{
-		$this->flavor['url'] = str_replace("{deliveryCode}", $this->deliveryCode, $this->flavor['url']);
-		$this->flavor['urlPrefix'] = str_replace("{deliveryCode}", $this->deliveryCode, $this->flavor['urlPrefix']);
- 	}
-	
+
 	protected function tokenizeUrls()
 	{
 		self::normalizeUrlPrefix($this->flavor);
@@ -435,19 +424,7 @@ class kMultiFlavorManifestRenderer extends kManifestRenderer
 		$this->entryId = $entryId;
 		$this->baseUrl = $baseUrl;
 	}
-	
-	protected function replaceDeliveryCode()
-	{
-		$this->baseUrl = str_replace("{deliveryCode}", $this->deliveryCode, $this->baseUrl);
-		
-		foreach ($this->flavors as &$flavor)
-		{
-			$flavor['url'] = str_replace("{deliveryCode}", $this->deliveryCode, $flavor['url']);
-			if (isset($flavor['urlPrefix']))
-				$flavor['urlPrefix'] = str_replace("{deliveryCode}", $this->deliveryCode, $flavor['urlPrefix']);
-		}
-	}
-	
+
 	protected function tokenizeUrls()
 	{
 		if ($this->baseUrl)

--- a/plugins/content/caption/base/CaptionPlugin.php
+++ b/plugins/content/caption/base/CaptionPlugin.php
@@ -13,11 +13,6 @@ class CaptionPlugin extends KalturaPlugin implements IKalturaServices, IKalturaP
 
 	const SERVE_WEBVTT_URL_PREFIX = '/api_v3/index.php/service/caption_captionasset/action/serveWebVTT';
 
-	private static $getHostFromDeliveryProfile = array(
-		DeliveryProfileType::VOD_PACKAGER_HLS,
-		DeliveryProfileType::VOD_PACKAGER_HLS_MANIFEST
-	);
-
 	/* (non-PHPdoc)
 	 * @see IKalturaPlugin::getPluginName()
 	 */
@@ -558,7 +553,8 @@ class CaptionPlugin extends KalturaPlugin implements IKalturaServices, IKalturaP
 						if (reset($fs) === null)
 							continue;
 
-						if(in_array($config->deliveryProfile->getType(), self::$getHostFromDeliveryProfile) && !$config->storageId)
+						$getHostFromDeliveryProfile = array(DeliveryProfileType::VOD_PACKAGER_HLS, DeliveryProfileType::VOD_PACKAGER_HLS_MANIFEST);
+						if(in_array($config->deliveryProfile->getType(), $getHostFromDeliveryProfile) && !$config->storageId)
 						{
 							$protocol = $config->deliveryProfile->getDynamicAttributes()->getMediaProtocol();
 							$host = $protocol . '://' . $config->deliveryProfile->getHostName();

--- a/plugins/content/caption/base/CaptionPlugin.php
+++ b/plugins/content/caption/base/CaptionPlugin.php
@@ -11,7 +11,12 @@ class CaptionPlugin extends KalturaPlugin implements IKalturaServices, IKalturaP
 	const MULTI_CAPTION_FLOW_MANAGER_CLASS = 'kMultiCaptionFlowManager';
 	const COPY_CAPTIONS_FLOW_MANAGER_CLASS = 'kCopyCaptionsFlowManager';
 
-       const SERVE_WEBVTT_URL_PREFIX = '/api_v3/index.php/service/caption_captionasset/action/serveWebVTT';
+	const SERVE_WEBVTT_URL_PREFIX = '/api_v3/index.php/service/caption_captionasset/action/serveWebVTT';
+
+	private static $getHostFromDeliveryProfile = array(
+		DeliveryProfileType::VOD_PACKAGER_HLS,
+		DeliveryProfileType::VOD_PACKAGER_HLS_MANIFEST
+	);
 
 	/* (non-PHPdoc)
 	 * @see IKalturaPlugin::getPluginName()
@@ -553,8 +558,13 @@ class CaptionPlugin extends KalturaPlugin implements IKalturaServices, IKalturaP
 						if (reset($fs) === null)
 							continue;
 
-						$protocol = $config->deliveryProfile->getDynamicAttributes()->getMediaProtocol();
-						$host = $protocol . '://' . $config->deliveryProfile->getHostName();
+						if(in_array($config->deliveryProfile->getType(), self::$getHostFromDeliveryProfile) && !$config->storageId)
+						{
+							$protocol = $config->deliveryProfile->getDynamicAttributes()->getMediaProtocol();
+							$host = $protocol . '://' . $config->deliveryProfile->getHostName();
+						}
+						else
+							$host = myPartnerUtils::getCdnHost($captionAsset->getPartnerId());
 
 						$versionStr = '';
 						if ($captionAsset->getVersion() > 1)


### PR DESCRIPTION
- use delivery profile hostname in case of VOD_PACKAGER_HLS or VOD_PACKAGER_HLS_MANIFEST and no remote storage
- replace delivery code after manifest contributors 