### PR TITLE
This alias will never match because of the one defined in line 26

### DIFF
--- a/configurations/apache/conf.d/apps.conf.template
+++ b/configurations/apache/conf.d/apps.conf.template
@@ -35,7 +35,6 @@ Alias /apps "@BASE_DIR@/apps"
     </IfVersion>
 </Directory>
 
-Alias /apps/kea "@BASE_DIR@/apps/kea"
 <Directory "@BASE_DIR@/apps/kea">
     DirectoryIndex index.php
     Options -Indexes +FollowSymLinks +Includes


### PR DESCRIPTION
Alias /apps "/opt/kaltura/apps"

All it does is trigger the following warning:

> The Alias directive in
> /opt/kaltura/app/configurations/apache/conf.d/enabled.apps.conf at line
> 38 will probably never match because it overlaps an earlier Alias.