### PR TITLE
Unset $this inside an object method is no longer allowed

### DIFF
--- a/infra/cdl/kdl/KDLProcessor.php
+++ b/infra/cdl/kdl/KDLProcessor.php
@@ -393,7 +393,7 @@ KalturaLog::log("Automatic Intermediate Source will be generated");
 			;
 		}
 		public function __destruct() {
-			unset($this);
+			;
 		}
 
 		/* ---------------------------


### PR DESCRIPTION
Additionally remove a unset($this) that was missed in 9f626278ee63672aec172138bbf569394fb697b6