### PR TITLE
add the player v3 versions map to studioV3 config

### DIFF
--- a/alpha/apps/kaltura/modules/kmc/actions/kmc4Action.class.php
+++ b/alpha/apps/kaltura/modules/kmc/actions/kmc4Action.class.php
@@ -167,7 +167,7 @@ class kmc4Action extends kalturaAction
 		$this->content_uiconfs_studio_v3 = isset($this->studioV3UiConf) ? array_values($this->studioV3UiConf) : null;
 		$this->content_uiconf_studio_v3 = (is_array($this->content_uiconfs_studio_v3) && reset($this->content_uiconfs_studio_v3)) ? reset($this->content_uiconfs_studio_v3) : null;
 
-		$this->playerV3VersionsUiConf = kmcUtils::getPartnersUiconfs(0, self::PLAYER_V3_VERSIONS_TAG);
+		$this->playerV3VersionsUiConf = uiConfPeer::getUiconfByTagAndVersion(self::PLAYER_V3_VERSIONS_TAG);
 		$this->content_uiconfs_player_v3_versions = isset($this->playerV3VersionsUiConf) ? array_values($this->playerV3VersionsUiConf) : null;
 		$this->content_uiconf_player_v3_versions = (is_array($this->content_uiconfs_player_v3_versions) && reset($this->content_uiconfs_player_v3_versions)) ? reset($this->content_uiconfs_player_v3_versions) : null;
 

--- a/alpha/apps/kaltura/modules/kmc/actions/kmc4Action.class.php
+++ b/alpha/apps/kaltura/modules/kmc/actions/kmc4Action.class.php
@@ -232,7 +232,7 @@ class kmc4Action extends kalturaAction
                 'version'				=> kConf::get("studio_v3_version"),
                 'uiConfID'				=> isset($this->content_uiconf_studio_v3) ? $this->content_uiconf_studio_v3->getId() : '',
                 'config'				=> isset($this->content_uiconf_studio_v3) ? $this->content_uiconf_studio_v3->getConfig() : '',
-                'playerV3VersionsMap'		=> isset($this->content_uiconf_player_v3_versions) ? $this->content_uiconf_player_v3_versions->getConfig() : '',
+                'playerVersionsMap'		=> isset($this->content_uiconf_player_v3_versions) ? $this->content_uiconf_player_v3_versions->getConfig() : '',
                 'showFlashStudio'		=> $showFlashStudio,
                 'showHTMLStudio'		=> $showHTMLStudio,
                 'showStudioV3'		    => $showStudioV3,

--- a/alpha/apps/kaltura/modules/kmc/actions/kmc4Action.class.php
+++ b/alpha/apps/kaltura/modules/kmc/actions/kmc4Action.class.php
@@ -8,6 +8,7 @@ class kmc4Action extends kalturaAction
 	const CURRENT_KMC_VERSION = 4;
     const HTML5_STUDIO_TAG = 'HTML5Studio';
     const STUDIO_V3_TAG = 'HTML5StudioV3';
+    const STUDIO_V3_VERSIONS_TAG = 'playerV3Versions';
 	const LIVE_ANALYTICS_UICONF_TAG = 'livea_player';
 	const LIVE_DASHBOARD_UICONF_TAG = 'lived_player';
 	
@@ -166,6 +167,10 @@ class kmc4Action extends kalturaAction
 		$this->content_uiconfs_studio_v3 = isset($this->studioV3UiConf) ? array_values($this->studioV3UiConf) : null;
 		$this->content_uiconf_studio_v3 = (is_array($this->content_uiconfs_studio_v3) && reset($this->content_uiconfs_studio_v3)) ? reset($this->content_uiconfs_studio_v3) : null;
 
+		$this->playerV3VersionsUiConf = kmcUtils::getPartnersUiconfs(0, self::STUDIO_V3_VERSIONS_TAG);
+		$this->content_uiconfs_player_v3_versions = isset($this->playerV3VersionsUiConf) ? array_values($this->playerV3VersionsUiConf) : null;
+		$this->content_uiconf_player_v3_versions = (is_array($this->content_uiconfs_player_v3_versions) && reset($this->content_uiconfs_player_v3_versions)) ? reset($this->content_uiconfs_player_v3_versions) : null;
+
 		$this->liveAUiConf = uiConfPeer::getUiconfByTagAndVersion(self::LIVE_ANALYTICS_UICONF_TAG, kConf::get("liveanalytics_version"));
 		$this->content_uiconfs_livea = isset($this->liveAUiConf) ? array_values($this->liveAUiConf) : null;
 		$this->content_uiconf_livea = (is_array($this->content_uiconfs_livea) && reset($this->content_uiconfs_livea)) ? reset($this->content_uiconfs_livea) : null;
@@ -227,6 +232,7 @@ class kmc4Action extends kalturaAction
                 'version'				=> kConf::get("studio_v3_version"),
                 'uiConfID'				=> isset($this->content_uiconf_studio_v3) ? $this->content_uiconf_studio_v3->getId() : '',
                 'config'				=> isset($this->content_uiconf_studio_v3) ? $this->content_uiconf_studio_v3->getConfig() : '',
+                'v3VersionsUiConfID'	=> isset($this->content_uiconf_player_v3_versions) ? $this->content_uiconf_player_v3_versions->getId() : '',
                 'showFlashStudio'		=> $showFlashStudio,
                 'showHTMLStudio'		=> $showHTMLStudio,
                 'showStudioV3'		    => $showStudioV3,

--- a/alpha/apps/kaltura/modules/kmc/actions/kmc4Action.class.php
+++ b/alpha/apps/kaltura/modules/kmc/actions/kmc4Action.class.php
@@ -8,7 +8,7 @@ class kmc4Action extends kalturaAction
 	const CURRENT_KMC_VERSION = 4;
     const HTML5_STUDIO_TAG = 'HTML5Studio';
     const STUDIO_V3_TAG = 'HTML5StudioV3';
-    const STUDIO_V3_VERSIONS_TAG = 'playerV3Versions';
+    const PLAYER_V3_VERSIONS_TAG = 'playerV3Versions';
 	const LIVE_ANALYTICS_UICONF_TAG = 'livea_player';
 	const LIVE_DASHBOARD_UICONF_TAG = 'lived_player';
 	
@@ -167,7 +167,7 @@ class kmc4Action extends kalturaAction
 		$this->content_uiconfs_studio_v3 = isset($this->studioV3UiConf) ? array_values($this->studioV3UiConf) : null;
 		$this->content_uiconf_studio_v3 = (is_array($this->content_uiconfs_studio_v3) && reset($this->content_uiconfs_studio_v3)) ? reset($this->content_uiconfs_studio_v3) : null;
 
-		$this->playerV3VersionsUiConf = kmcUtils::getPartnersUiconfs(0, self::STUDIO_V3_VERSIONS_TAG);
+		$this->playerV3VersionsUiConf = kmcUtils::getPartnersUiconfs(0, self::PLAYER_V3_VERSIONS_TAG);
 		$this->content_uiconfs_player_v3_versions = isset($this->playerV3VersionsUiConf) ? array_values($this->playerV3VersionsUiConf) : null;
 		$this->content_uiconf_player_v3_versions = (is_array($this->content_uiconfs_player_v3_versions) && reset($this->content_uiconfs_player_v3_versions)) ? reset($this->content_uiconfs_player_v3_versions) : null;
 
@@ -232,7 +232,7 @@ class kmc4Action extends kalturaAction
                 'version'				=> kConf::get("studio_v3_version"),
                 'uiConfID'				=> isset($this->content_uiconf_studio_v3) ? $this->content_uiconf_studio_v3->getId() : '',
                 'config'				=> isset($this->content_uiconf_studio_v3) ? $this->content_uiconf_studio_v3->getConfig() : '',
-                'v3VersionsUiConfID'	=> isset($this->content_uiconf_player_v3_versions) ? $this->content_uiconf_player_v3_versions->getId() : '',
+                'playerV3VersionsUiConfID'	=> isset($this->content_uiconf_player_v3_versions) ? $this->content_uiconf_player_v3_versions->getId() : '',
                 'showFlashStudio'		=> $showFlashStudio,
                 'showHTMLStudio'		=> $showHTMLStudio,
                 'showStudioV3'		    => $showStudioV3,

--- a/alpha/apps/kaltura/modules/kmc/actions/kmc4Action.class.php
+++ b/alpha/apps/kaltura/modules/kmc/actions/kmc4Action.class.php
@@ -232,7 +232,7 @@ class kmc4Action extends kalturaAction
                 'version'				=> kConf::get("studio_v3_version"),
                 'uiConfID'				=> isset($this->content_uiconf_studio_v3) ? $this->content_uiconf_studio_v3->getId() : '',
                 'config'				=> isset($this->content_uiconf_studio_v3) ? $this->content_uiconf_studio_v3->getConfig() : '',
-                'playerV3VersionsUiConfID'	=> isset($this->content_uiconf_player_v3_versions) ? $this->content_uiconf_player_v3_versions->getId() : '',
+                'playerV3VersionsMap'		=> isset($this->content_uiconf_player_v3_versions) ? $this->content_uiconf_player_v3_versions->getConfig() : '',
                 'showFlashStudio'		=> $showFlashStudio,
                 'showHTMLStudio'		=> $showHTMLStudio,
                 'showStudioV3'		    => $showStudioV3,


### PR DESCRIPTION
e.g 
`kmc.vars.studioV3.playerVersionsMap` is
```
"{
    "kaltura-ovp-player": "0.27.0",
    "kaltura-tv-player": "0.27.0",
    "playkit-ima": "0.6.0",
    "playkit-youbora": "0.4.0",
    "playkit-comscore": "1.0.1",
    "playkit-google-analytics": "0.1.1",
    "playkit-offline-manager":"1.0.2"
}"
```