### PR TITLE
Naos-14.1.0-PLAT-8940-Facebook const fix

### DIFF
--- a/alpha/apps/kaltura/lib/kAuthDataCache.php
+++ b/alpha/apps/kaltura/lib/kAuthDataCache.php
@@ -2,7 +2,7 @@
 
 class kAuthDataCache
 {
-	CONST DEFAULT_TIME_IN_CACHE_FOR_AUTH_CACHED_DATA = 60*30; //half an hour
+	CONST DEFAULT_TIME_IN_CACHE_FOR_AUTH_CACHED_DATA = 1800; //half an hour
 
 	/**
 	 * @var kBaseCacheWrapper $cache

--- a/alpha/apps/kaltura/lib/kAuthDataCache.php
+++ b/alpha/apps/kaltura/lib/kAuthDataCache.php
@@ -2,7 +2,7 @@
 
 class kAuthDataCache
 {
-	CONST DEFAULT_TIME_IN_CACHE_FOR_AUTH_CACHED_DATA = 1800; //half an hour
+	const DEFAULT_TIME_IN_CACHE_FOR_AUTH_CACHED_DATA = 1800; //half an hour
 
 	/**
 	 * @var kBaseCacheWrapper $cache


### PR DESCRIPTION
Const Scalar Expressions only work from php 5.6