### PR TITLE
Update DeliveryProfilePeer.php

### DIFF
--- a/alpha/lib/model/DeliveryProfilePeer.php
+++ b/alpha/lib/model/DeliveryProfilePeer.php
@@ -357,14 +357,15 @@ class DeliveryProfilePeer extends BaseDeliveryProfilePeer {
 	{
 		$c = new Criteria();
 
-		if (!count($deliveryAttributes->getDeliveryProfileIds()) && !$deliveryAttributes->getIsDeliveryProfilesBlockedList())
+		// If delivery profile ids were provided and it's a white list don't filter by IS_DEFAULT
+		if (count($deliveryAttributes->getDeliveryProfileIds()) && !$deliveryAttributes->getIsDeliveryProfilesBlockedList())
 		{
-			$c->add(DeliveryProfilePeer::IS_DEFAULT, true);
-			$c->add(DeliveryProfilePeer::PARTNER_ID, PartnerPeer::GLOBAL_PARTNER);
+			$c->add(DeliveryProfilePeer::PARTNER_ID, array(PartnerPeer::GLOBAL_PARTNER, $partner->getId()), Criteria::IN);
 		}
 		else
 		{
-			$c->add(DeliveryProfilePeer::PARTNER_ID, array(PartnerPeer::GLOBAL_PARTNER, $partner->getId()), Criteria::IN);
+			$c->add(DeliveryProfilePeer::IS_DEFAULT, true);
+			$c->add(DeliveryProfilePeer::PARTNER_ID, PartnerPeer::GLOBAL_PARTNER);
 		}
 
 		$c->add(DeliveryProfilePeer::STREAMER_TYPE, $streamerType);


### PR DESCRIPTION
Fix issue where blacklisting DP IDs would cause unexpected DP IDs to be used for the manifest construction.