### PR TITLE
add Access-Control-Max-Age header to API calls

### DIFF
--- a/api_v3/web/index.php
+++ b/api_v3/web/index.php
@@ -7,6 +7,7 @@ if($_SERVER['REQUEST_METHOD'] == 'OPTIONS')
 	header('Access-Control-Allow-Origin: *');
 	header('Access-Control-Allow-Headers: Origin, X-Requested-With, Content-Type, Accept, Range, Cache-Control');
 	header('Access-Control-Allow-Methods: POST, GET, HEAD, OPTIONS');
+	header('Access-Control-Max-Age: 86400');
 	exit;
 }
 


### PR DESCRIPTION
See https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Access-Control-Max-Age.

This change should reduce the number of preflight `OPTIONS` requests to the server significantly, especially with a client-side application, e.g., KMC.