### PR TITLE
Support custom thumbnails for image entries

### DIFF
--- a/alpha/apps/kaltura/lib/batch2/bcdl/kBusinessConvertDL.php
+++ b/alpha/apps/kaltura/lib/batch2/bcdl/kBusinessConvertDL.php
@@ -300,15 +300,15 @@ class kBusinessConvertDL
 			$thumbAsset->addTags(array(thumbParams::TAG_DEFAULT_THUMB));
 			$thumbAsset->save();
 			KalturaLog::info("Setting entry [". $thumbAsset->getEntryId() ."] default ThumbAsset to [". $thumbAsset->getId() ."]");
+
+			$entry->setThumbnail(".jpg");
+			$entry->setCreateThumb(false, $thumbAsset);
+			$entry->save();
+
+			$thumbSyncKey = $thumbAsset->getSyncKey(thumbAsset::FILE_SYNC_FLAVOR_ASSET_SUB_TYPE_ASSET);
+			$entrySyncKey = $entry->getSyncKey(entry::FILE_SYNC_ENTRY_SUB_TYPE_THUMB);
+			kFileSyncUtils::createSyncFileLinkForKey($entrySyncKey, $thumbSyncKey);
 		}
-
-		$entry->setThumbnail(".jpg");
-		$entry->setCreateThumb(false, $thumbAsset);
-		$entry->save();
-
-		$thumbSyncKey = $thumbAsset->getSyncKey(thumbAsset::FILE_SYNC_FLAVOR_ASSET_SUB_TYPE_ASSET);
-		$entrySyncKey = $entry->getSyncKey(entry::FILE_SYNC_ENTRY_SUB_TYPE_THUMB);
-		kFileSyncUtils::createSyncFileLinkForKey($entrySyncKey, $thumbSyncKey);
 	}
 
 	public static function parseFlavorDescription(flavorParamsOutputWrap $flavor)

--- a/alpha/apps/kaltura/lib/myEntryUtils.class.php
+++ b/alpha/apps/kaltura/lib/myEntryUtils.class.php
@@ -1266,7 +1266,8 @@ class myEntryUtils
 	
 	public static function getLocalImageFilePathByEntry( $entry, $version = null )
 	{
-		$sub_type = $entry->getMediaType() == entry::ENTRY_MEDIA_TYPE_IMAGE ? entry::FILE_SYNC_ENTRY_SUB_TYPE_DATA : entry::FILE_SYNC_ENTRY_SUB_TYPE_THUMB;
+		$sub_type = $entry->getMediaType() == entry::ENTRY_MEDIA_TYPE_IMAGE ?
+			$entry->getThumbnailOrDataSubType($version) : entry::FILE_SYNC_ENTRY_SUB_TYPE_THUMB;
 		$entry_image_key = $entry->getSyncKey($sub_type, $version);
 		$entry_image_path = kFileSyncUtils::getReadyLocalFilePathForKey($entry_image_key);
 		if (!$entry_image_path && $version == 100000)

--- a/alpha/apps/kaltura/modules/extwidget/actions/thumbnailAction.class.php
+++ b/alpha/apps/kaltura/modules/extwidget/actions/thumbnailAction.class.php
@@ -60,6 +60,7 @@ class thumbnailAction extends sfAction
 		$widget_id = $this->getRequestParameter("widget_id", 0);
 		$upload_token_id = $this->getRequestParameter("upload_token_id");
 		$version = $this->getIntRequestParameter("version", null, 0, 10000000);
+		$version = $version < 1 ? null : $version;
 		$type = $this->getIntRequestParameter("type", 1, 1, 5);
 		//Hack: if KMS sends thumbnail request containing "!" char, the type should be treated as 5.
 		
@@ -344,7 +345,7 @@ class thumbnailAction extends sfAction
 		
 		$subType = entry::FILE_SYNC_ENTRY_SUB_TYPE_THUMB;
 		if($entry->getMediaType() == entry::ENTRY_MEDIA_TYPE_IMAGE)
-			$subType = entry::FILE_SYNC_ENTRY_SUB_TYPE_DATA;
+			$subType = $entry->getThumbnailOrDataSubType($version);
 			
 		$dataKey = $entry->getSyncKey($subType);
 		list ( $file_sync , $local ) = kFileSyncUtils::getReadyFileSyncForKey( $dataKey ,true , false );


### PR DESCRIPTION
This adds support for image entries to have custom thumbnails and changes are made accordingly when fetching media metadata or calling thumbnail service.

Changes are tested with external storage enabled and disabled. It is working in both cases. 
However, in case of external storage enabled and once the file is exported, on the KMC content tab, thumbnails for image entries disappear because the URLs become like this "http://xxxxx.cloudfront.net/content/entry/data/0/0/0_j8y8fxw8_100002.jpg/bgcolor/F7F7F7/type/2". I couldn't look into this as KMC is in flash

Thanks