### PR TITLE
kava live - optimization for KWP queries

### DIFF
--- a/api_v3/services/LiveReportsService.php
+++ b/api_v3/services/LiveReportsService.php
@@ -125,7 +125,12 @@ class LiveReportsService extends KalturaBaseService
 		}
 		
 		list($methodName, $objectType) = $reportTypes[$reportType];
-		
+		if ($methodName == 'entryTotal' &&
+			kString::beginsWith(kCurrentContext::$client_lang, 'KWP:'))
+		{
+			$methodName = 'entryQuality';
+		} 
+
 		try
 		{
 			list($items, $totalCount) = call_user_func(array('kKavaLiveReportsMgr', $methodName), 


### PR DESCRIPTION
return only the fields needed by the application, specifically peakAudience / peakDvrAudience require an additional query to calc, which can be skipped