### PR TITLE
remove studio v3 from kmc beta

### DIFF
--- a/alpha/apps/kaltura/modules/kmcng/actions/kmcngAction.class.php
+++ b/alpha/apps/kaltura/modules/kmcng/actions/kmcngAction.class.php
@@ -95,7 +95,8 @@ class kmcngAction extends kalturaAction
 			);
 		}
 
-		if (kConf::hasParam("studio_v3_version") && kConf::hasParam("html5_version"))
+		// TODO Future use - remove the false flag
+		if (false && kConf::hasParam("studio_v3_version") && kConf::hasParam("html5_version"))
 		{
 			$studioV3 = array(
 				"enabled" => true,


### PR DESCRIPTION
Per @itaykinnrot request this PR remove studio v3 from kmcng beta version. It will be re-added for the GA version which include additional required data.