### PR TITLE
PHP7: Make sure getStreamInfo will always return an array object to avoid PHP Warning when calling count on it

### DIFF
--- a/alpha/lib/data/live/kLiveStreamConfiguration.php
+++ b/alpha/lib/data/live/kLiveStreamConfiguration.php
@@ -121,7 +121,7 @@ class kLiveStreamConfiguration
 	}
 	
 	public function getPrimaryStreamInfo() {
-		return $this->primaryStreamInfo;
+		return $this->primaryStreamInfo ? $this->primaryStreamInfo : array();
 	}
 	
 	public function setBackupStreamInfo($v) {
@@ -129,6 +129,6 @@ class kLiveStreamConfiguration
 	}
 	
 	public function getBackupStreamInfo() {
-		return $this->backupStreamInfo;
+		return $this->backupStreamInfo ? $this->backupStreamInfo : array();
 	}
 }


### PR DESCRIPTION
…void PHP Warning when calling count on it