### PR TITLE
PSVAMB-4593 Email notifications per KMS

### DIFF
--- a/tests/standAloneClient/uniqueMediaspaceNotificationsTemplates.xml
+++ b/tests/standAloneClient/uniqueMediaspaceNotificationsTemplates.xml
@@ -22,7 +22,7 @@
 				<eventObjectType>37</eventObjectType> <!-- EventNotificationEventObjectType::CATEGORYENTRY -->
 				<eventConditions objectType="array">
 					<item objectType="KalturaEventFieldCondition">
-						<description>Status is pending, See:KalturaCategoryEntryStatus:/api_v3/testmeDoc/?object=KalturaCategoryEntryStatus</description>
+						<description>Status is pending, see KalturaCategoryEntryStatus</description>
 						<field objectType="KalturaEvalBooleanField">
 							<code>$scope->getObject() instanceof categoryEntry &amp;&amp; $scope->getObject()->getStatus() == CategoryEntryStatus::PENDING</code>
 						</field>
@@ -66,7 +66,7 @@
 						<key>entry_name</key>
 						<description>Entry name</description>
 						<value objectType="KalturaEvalStringField">
-							<code>!is_null(entryPeer::retrieveByPk($scope->getObject()->getEntryId())) ? entryPeer::retrieveByPk($scope->getObject()->getEntryId())->getName() : ''</code>
+							<code>($entry = entryPeer::retrieveByPk($scope->getObject()->getEntryId())) ? $entry->getName() : ''</code>
 						</value>
 					</item>
 					<item objectType="KalturaEventNotificationParameter">
@@ -80,14 +80,14 @@
 						<key>category_name</key>
 						<description>Category name</description>
 						<value objectType="KalturaEvalStringField">
-							<code>!is_null(categoryPeer::retrieveByPk($scope->getObject()->getCategoryId())) ? categoryPeer::retrieveByPk($scope->getObject()->getCategoryId())->getName() : ''</code>
+							<code>($category = categoryPeer::retrieveByPk($scope->getObject()->getCategoryId())) ? $category->getName() : ''</code>
 						</value>
 					</item>
 					<item objectType="KalturaEventNotificationParameter">
 						<key>category_name_encoded</key>
 						<description>Encoded category name</description>
 						<value objectType="KalturaEvalStringField">
-							<code>urlencode(!is_null(categoryPeer::retrieveByPk($scope->getObject()->getCategoryId())) ? categoryPeer::retrieveByPk($scope->getObject()->getCategoryId())->getName() : '')</code>
+							<code>urlencode(($category = categoryPeer::retrieveByPk($scope->getObject()->getCategoryId())) ? $category->getName() : '')</code>
 						</value>
 					</item>
 				</contentParameters>
@@ -119,7 +119,7 @@
 				<eventObjectType>37</eventObjectType> <!-- EventNotificationEventObjectType::CATEGORYENTRY -->
 				<eventConditions objectType="array">
 					<item objectType="KalturaEventFieldCondition">
-						<description>Status changed to pending, See:KalturaCategoryEntryStatus:/api_v3/testmeDoc/?object=KalturaCategoryEntryStatus</description>
+						<description>Status changed to pending, see KalturaCategoryEntryStatus</description>
 						<field objectType="KalturaEvalBooleanField">
 							<code>$scope->getObject() instanceof categoryEntry &amp;&amp; in_array(categoryEntryPeer::STATUS, $scope->getEvent()->getModifiedColumns()) &amp;&amp; $scope->getObject()->getStatus() == CategoryEntryStatus::PENDING</code>
 						</field>
@@ -163,7 +163,7 @@
 						<key>entry_name</key>
 						<description>Entry name</description>
 						<value objectType="KalturaEvalStringField">
-							<code>!is_null(entryPeer::retrieveByPk($scope->getObject()->getEntryId())) ? entryPeer::retrieveByPk($scope->getObject()->getEntryId())->getName() : ''</code>
+							<code>($entry = entryPeer::retrieveByPk($scope->getObject()->getEntryId())) ? $entry->getName() : ''</code>
 						</value>
 					</item>
 					<item objectType="KalturaEventNotificationParameter">
@@ -177,14 +177,14 @@
 						<key>category_name</key>
 						<description>Category name</description>
 						<value objectType="KalturaEvalStringField">
-							<code>!is_null(categoryPeer::retrieveByPk($scope->getObject()->getCategoryId())) ? categoryPeer::retrieveByPk($scope->getObject()->getCategoryId())->getName() : ''</code>
+							<code>($category = categoryPeer::retrieveByPk($scope->getObject()->getCategoryId())) ? $category->getName() : ''</code>
 						</value>
 					</item>
 					<item objectType="KalturaEventNotificationParameter">
 						<key>category_name_encoded</key>
 						<description>Encoded category name</description>
 						<value objectType="KalturaEvalStringField">
-							<code>urlencode(!is_null(categoryPeer::retrieveByPk($scope->getObject()->getCategoryId())) ? categoryPeer::retrieveByPk($scope->getObject()->getCategoryId())->getName() : '')</code>
+							<code>urlencode(($category = categoryPeer::retrieveByPk($scope->getObject()->getCategoryId())) ? $category->getName() : '')</code>
 						</value>
 					</item>
 				</contentParameters>
@@ -216,7 +216,7 @@
 				<eventObjectType>37</eventObjectType> <!-- EventNotificationEventObjectType::CATEGORYENTRY -->
 				<eventConditions objectType="array">
 					<item objectType="KalturaEventFieldCondition">
-						<description>Status changed to active, See:KalturaCategoryEntryStatus:/api_v3/testmeDoc/?object=KalturaCategoryEntryStatus</description>
+						<description>Status changed to active, see KalturaCategoryEntryStatus</description>
 						<field objectType="KalturaEvalBooleanField">
 							<code>$scope->getObject() instanceof categoryEntry &amp;&amp; in_array(categoryEntryPeer::STATUS, $scope->getEvent()->getModifiedColumns()) &amp;&amp; $scope->getObject()->getStatus() == CategoryEntryStatus::ACTIVE</code>
 						</field>
@@ -237,10 +237,10 @@
 					<emailRecipients objectType="array">
 						<item objectType = "KalturaEmailNotificationRecipient">
 							<email objectType="KalturaEvalStringField">
-								<code>!is_null(entryPeer::retrieveByPk($scope->getObject()->getEntryId())) ? entryPeer::retrieveByPk($scope->getObject()->getEntryId())->getkuser()->getEmail() : ''</code>
+								<code>($entry = entryPeer::retrieveByPk($scope->getObject()->getEntryId())) ? $entry->getkuser()->getEmail() : ''</code>
 							</email>
 							<name objectType="KalturaEvalStringField">
-								<code>!is_null(entryPeer::retrieveByPk($scope->getObject()->getEntryId())) ? entryPeer::retrieveByPk($scope->getObject()->getEntryId())->getkuser()->getFirstName().' '.entryPeer::retrieveByPk($scope->getObject()->getEntryId())->getkuser()->getLastName() : ''</code>
+								<code>($entry = entryPeer::retrieveByPk($scope->getObject()->getEntryId())) ? $entry->getkuser()->getFirstName().' '.$entry->getkuser()->getLastName() : ''</code>
 							</name>
 						</item>
 					</emailRecipients>
@@ -264,14 +264,14 @@
 						<key>entry_name</key>
 						<description>Entry name</description>
 						<value objectType="KalturaEvalStringField">
-							<code>!is_null(entryPeer::retrieveByPk($scope->getObject()->getEntryId())) ? entryPeer::retrieveByPk($scope->getObject()->getEntryId())->getName() : ''</code>
+							<code>($entry = entryPeer::retrieveByPk($scope->getObject()->getEntryId())) ? $entry->getName() : ''</code>
 						</value>
 					</item>
 					<item objectType="KalturaEventNotificationParameter">
 						<key>category_name</key>
 						<description>Category name</description>
 						<value objectType="KalturaEvalStringField">
-							<code>!is_null(categoryPeer::retrieveByPk($scope->getObject()->getCategoryId())) ? categoryPeer::retrieveByPk($scope->getObject()->getCategoryId())->getName() : ''</code>
+							<code>($category = categoryPeer::retrieveByPk($scope->getObject()->getCategoryId())) ? $category->getName() : ''</code>
 						</value>
 					</item>
 					<item objectType="KalturaEventNotificationParameter">
@@ -310,7 +310,7 @@
 				<eventObjectType>37</eventObjectType> <!-- EventNotificationEventObjectType::CATEGORYENTRY -->
 				<eventConditions objectType="array">
 					<item objectType="KalturaEventFieldCondition">
-						<description>Status changed to rejected, See:KalturaCategoryEntryStatus:/api_v3/testmeDoc/?object=KalturaCategoryEntryStatus</description>
+						<description>Status changed to rejected, see KalturaCategoryEntryStatus</description>
 						<field objectType="KalturaEvalBooleanField">
 							<code>$scope->getObject() instanceof categoryEntry &amp;&amp; in_array(categoryEntryPeer::STATUS, $scope->getEvent()->getModifiedColumns()) &amp;&amp; $scope->getObject()->getStatus() == CategoryEntryStatus::REJECTED</code>
 						</field>
@@ -331,10 +331,10 @@
 					<emailRecipients objectType="array">
 						<item objectType = "KalturaEmailNotificationRecipient">
 							<email objectType="KalturaEvalStringField">
-								<code>!is_null(entryPeer::retrieveByPk($scope->getObject()->getEntryId())) ? entryPeer::retrieveByPk($scope->getObject()->getEntryId())->getkuser()->getEmail() : ''</code>
+								<code>($entry = entryPeer::retrieveByPk($scope->getObject()->getEntryId())) ? $entry->getkuser()->getEmail() : ''</code>
 							</email>
 							<name objectType="KalturaEvalStringField">
-								<code>!is_null(entryPeer::retrieveByPk($scope->getObject()->getEntryId())) ? entryPeer::retrieveByPk($scope->getObject()->getEntryId())->getkuser()->getFirstName().' '.entryPeer::retrieveByPk($scope->getObject()->getEntryId())->getkuser()->getLastName() : ''</code>
+								<code>($entry = entryPeer::retrieveByPk($scope->getObject()->getEntryId())) ? $entry->getkuser()->getFirstName().' '.$entry->getkuser()->getLastName() : ''</code>
 							</name>
 						</item>
 					</emailRecipients>
@@ -358,14 +358,14 @@
 						<key>entry_name</key>
 						<description>Entry name</description>
 						<value objectType="KalturaEvalStringField">
-							<code>!is_null(entryPeer::retrieveByPk($scope->getObject()->getEntryId())) ? entryPeer::retrieveByPk($scope->getObject()->getEntryId())->getName() : ''</code>
+							<code>($entry = entryPeer::retrieveByPk($scope->getObject()->getEntryId())) ? $entry->getName() : ''</code>
 						</value>
 					</item>
 					<item objectType="KalturaEventNotificationParameter">
 						<key>category_name</key>
 						<description>Category name</description>
 						<value objectType="KalturaEvalStringField">
-							<code>!is_null(categoryPeer::retrieveByPk($scope->getObject()->getCategoryId())) ? categoryPeer::retrieveByPk($scope->getObject()->getCategoryId())->getName() : ''</code>
+							<code>($category = categoryPeer::retrieveByPk($scope->getObject()->getCategoryId())) ? $category->getName() : ''</code>
 						</value>
 					</item>
 					<item objectType="KalturaEventNotificationParameter">
@@ -404,7 +404,7 @@
 				<eventObjectType>1</eventObjectType> <!-- EventNotificationEventObjectType::ENTRY -->
 				<eventConditions objectType="array">
 					<item objectType="KalturaEventFieldCondition">
-						<description>Moderation status changed to rejected, See:KalturaEntryModerationStatus:/api_v3/testmeDoc/?object=KalturaEntryModerationStatus</description>
+						<description>Moderation status changed to rejected, see KalturaEntryModerationStatus</description>
 						<field objectType="KalturaEvalBooleanField">
 							<code>$scope->getObject() instanceof entry &amp;&amp; in_array(entryPeer::MODERATION_STATUS, $scope->getEvent()->getModifiedColumns()) &amp;&amp; $scope->getObject()->getModerationStatus() == entry::ENTRY_MODERATION_STATUS_REJECTED</code>
 						</field>
@@ -429,10 +429,10 @@
 					<emailRecipients objectType="array">
 						<item objectType = "KalturaEmailNotificationRecipient">
 							<email objectType="KalturaEvalStringField">
-								<code>!is_null($scope->getObject()->getkuser()) ? $scope->getObject()->getkuser()->getEmail() : ''</code>
+								<code>($user = $scope->getObject()->getkuser()) ? $user->getEmail() : ''</code>
 							</email>
 							<name objectType="KalturaEvalStringField">
-								<code>!is_null($scope->getObject()->getkuser()) ? $scope->getObject()->getkuser()->getFirstName().' '.$scope->getObject()->getkuser()->getLastName() : ''</code>
+								<code>($user = $scope->getObject()->getkuser()) ? $user->getFirstName().' '.$user->getLastName() : ''</code>
 							</name>
 						</item>
 					</emailRecipients>
@@ -488,7 +488,7 @@
 				<eventObjectType>1</eventObjectType> <!-- EventNotificationEventObjectType::ENTRY -->
 				<eventConditions objectType="array">
 					<item objectType="KalturaEventFieldCondition">
-						<description>Moderation status changed to approved, See:KalturaEntryModerationStatus:/api_v3/testmeDoc/?object=KalturaEntryModerationStatus</description>
+						<description>Moderation status changed to approved, see KalturaEntryModerationStatus</description>
 						<field objectType="KalturaEvalBooleanField">
 							<code>$scope->getObject() instanceof entry &amp;&amp; in_array(entryPeer::MODERATION_STATUS, $scope->getEvent()->getModifiedColumns()) &amp;&amp; $scope->getObject()->getModerationStatus() == entry::ENTRY_MODERATION_STATUS_APPROVED</code>
 						</field>
@@ -513,10 +513,10 @@
 					<emailRecipients objectType="array">
 						<item objectType = "KalturaEmailNotificationRecipient">
 							<email objectType="KalturaEvalStringField">
-								<code>!is_null($scope->getObject()->getkuser()) ? $scope->getObject()->getkuser()->getEmail() : ''</code>
+								<code>($user = $scope->getObject()->getkuser()) ? $user->getEmail() : ''</code>
 							</email>
 							<name objectType="KalturaEvalStringField">
-								<code>!is_null($scope->getObject()->getkuser()) ? $scope->getObject()->getkuser()->getFirstName().' '.$scope->getObject()->getkuser()->getLastName() : ''</code>
+								<code>($user = $scope->getObject()->getkuser()) ? $user->getFirstName().' '.$user->getLastName() : ''</code>
 							</name>
 						</item>
 					</emailRecipients>
@@ -572,7 +572,7 @@
 				<eventObjectType>1</eventObjectType> <!-- EventNotificationEventObjectType::ENTRY -->
 				<eventConditions objectType="array">
 					<item objectType="KalturaEventFieldCondition">
-						<description>Status changed to ready, See:KalturaEntryStatus:/api_v3/testmeDoc/?object=KalturaEntryStatus</description>
+						<description>Status changed to ready, see KalturaEntryStatus</description>
 						<field objectType="KalturaEvalBooleanField">
 							<code>$scope->getObject() instanceof entry &amp;&amp; in_array(entryPeer::STATUS, $scope->getEvent()->getModifiedColumns()) &amp;&amp; $scope->getObject()->getStatus() == entryStatus::READY</code>
 						</field>
@@ -688,14 +688,14 @@
 						<key>owner_name</key>
 						<description>Account owner name</description>
 						<value objectType="KalturaEvalStringField">
-							<code>!is_null(entryPeer::retrieveByPk($scope->getObject()->getEntryId())) ? entryPeer::retrieveByPk($scope->getObject()->getEntryId())->getPartner()->getPartnerName() : ''</code>
+							<code>($entry = entryPeer::retrieveByPk($scope->getObject()->getEntryId())) ? $entry->getPartner()->getPartnerName() : ''</code>
 						</value>
 					</item>
 					<item objectType="KalturaEventNotificationParameter">
 						<key>owner_email</key>
 						<description>Account owner email</description>
 						<value objectType="KalturaEvalStringField">
-							<code>!is_null(entryPeer::retrieveByPk($scope->getObject()->getEntryId())) ? entryPeer::retrieveByPk($scope->getObject()->getEntryId())->getPartner()->getAdminEmail() : ''</code>
+							<code>($entry = entryPeer::retrieveByPk($scope->getObject()->getEntryId())) ? $entry->getPartner()->getAdminEmail() : ''</code>
 						</value>
 					</item>
 				</contentParameters>
@@ -727,13 +727,13 @@
 				<eventObjectType>12</eventObjectType> <!-- EventNotificationEventObjectType::CATEGORYKUSER -->
 				<eventConditions objectType="array">
 					<item objectType="KalturaEventFieldCondition">
-						<description>Status is active, See:KalturaCategoryUserStatus:/api_v3/testmeDoc/?object=KalturaCategoryUserStatus</description>
+						<description>Status is active, see KalturaCategoryUserStatus</description>
 						<field objectType="KalturaEvalBooleanField">
 							<code>$scope->getObject() instanceof categoryKuser &amp;&amp; $scope->getObject()->getStatus() == CategoryKuserStatus::ACTIVE</code>
 						</field>
 					</item>
 					<item objectType="KalturaEventFieldCondition">
-						<description>User has role, See:KalturaCategoryUserPermissionLevel:/api_v3/testmeDoc/?object=KalturaCategoryUserStatus</description>
+						<description>User has role, see KalturaCategoryUserPermissionLevel</description>
 						<field objectType="KalturaEvalBooleanField">
 							<code>$scope->getObject() instanceof categoryKuser &amp;&amp; category::getPermissionLevelName($scope->getObject()->getPermissionLevel())</code>
 						</field>
@@ -754,10 +754,10 @@
 					<emailRecipients objectType="array">
 						<item objectType = "KalturaEmailNotificationRecipient">
 							<email objectType="KalturaEvalStringField">
-								<code>!is_null($scope->getObject()->getkuser()) ? $scope->getObject()->getkuser()->getEmail() : ''</code>
+								<code>($user = $scope->getObject()->getkuser()) ? $user->getEmail() : ''</code>
 							</email>
 							<name objectType="KalturaEvalStringField">
-								<code>!is_null($scope->getObject()->getkuser()) ? $scope->getObject()->getkuser()->getFirstName().' '.$scope->getObject()->getkuser()->getLastName() : ''</code>
+								<code>($user = $scope->getObject()->getkuser()) ? $user->getFirstName().' '.$user->getLastName() : ''</code>
 							</name>
 						</item>
 					</emailRecipients>
@@ -781,7 +781,7 @@
 						<key>category_name</key>
 						<description>Category name</description>
 						<value objectType="KalturaEvalStringField">
-							<code>($scope->getObject()->getcategory()) ? $scope->getObject()->getcategory()->getName() : ''</code>
+							<code>($category = $scope->getObject()->getcategory()) ? $category->getName() : ''</code>
 						</value>
 					</item>
 					<item objectType="KalturaEventNotificationParameter">
@@ -820,7 +820,7 @@
 				<eventObjectType>12</eventObjectType> <!-- EventNotificationEventObjectType::CATEGORYKUSER -->
 				<eventConditions objectType="array">
 					<item objectType="KalturaEventFieldCondition">
-						<description>Permission level change, See:KalturaCategoryUserPermissionLevel:/api_v3/testmeDoc/?object=KalturaCategoryUserStatus, and status is active, See:KalturaCategoryUserStatus:/api_v3/testmeDoc/?object=KalturaCategoryUserStatus</description>
+						<description>Permission level changed (see KalturaCategoryUserPermissionLevel) and status is active (see KalturaCategoryUserStatus)</description>
 						<field objectType="KalturaEvalBooleanField">
 							<code>$scope->getObject() instanceof categoryKuser &amp;&amp; in_array(categoryKuserPeer::PERMISSION_LEVEL, $scope->getEvent()->getModifiedColumns()) &amp;&amp; $scope->getObject()->getStatus() == CategoryKuserStatus::ACTIVE</code>
 						</field>
@@ -841,10 +841,10 @@
 					<emailRecipients objectType="array">
 						<item objectType = "KalturaEmailNotificationRecipient">
 							<email objectType="KalturaEvalStringField">
-								<code>!is_null($scope->getObject()->getkuser()) ? $scope->getObject()->getkuser()->getEmail() : ''</code>
+								<code>($user = $scope->getObject()->getkuser()) ? $user->getEmail() : ''</code>
 							</email>
 							<name objectType="KalturaEvalStringField">
-								<code>!is_null($scope->getObject()->getkuser()) ? $scope->getObject()->getkuser()->getFirstName().' '.$scope->getObject()->getkuser()->getLastName() : ''</code>
+								<code>($user = $scope->getObject()->getkuser()) ? $user->getFirstName().' '.$user->getLastName() : ''</code>
 							</name>
 						</item>
 					</emailRecipients>
@@ -868,7 +868,7 @@
 						<key>category_name</key>
 						<description>Category name</description>
 						<value objectType="KalturaEvalStringField">
-							<code>($scope->getObject()->getcategory()) ? $scope->getObject()->getcategory()->getName() : ''</code>
+							<code>($category = $scope->getObject()->getcategory()) ? $category->getName() : ''</code>
 						</value>
 					</item>
 					<item objectType="KalturaEventNotificationParameter">
@@ -928,10 +928,10 @@
 					<emailRecipients objectType="array">
 						<item objectType = "KalturaEmailNotificationRecipient">
 							<email objectType="KalturaEvalStringField">
-								<code>!is_null($scope->getObject()->getkuser()) ? $scope->getObject()->getkuser()->getEmail() : ''</code>
+								<code>($user = $scope->getObject()->getkuser()) ? $user->getEmail() : ''</code>
 							</email>
 							<name objectType="KalturaEvalStringField">
-								<code>!is_null($scope->getObject()->getkuser()) ? $scope->getObject()->getkuser()->getFirstName().' '.$scope->getObject()->getkuser()->getLastName() : ''</code>
+								<code>($user = $scope->getObject()->getkuser()) ? $user->getFirstName().' '.$user->getLastName() : ''</code>
 							</name>
 						</item>
 					</emailRecipients>
@@ -955,7 +955,7 @@
 						<key>category_name</key>
 						<description>Category name</description>
 						<value objectType="KalturaEvalStringField">
-							<code>($scope->getObject()->getcategory()) ? $scope->getObject()->getcategory()->getName() : ''</code>
+							<code>($category = $scope->getObject()->getcategory()) ? $category->getName() : ''</code>
 						</value>
 					</item>
 				</contentParameters>
@@ -987,7 +987,7 @@
 				<eventObjectType>37</eventObjectType> <!-- EventNotificationEventObjectType::CATEGORYENTRY -->
 				<eventConditions objectType="array">
 					<item objectType="KalturaEventFieldCondition">
-						<description>Status is active, See:KalturaCategoryEntryStatus:/api_v3/testmeDoc/?object=KalturaCategoryEntryStatus</description>
+						<description>Status is active, see KalturaCategoryEntryStatus</description>
 						<field objectType="KalturaEvalBooleanField">
 							<code>$scope->getObject() instanceof categoryEntry &amp;&amp; $scope->getObject()->getStatus() == CategoryEntryStatus::ACTIVE</code>
 						</field>
@@ -1031,7 +1031,7 @@
 						<key>category_name</key>
 						<description>Category name</description>
 						<value objectType="KalturaEvalStringField">
-							<code>!is_null(categoryPeer::retrieveByPk($scope->getObject()->getCategoryId())) ? categoryPeer::retrieveByPk($scope->getObject()->getCategoryId())->getName() : ''</code>
+							<code>($category = categoryPeer::retrieveByPk($scope->getObject()->getCategoryId())) ? $category->getName() : ''</code>
 						</value>
 					</item>
 					<item objectType="KalturaEventNotificationParameter">
@@ -1045,7 +1045,7 @@
 						<key>entry_name</key>
 						<description>Entry name</description>
 						<value objectType="KalturaEvalStringField">
-							<code>!is_null(entryPeer::retrieveByPk($scope->getObject()->getEntryId())) ? entryPeer::retrieveByPk($scope->getObject()->getEntryId())->getName() : ''</code>
+							<code>($entry = entryPeer::retrieveByPk($scope->getObject()->getEntryId())) ? $entry->getName() : ''</code>
 						</value>
 					</item>
 				</contentParameters>
@@ -1130,10 +1130,10 @@
 					<emailRecipients objectType="array">
 						<item objectType = "KalturaEmailNotificationRecipient">
 							<email objectType="KalturaEvalStringField">
-								<code>!is_null(entryPeer::retrieveByPk(CuePointPeer::retrieveByPK($scope->getObject()->getObjectId())->getEntryId())) ? (!is_null(entryPeer::retrieveByPk(CuePointPeer::retrieveByPK($scope->getObject()->getObjectId())->getEntryId())->getkuser()) ? entryPeer::retrieveByPk(CuePointPeer::retrieveByPK($scope->getObject()->getObjectId())->getEntryId())->getkuser()->getEmail() : '') : ''</code>
+								<code>($comment = CuePointPeer::retrieveByPK($scope->getObject()->getObjectId())) &amp;&amp; ($entry = entryPeer::retrieveByPk($comment->getEntryId())) &amp;&amp; ($user = $entry->getkuser()) ? $user->getEmail() : ''</code>
 							</email>
 							<name objectType="KalturaEvalStringField">
-								<code>!is_null(entryPeer::retrieveByPk(CuePointPeer::retrieveByPK($scope->getObject()->getObjectId())->getEntryId())) ? (!is_null(entryPeer::retrieveByPk(CuePointPeer::retrieveByPK($scope->getObject()->getObjectId())->getEntryId())->getkuser()) ? entryPeer::retrieveByPk(CuePointPeer::retrieveByPK($scope->getObject()->getObjectId())->getEntryId())->getkuser()->getFirstName().' '.entryPeer::retrieveByPk(CuePointPeer::retrieveByPK($scope->getObject()->getObjectId())->getEntryId())->getkuser()->getLastName() : '') : ''</code>
+								<code>($comment = CuePointPeer::retrieveByPK($scope->getObject()->getObjectId())) &amp;&amp; ($entry = entryPeer::retrieveByPk($comment->getEntryId())) &amp;&amp; ($user = $entry->getkuser()) ? $user->getFirstName().' '.$user->getLastName() : ''</code>
 							</name>
 						</item>
 					</emailRecipients>

--- a/tests/standAloneClient/uniqueMediaspaceNotificationsTemplates.xml
+++ b/tests/standAloneClient/uniqueMediaspaceNotificationsTemplates.xml
@@ -1154,79 +1154,79 @@
 					<item objectType="KalturaEventNotificationParameter">
 						<key>entry_id</key>
 						<value objectType="KalturaEvalStringField">
-							<code>CuePointPeer::retrieveByPK($scope->getObject()->getObjectId()) ? CuePointPeer::retrieveByPK($scope->getObject()->getObjectId())->getEntryId() : ''</code>
+							<code>($comment = CuePointPeer::retrieveByPK($scope->getObject()->getObjectId())) ? $comment->getEntryId() : ''</code>
 						</value>
 					</item>
 					<item objectType="KalturaEventNotificationParameter">
 						<key>entry_name</key>
 						<value objectType="KalturaEvalStringField">
-							<code>CuePointPeer::retrieveByPK($scope->getObject()->getObjectId()) &amp;&amp; !is_null(entryPeer::retrieveByPk(CuePointPeer::retrieveByPK($scope->getObject()->getObjectId())->getEntryId())) ? entryPeer::retrieveByPk(CuePointPeer::retrieveByPK($scope->getObject()->getObjectId())->getEntryId())->getName() : ''</code>
+							<code>($comment = CuePointPeer::retrieveByPK($scope->getObject()->getObjectId())) &amp;&amp; ($entry = entryPeer::retrieveByPk($comment->getEntryId())) ? $entry->getName() : ''</code>
 						</value>
 					</item>
 					<item objectType="KalturaEventNotificationParameter">
 						<key>comment_text</key>
 						<value objectType="KalturaEvalStringField">
-							<code>CuePointPeer::retrieveByPK($scope->getObject()->getObjectId()) ? CuePointPeer::retrieveByPK($scope->getObject()->getObjectId())->getText() : ''</code>
+							<code>($comment = CuePointPeer::retrieveByPK($scope->getObject()->getObjectId())) ? $comment->getText() : ''</code>
 						</value>
 					</item>
 					<item objectType="KalturaEventNotificationParameter">
 						<key>comment_id</key>
 						<value objectType="KalturaEvalStringField">
-							<code>CuePointPeer::retrieveByPK($scope->getObject()->getObjectId()) ? CuePointPeer::retrieveByPK($scope->getObject()->getObjectId())->getId() : ''</code>
+							<code>($comment = CuePointPeer::retrieveByPK($scope->getObject()->getObjectId())) ? $comment->getId() : ''</code>
 						</value>
 					</item>
 					<item objectType="KalturaEventNotificationParameter">
 						<key>comment_parent_id</key>
 						<value objectType="KalturaEvalStringField">
-							<code>CuePointPeer::retrieveByPK($scope->getObject()->getObjectId()) ? CuePointPeer::retrieveByPK($scope->getObject()->getObjectId())->getParentId() : ''</code>
+							<code>($comment = CuePointPeer::retrieveByPK($scope->getObject()->getObjectId())) ? $comment->getParentId() : ''</code>
 						</value>
 					</item>
 					<item objectType="KalturaEventNotificationParameter">
 						<key>comment_system_name</key>
 						<value objectType="KalturaEvalStringField">
-							<code>CuePointPeer::retrieveByPK($scope->getObject()->getObjectId()) ? CuePointPeer::retrieveByPK($scope->getObject()->getObjectId())->getSystemName() : ''</code>
+							<code>($comment = CuePointPeer::retrieveByPK($scope->getObject()->getObjectId())) ? $comment->getSystemName() : ''</code>
 						</value>
 					</item>
 					<item objectType="KalturaEventNotificationParameter">
 						<key>comment_user_id</key>
 						<value objectType="KalturaEvalStringField">
-							<code>CuePointPeer::retrieveByPK($scope->getObject()->getObjectId()) ? CuePointPeer::retrieveByPK($scope->getObject()->getObjectId())->getPuserId() : ''</code>
+							<code>($comment = CuePointPeer::retrieveByPK($scope->getObject()->getObjectId())) ? $comment->getPuserId() : ''</code>
 						</value>
 					</item>
 					<item objectType="KalturaEventNotificationParameter">
 						<key>comment_created_at</key>
 						<value objectType="KalturaEvalStringField">
-							<code>CuePointPeer::retrieveByPK($scope->getObject()->getObjectId()) ? CuePointPeer::retrieveByPK($scope->getObject()->getObjectId())->getCreatedAt() : ''</code>
+							<code>($comment = CuePointPeer::retrieveByPK($scope->getObject()->getObjectId())) ? $comment->getCreatedAt() : ''</code>
 						</value>
 					</item>
 					<item objectType="KalturaEventNotificationParameter">
 						<key>comment_updated_at</key>
 						<value objectType="KalturaEvalStringField">
-							<code>CuePointPeer::retrieveByPK($scope->getObject()->getObjectId()) ? CuePointPeer::retrieveByPK($scope->getObject()->getObjectId())->getUpdatedAt() : ''</code>
+							<code>($comment = CuePointPeer::retrieveByPK($scope->getObject()->getObjectId())) ? $comment->getUpdatedAt() : ''</code>
 						</value>
 					</item>
 					<item objectType="KalturaEventNotificationParameter">
 						<key>comment_partner_data</key>
 						<value objectType="KalturaEvalStringField">
-							<code>CuePointPeer::retrieveByPK($scope->getObject()->getObjectId()) ? CuePointPeer::retrieveByPK($scope->getObject()->getObjectId())->getPartnerData() : ''</code>
+							<code>($comment = CuePointPeer::retrieveByPK($scope->getObject()->getObjectId())) ? $comment->getPartnerData() : ''</code>
 						</value>
 					</item>
 					<item objectType="KalturaEventNotificationParameter">
 						<key>comment_start_time</key>
 						<value objectType="KalturaEvalStringField">
-							<code>CuePointPeer::retrieveByPK($scope->getObject()->getObjectId()) ? CuePointPeer::retrieveByPK($scope->getObject()->getObjectId())->getStartTime() : ''</code>
+							<code>($comment = CuePointPeer::retrieveByPK($scope->getObject()->getObjectId())) ? $comment->getStartTime() : ''</code>
 						</value>
 					</item>
 					<item objectType="KalturaEventNotificationParameter">
 						<key>comment_end_time</key>
 						<value objectType="KalturaEvalStringField">
-							<code>CuePointPeer::retrieveByPK($scope->getObject()->getObjectId()) ? CuePointPeer::retrieveByPK($scope->getObject()->getObjectId())->getEndTime() : ''</code>
+							<code>($comment = CuePointPeer::retrieveByPK($scope->getObject()->getObjectId())) ? $comment->getEndTime() : ''</code>
 						</value>
 					</item>
 					<item objectType="KalturaEventNotificationParameter">
 						<key>comment_duration</key>
 						<value objectType="KalturaEvalStringField">
-							<code>CuePointPeer::retrieveByPK($scope->getObject()->getObjectId()) ? CuePointPeer::retrieveByPK($scope->getObject()->getObjectId())->getDuration() : ''</code>
+							<code>($comment = CuePointPeer::retrieveByPK($scope->getObject()->getObjectId())) ? $comment->getDuration() : ''</code>
 						</value>
 					</item>
 					<item objectType="KalturaEventNotificationParameter">

--- a/tests/standAloneClient/uniqueMediaspaceNotificationsTemplates.xml
+++ b/tests/standAloneClient/uniqueMediaspaceNotificationsTemplates.xml
@@ -1,0 +1,1037 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xml>
+	<config>
+		<serviceUrl>http://{prompt:Host name:}/</serviceUrl>
+		<partnerId>-2</partnerId>
+		<clientTag>Stand alone php 1.0.0</clientTag>
+		<curlTimeout>30</curlTimeout>
+		<userAgent>Stand alone php 1.0.0</userAgent>
+	</config>
+	<session>
+		<!-- script will ask for username / password interactively -->
+	</session>
+	<multirequest>
+		<!-- New Item Pending Moderation -->
+		<request service="eventNotificationTemplate" action="add" plugin="eventNotification" partnerId="0">
+			<template objectType="KalturaEmailNotificationTemplate">
+				<name>New Item Pending Moderation</name>
+				<systemName>New_Item_Pending_Moderation</systemName>
+				<description>Email notification template to be sent when a new item is pending moderation in a specific category (channel).</description>
+				<automaticDispatchEnabled>1</automaticDispatchEnabled>
+				<eventType>5</eventType> <!-- EventNotificationEventType::OBJECT_CREATED -->
+				<eventObjectType>37</eventObjectType> <!-- EventNotificationEventObjectType::CATEGORYENTRY -->
+				<eventConditions objectType="array">
+					<item objectType="KalturaEventFieldCondition">
+						<description>Status is pending, See:KalturaCategoryEntryStatus:/api_v3/testmeDoc/?object=KalturaCategoryEntryStatus</description>
+						<field objectType="KalturaEvalBooleanField">
+							<code>$scope->getObject() instanceof categoryEntry &amp;&amp; $scope->getObject()->getStatus() == CategoryEntryStatus::PENDING</code>
+						</field>
+					</item>
+				</eventConditions>
+				<format>1</format>
+				<subject>[AppTitle] - New Item Pending Moderation</subject>
+				<body>A new item is pending your approval: [ChannelSettingsPendingURLPrefix]{category_name_encoded}/{category_id}[ChannelSettingsPendingURLSuffix]</body>
+				<fromEmail>{from_email}</fromEmail>
+				<fromName>{from_name}</fromName>
+				<bcc objectType="KalturaEmailNotificationCategoryRecipientProvider">
+					<categoryId objectType="KalturaEvalStringField">
+						<code>$scope->getObject()->getCategoryId()</code>
+					</categoryId>
+					<categoryUserFilter objectType="KalturaCategoryUserProviderFilter">
+						<permissionNamesMatchOr>CATEGORY_MODERATE</permissionNamesMatchOr>
+					</categoryUserFilter>
+				</bcc>
+				<contentParameters objectType="array">
+					<item objectType="KalturaEventNotificationParameter">
+						<key>from_email</key>
+						<description>Server configuration: partner_notification_email</description>
+						<value objectType="KalturaEvalStringField">
+							<code>kConf::get("partner_notification_email")</code>
+						</value>
+					</item>
+					<item objectType="KalturaEventNotificationParameter">
+						<key>from_name</key>
+						<description>Server configuration: partner_notification_name</description>
+						<value objectType="KalturaEvalStringField">
+							<code>kConf::get("partner_notification_name")</code>
+						</value>
+					</item>
+					<item objectType="KalturaEventNotificationParameter">
+						<key>entry_name</key>
+						<description>Entry name</description>
+						<value objectType="KalturaEvalStringField">
+							<code>!is_null(entryPeer::retrieveByPk($scope->getObject()->getEntryId())) ? entryPeer::retrieveByPk($scope->getObject()->getEntryId())->getName() : ''</code>
+						</value>
+					</item>
+					<item objectType="KalturaEventNotificationParameter">
+						<key>category_id</key>
+						<description>Category ID</description>
+						<value objectType="KalturaEvalStringField">
+							<code>$scope->getObject()->getCategoryId()</code>
+						</value>
+					</item>
+					<item objectType="KalturaEventNotificationParameter">
+						<key>category_name</key>
+						<description>Category name</description>
+						<value objectType="KalturaEvalStringField">
+							<code>!is_null(categoryPeer::retrieveByPk($scope->getObject()->getCategoryId())) ? categoryPeer::retrieveByPk($scope->getObject()->getCategoryId())->getName() : ''</code>
+						</value>
+					</item>
+					<item objectType="KalturaEventNotificationParameter">
+						<key>category_name_encoded</key>
+						<description>Encoded category name</description>
+						<value objectType="KalturaEvalStringField">
+							<code>urlencode(!is_null(categoryPeer::retrieveByPk($scope->getObject()->getCategoryId())) ? categoryPeer::retrieveByPk($scope->getObject()->getCategoryId())->getName() : '')</code>
+						</value>
+					</item>
+				</contentParameters>
+			</template>
+		</request>
+		<request service="eventNotificationTemplate" action="updateStatus" plugin="eventNotification" partnerId="0">
+			<id>{1:result:id}</id>
+			<status>1</status><!-- EventNotificationTemplateStatus::DISABLED -->
+		</request>
+	</multirequest>
+	<multirequest>
+		<!-- New Item Pending Moderation -->
+		<request service="eventNotificationTemplate" action="add" plugin="eventNotification" partnerId="0">
+			<template objectType="KalturaEmailNotificationTemplate">
+				<name>New Item Pending Moderation</name>
+				<systemName>New_Item_Pending_Moderation_2</systemName>
+				<description>Email notification template to be sent when a new item is pending moderation in a specific category (channel).</description>
+				<automaticDispatchEnabled>1</automaticDispatchEnabled>
+				<eventType>3</eventType> <!-- EventNotificationEventType::OBJECT_CHANGED -->
+				<eventObjectType>37</eventObjectType> <!-- EventNotificationEventObjectType::CATEGORYENTRY -->
+				<eventConditions objectType="array">
+					<item objectType="KalturaEventFieldCondition">
+						<description>Status changed to pending, See:KalturaCategoryEntryStatus:/api_v3/testmeDoc/?object=KalturaCategoryEntryStatus</description>
+						<field objectType="KalturaEvalBooleanField">
+							<code>$scope->getObject() instanceof categoryEntry &amp;&amp; in_array(categoryEntryPeer::STATUS, $scope->getEvent()->getModifiedColumns()) &amp;&amp; $scope->getObject()->getStatus() == CategoryEntryStatus::PENDING</code>
+						</field>
+					</item>
+				</eventConditions>
+				<format>1</format>
+				<subject>[AppTitle] - New Item Pending Moderation</subject>
+				<body>A new item is pending your approval: [ChannelSettingsPendingURLPrefix]{category_name_encoded}/{category_id}[ChannelSettingsPendingURLSuffix]</body>
+				<fromEmail>{from_email}</fromEmail>
+				<fromName>{from_name}</fromName>
+				<bcc objectType="KalturaEmailNotificationCategoryRecipientProvider">
+					<categoryId objectType="KalturaEvalStringField">
+						<code>$scope->getObject()->getCategoryId()</code>
+					</categoryId>
+					<categoryUserFilter objectType="KalturaCategoryUserProviderFilter">
+						<permissionNamesMatchOr>CATEGORY_MODERATE</permissionNamesMatchOr>
+					</categoryUserFilter>
+				</bcc>
+				<contentParameters objectType="array">
+					<item objectType="KalturaEventNotificationParameter">
+						<key>from_email</key>
+						<description>Server configuration: partner_notification_email</description>
+						<value objectType="KalturaEvalStringField">
+							<code>kConf::get("partner_notification_email")</code>
+						</value>
+					</item>
+					<item objectType="KalturaEventNotificationParameter">
+						<key>from_name</key>
+						<description>Server configuration: partner_notification_name</description>
+						<value objectType="KalturaEvalStringField">
+							<code>kConf::get("partner_notification_name")</code>
+						</value>
+					</item>
+					<item objectType="KalturaEventNotificationParameter">
+						<key>entry_name</key>
+						<description>Entry name</description>
+						<value objectType="KalturaEvalStringField">
+							<code>!is_null(entryPeer::retrieveByPk($scope->getObject()->getEntryId())) ? entryPeer::retrieveByPk($scope->getObject()->getEntryId())->getName() : ''</code>
+						</value>
+					</item>
+					<item objectType="KalturaEventNotificationParameter">
+						<key>category_id</key>
+						<description>Category ID</description>
+						<value objectType="KalturaEvalStringField">
+							<code>$scope->getObject()->getCategoryId()</code>
+						</value>
+					</item>
+					<item objectType="KalturaEventNotificationParameter">
+						<key>category_name</key>
+						<description>Category name</description>
+						<value objectType="KalturaEvalStringField">
+							<code>!is_null(categoryPeer::retrieveByPk($scope->getObject()->getCategoryId())) ? categoryPeer::retrieveByPk($scope->getObject()->getCategoryId())->getName() : ''</code>
+						</value>
+					</item>
+					<item objectType="KalturaEventNotificationParameter">
+						<key>category_name_encoded</key>
+						<description>Encoded category name</description>
+						<value objectType="KalturaEvalStringField">
+							<code>urlencode(!is_null(categoryPeer::retrieveByPk($scope->getObject()->getCategoryId())) ? categoryPeer::retrieveByPk($scope->getObject()->getCategoryId())->getName() : '')</code>
+						</value>
+					</item>
+				</contentParameters>
+			</template>
+		</request>
+		<request service="eventNotificationTemplate" action="updateStatus" plugin="eventNotification" partnerId="0">
+			<id>{1:result:id}</id>
+			<status>1</status><!-- EventNotificationTemplateStatus::DISABLED -->
+		</request>
+	</multirequest>
+	<multirequest>
+		<!-- Entry Approved In Category -->
+		<request service="eventNotificationTemplate" action="add" plugin="eventNotification" partnerId="0">
+			<template objectType="KalturaEmailNotificationTemplate">
+				<name>Entry Approved In Category</name>
+				<systemName>Entry_Approved_In_Category</systemName>
+				<description>Email notification template to be sent when a new entry is approved in a category.</description>
+				<automaticDispatchEnabled>1</automaticDispatchEnabled>
+				<eventType>3</eventType> <!-- EventNotificationEventType::OBJECT_CHANGED -->
+				<eventObjectType>37</eventObjectType> <!-- EventNotificationEventObjectType::CATEGORYENTRY -->
+				<eventConditions objectType="array">
+					<item objectType="KalturaEventFieldCondition">
+						<description>Status changed to active, See:KalturaCategoryEntryStatus:/api_v3/testmeDoc/?object=KalturaCategoryEntryStatus</description>
+						<field objectType="KalturaEvalBooleanField">
+							<code>$scope->getObject() instanceof categoryEntry &amp;&amp; in_array(categoryEntryPeer::STATUS, $scope->getEvent()->getModifiedColumns()) &amp;&amp; $scope->getObject()->getStatus() == CategoryEntryStatus::ACTIVE</code>
+						</field>
+					</item>
+				</eventConditions>
+				<format>1</format>
+				<subject>[AppTitle] - Your Media has been approved</subject>
+				<body>Your media {entry_name} [AppEntryUrl]{entry_id} has been approved to be published in {category_name}</body>
+				<fromEmail>{from_email}</fromEmail>
+				<fromName>{from_name}</fromName>
+				<to objectType="KalturaEmailNotificationStaticRecipientProvider">
+					<emailRecipients objectType="array">
+						<item objectType = "KalturaEmailNotificationRecipient">
+							<email objectType="KalturaEvalStringField">
+								<code>!is_null(entryPeer::retrieveByPk($scope->getObject()->getEntryId())) ? entryPeer::retrieveByPk($scope->getObject()->getEntryId())->getkuser()->getEmail() : ''</code>
+							</email>
+							<name objectType="KalturaEvalStringField">
+								<code>!is_null(entryPeer::retrieveByPk($scope->getObject()->getEntryId())) ? entryPeer::retrieveByPk($scope->getObject()->getEntryId())->getkuser()->getFirstName().' '.entryPeer::retrieveByPk($scope->getObject()->getEntryId())->getkuser()->getLastName() : ''</code>
+							</name>
+						</item>
+					</emailRecipients>
+				</to>
+				<contentParameters objectType="array">
+					<item objectType="KalturaEventNotificationParameter">
+						<key>from_email</key>
+						<description>Server configuration: partner_notification_email</description>
+						<value objectType="KalturaEvalStringField">
+							<code>kConf::get("partner_notification_email")</code>
+						</value>
+					</item>
+					<item objectType="KalturaEventNotificationParameter">
+						<key>from_name</key>
+						<description>Server configuration: partner_notification_name</description>
+						<value objectType="KalturaEvalStringField">
+							<code>kConf::get("partner_notification_name")</code>
+						</value>
+					</item>
+					<item objectType="KalturaEventNotificationParameter">
+						<key>entry_name</key>
+						<description>Entry name</description>
+						<value objectType="KalturaEvalStringField">
+							<code>!is_null(entryPeer::retrieveByPk($scope->getObject()->getEntryId())) ? entryPeer::retrieveByPk($scope->getObject()->getEntryId())->getName() : ''</code>
+						</value>
+					</item>
+					<item objectType="KalturaEventNotificationParameter">
+						<key>category_name</key>
+						<description>Category name</description>
+						<value objectType="KalturaEvalStringField">
+							<code>!is_null(categoryPeer::retrieveByPk($scope->getObject()->getCategoryId())) ? categoryPeer::retrieveByPk($scope->getObject()->getCategoryId())->getName() : ''</code>
+						</value>
+					</item>
+					<item objectType="KalturaEventNotificationParameter">
+						<key>entry_id</key>
+						<description>Entry ID</description>
+						<value objectType="KalturaEvalStringField">
+							<code>$scope->getObject()->getEntryId()</code>
+						</value>
+					</item>
+				</contentParameters>
+			</template>
+		</request>
+		<request service="eventNotificationTemplate" action="updateStatus" plugin="eventNotification" partnerId="0">
+			<id>{1:result:id}</id>
+			<status>1</status><!-- EventNotificationTemplateStatus::DISABLED -->
+		</request>
+	</multirequest>
+	<multirequest>
+		<!-- Entry Rejected In Category -->
+		<request service="eventNotificationTemplate" action="add" plugin="eventNotification" partnerId="0">
+			<template objectType="KalturaEmailNotificationTemplate">
+				<name>Entry Rejected In Category</name>
+				<systemName>Entry_Rejected_In_Category</systemName>
+				<description>Email notification template to be sent when a new entry is rejected in a category.</description>
+				<automaticDispatchEnabled>1</automaticDispatchEnabled>
+				<eventType>3</eventType> <!-- EventNotificationEventType::OBJECT_CHANGED -->
+				<eventObjectType>37</eventObjectType> <!-- EventNotificationEventObjectType::CATEGORYENTRY -->
+				<eventConditions objectType="array">
+					<item objectType="KalturaEventFieldCondition">
+						<description>Status changed to rejected, See:KalturaCategoryEntryStatus:/api_v3/testmeDoc/?object=KalturaCategoryEntryStatus</description>
+						<field objectType="KalturaEvalBooleanField">
+							<code>$scope->getObject() instanceof categoryEntry &amp;&amp; in_array(categoryEntryPeer::STATUS, $scope->getEvent()->getModifiedColumns()) &amp;&amp; $scope->getObject()->getStatus() == CategoryEntryStatus::REJECTED</code>
+						</field>
+					</item>
+				</eventConditions>
+				<format>1</format>
+				<subject>[AppTitle] - Your Media has been rejected</subject>
+				<body>Your media {entry_name} [AppEntryUrl]{entry_id} has been rejected to be published in {category_name}</body>
+				<fromEmail>{from_email}</fromEmail>
+				<fromName>{from_name}</fromName>
+				<to objectType="KalturaEmailNotificationStaticRecipientProvider">
+					<emailRecipients objectType="array">
+						<item objectType = "KalturaEmailNotificationRecipient">
+							<email objectType="KalturaEvalStringField">
+								<code>!is_null(entryPeer::retrieveByPk($scope->getObject()->getEntryId())) ? entryPeer::retrieveByPk($scope->getObject()->getEntryId())->getkuser()->getEmail() : ''</code>
+							</email>
+							<name objectType="KalturaEvalStringField">
+								<code>!is_null(entryPeer::retrieveByPk($scope->getObject()->getEntryId())) ? entryPeer::retrieveByPk($scope->getObject()->getEntryId())->getkuser()->getFirstName().' '.entryPeer::retrieveByPk($scope->getObject()->getEntryId())->getkuser()->getLastName() : ''</code>
+							</name>
+						</item>
+					</emailRecipients>
+				</to>
+				<contentParameters objectType="array">
+					<item objectType="KalturaEventNotificationParameter">
+						<key>from_email</key>
+						<description>Server configuration: partner_notification_email</description>
+						<value objectType="KalturaEvalStringField">
+							<code>kConf::get("partner_notification_email")</code>
+						</value>
+					</item>
+					<item objectType="KalturaEventNotificationParameter">
+						<key>from_name</key>
+						<description>Server configuration: partner_notification_name</description>
+						<value objectType="KalturaEvalStringField">
+							<code>kConf::get("partner_notification_name")</code>
+						</value>
+					</item>
+					<item objectType="KalturaEventNotificationParameter">
+						<key>entry_name</key>
+						<description>Entry name</description>
+						<value objectType="KalturaEvalStringField">
+							<code>!is_null(entryPeer::retrieveByPk($scope->getObject()->getEntryId())) ? entryPeer::retrieveByPk($scope->getObject()->getEntryId())->getName() : ''</code>
+						</value>
+					</item>
+					<item objectType="KalturaEventNotificationParameter">
+						<key>category_name</key>
+						<description>Category name</description>
+						<value objectType="KalturaEvalStringField">
+							<code>!is_null(categoryPeer::retrieveByPk($scope->getObject()->getCategoryId())) ? categoryPeer::retrieveByPk($scope->getObject()->getCategoryId())->getName() : ''</code>
+						</value>
+					</item>
+					<item objectType="KalturaEventNotificationParameter">
+						<key>entry_id</key>
+						<description>Entry ID</description>
+						<value objectType="KalturaEvalStringField">
+							<code>$scope->getObject()->getEntryId()</code>
+						</value>
+					</item>
+				</contentParameters>
+			</template>
+		</request>
+		<request service="eventNotificationTemplate" action="updateStatus" plugin="eventNotification" partnerId="0">
+			<id>{1:result:id}</id>
+			<status>1</status><!-- EventNotificationTemplateStatus::DISABLED -->
+		</request>
+	</multirequest>
+	<multirequest>
+		<!-- Entry Rejected -->
+		<request service="eventNotificationTemplate" action="add" plugin="eventNotification" partnerId="0">
+			<template objectType="KalturaEmailNotificationTemplate">
+				<name>Entry Rejected</name>
+				<systemName>Entry_Rejected</systemName>
+				<description>Email notification template to be sent when a new entry is rejected.</description>
+				<automaticDispatchEnabled>1</automaticDispatchEnabled>
+				<eventType>3</eventType> <!-- EventNotificationEventType::OBJECT_CHANGED -->
+				<eventObjectType>1</eventObjectType> <!-- EventNotificationEventObjectType::ENTRY -->
+				<eventConditions objectType="array">
+					<item objectType="KalturaEventFieldCondition">
+						<description>Moderation status changed to rejected, See:KalturaEntryModerationStatus:/api_v3/testmeDoc/?object=KalturaEntryModerationStatus</description>
+						<field objectType="KalturaEvalBooleanField">
+							<code>$scope->getObject() instanceof entry &amp;&amp; in_array(entryPeer::MODERATION_STATUS, $scope->getEvent()->getModifiedColumns()) &amp;&amp; $scope->getObject()->getModerationStatus() == entry::ENTRY_MODERATION_STATUS_REJECTED</code>
+						</field>
+					</item>
+				</eventConditions>
+				<format>1</format>
+				<subject>[AppTitle] - Your Media has been rejected</subject>
+				<body>Your media {entry_name} has been rejected</body>
+				<fromEmail>{from_email}</fromEmail>
+				<fromName>{from_name}</fromName>
+				<to objectType="KalturaEmailNotificationStaticRecipientProvider">
+					<emailRecipients objectType="array">
+						<item objectType = "KalturaEmailNotificationRecipient">
+							<email objectType="KalturaEvalStringField">
+								<code>!is_null($scope->getObject()->getkuser()) ? $scope->getObject()->getkuser()->getEmail() : ''</code>
+							</email>
+							<name objectType="KalturaEvalStringField">
+								<code>!is_null($scope->getObject()->getkuser()) ? $scope->getObject()->getkuser()->getFirstName().' '.$scope->getObject()->getkuser()->getLastName() : ''</code>
+							</name>
+						</item>
+					</emailRecipients>
+				</to>
+				<contentParameters objectType="array">
+					<item objectType="KalturaEventNotificationParameter">
+						<key>from_email</key>
+						<description>Server configuration: partner_notification_email</description>
+						<value objectType="KalturaEvalStringField">
+							<code>kConf::get("partner_notification_email")</code>
+						</value>
+					</item>
+					<item objectType="KalturaEventNotificationParameter">
+						<key>from_name</key>
+						<description>Server configuration: partner_notification_name</description>
+						<value objectType="KalturaEvalStringField">
+							<code>kConf::get("partner_notification_name")</code>
+						</value>
+					</item>
+					<item objectType="KalturaEventNotificationParameter">
+						<key>entry_name</key>
+						<description>Entry name</description>
+						<value objectType="KalturaEvalStringField">
+							<code>$scope->getObject()->getName()</code>
+						</value>
+					</item>
+				</contentParameters>
+			</template>
+		</request>
+		<request service="eventNotificationTemplate" action="updateStatus" plugin="eventNotification" partnerId="0">
+			<id>{1:result:id}</id>
+			<status>1</status><!-- EventNotificationTemplateStatus::DISABLED -->
+		</request>
+	</multirequest>
+	<multirequest>
+		<!-- Entry Approved -->
+		<request service="eventNotificationTemplate" action="add" plugin="eventNotification" partnerId="0">
+			<template objectType="KalturaEmailNotificationTemplate">
+				<name>Entry Approved</name>
+				<systemName>Entry_Approved</systemName>
+				<description>Email notification template to be sent when a new entry is approved.</description>
+				<automaticDispatchEnabled>1</automaticDispatchEnabled>
+				<eventType>3</eventType> <!-- EventNotificationEventType::OBJECT_CHANGED -->
+				<eventObjectType>1</eventObjectType> <!-- EventNotificationEventObjectType::ENTRY -->
+				<eventConditions objectType="array">
+					<item objectType="KalturaEventFieldCondition">
+						<description>Moderation status changed to approved, See:KalturaEntryModerationStatus:/api_v3/testmeDoc/?object=KalturaEntryModerationStatus</description>
+						<field objectType="KalturaEvalBooleanField">
+							<code>$scope->getObject() instanceof entry &amp;&amp; in_array(entryPeer::MODERATION_STATUS, $scope->getEvent()->getModifiedColumns()) &amp;&amp; $scope->getObject()->getModerationStatus() == entry::ENTRY_MODERATION_STATUS_APPROVED</code>
+						</field>
+					</item>
+				</eventConditions>
+				<format>1</format>
+				<subject>[AppTitle] - Your Media has been approved</subject>
+				<body>Your media {entry_name} has been approved</body>
+				<fromEmail>{from_email}</fromEmail>
+				<fromName>{from_name}</fromName>
+				<to objectType="KalturaEmailNotificationStaticRecipientProvider">
+					<emailRecipients objectType="array">
+						<item objectType = "KalturaEmailNotificationRecipient">
+							<email objectType="KalturaEvalStringField">
+								<code>!is_null($scope->getObject()->getkuser()) ? $scope->getObject()->getkuser()->getEmail() : ''</code>
+							</email>
+							<name objectType="KalturaEvalStringField">
+								<code>!is_null($scope->getObject()->getkuser()) ? $scope->getObject()->getkuser()->getFirstName().' '.$scope->getObject()->getkuser()->getLastName() : ''</code>
+							</name>
+						</item>
+					</emailRecipients>
+				</to>
+				<contentParameters objectType="array">
+					<item objectType="KalturaEventNotificationParameter">
+						<key>from_email</key>
+						<description>Server configuration: partner_notification_email</description>
+						<value objectType="KalturaEvalStringField">
+							<code>kConf::get("partner_notification_email")</code>
+						</value>
+					</item>
+					<item objectType="KalturaEventNotificationParameter">
+						<key>from_name</key>
+						<description>Server configuration: partner_notification_name</description>
+						<value objectType="KalturaEvalStringField">
+							<code>kConf::get("partner_notification_name")</code>
+						</value>
+					</item>
+					<item objectType="KalturaEventNotificationParameter">
+						<key>entry_name</key>
+						<description>Entry name</description>
+						<value objectType="KalturaEvalStringField">
+							<code>$scope->getObject()->getName()</code>
+						</value>
+					</item>
+				</contentParameters>
+			</template>
+		</request>
+		<request service="eventNotificationTemplate" action="updateStatus" plugin="eventNotification" partnerId="0">
+			<id>{1:result:id}</id>
+			<status>1</status><!-- EventNotificationTemplateStatus::DISABLED -->
+		</request>
+	</multirequest>
+	<multirequest>
+		<!-- Entry Ready -->
+		<request service="eventNotificationTemplate" action="add" plugin="eventNotification" partnerId="0">
+			<template objectType="KalturaEmailNotificationTemplate">
+				<name>Entry Ready</name>
+				<systemName>Entry_Ready</systemName>
+				<description>Email notification template to be sent when a new entry is ready.</description>
+				<automaticDispatchEnabled>1</automaticDispatchEnabled>
+				<eventType>3</eventType> <!-- EventNotificationEventType::OBJECT_CHANGED -->
+				<eventObjectType>1</eventObjectType> <!-- EventNotificationEventObjectType::ENTRY -->
+				<eventConditions objectType="array">
+					<item objectType="KalturaEventFieldCondition">
+						<description>Status changed to ready, See:KalturaEntryStatus:/api_v3/testmeDoc/?object=KalturaEntryStatus</description>
+						<field objectType="KalturaEvalBooleanField">
+							<code>$scope->getObject() instanceof entry &amp;&amp; in_array(entryPeer::STATUS, $scope->getEvent()->getModifiedColumns()) &amp;&amp; $scope->getObject()->getStatus() == entryStatus::READY</code>
+						</field>
+					</item>
+					<item objectType="KalturaOrCondition">
+						<conditions objectType="array">
+							<item objectType="KalturaEventFieldCondition">
+								<field objectType="KalturaEvalBooleanField">
+									<code>!$scope->getObject()->getReplacedEntryId()</code>
+								</field>
+							</item>
+							<item objectType="KalturaEventFieldCondition">
+								<field objectType="KalturaEvalBooleanField">
+									<code>$scope->getObject()->getReplacedEntryId() &amp;&amp; entryPeer::retrieveByPK($scope->getObject()->getReplacedEntryId())->getSourceType()!= EntrySourceType::RECORDED_LIVE</code>
+								</field>
+							</item>
+						</conditions>
+					</item>
+				</eventConditions>
+				<format>1</format>
+				<subject>Entry is Ready for Publishing: {entry_name}/ ID: {entry_id}</subject>
+				<body><![CDATA[ Hello,<p>A new entry is ready for publishing:</p><p>Entry Name: {entry_name} <br>Entry ID:  {entry_id}<br>Entry Creator: {creator_name}, {creator_id}/{creator_email} </p>]]></body>
+				<fromEmail>{from_email}</fromEmail>
+				<fromName>{from_name}</fromName>
+				<to objectType="KalturaEmailNotificationStaticRecipientProvider">
+					<emailRecipients objectType="array">
+						<item objectType = "KalturaEmailNotificationRecipient">
+							<email objectType="KalturaStringValue">
+								<value>{creator_email}</value>
+							</email>
+							<name objectType="KalturaStringValue">
+								<value>{creator_name}</value>
+							</name>
+						</item>
+					</emailRecipients>
+				</to>
+				<cc objectType="KalturaEmailNotificationStaticRecipientProvider">
+					<emailRecipients objectType="array">
+						<item objectType="KalturaEmailNotificationRecipient">
+							<email objectType="KalturaStringValue">
+								<value>{owner_email}</value>
+							</email>
+							<name objectType="KalturaStringValue">
+								<value>{owner_name}</value>
+							</name>
+						</item>
+					</emailRecipients>
+				</cc>
+				<contentParameters objectType="array">
+					<item objectType="KalturaEventNotificationParameter">
+						<key>from_email</key>
+						<description>Sender email</description>
+						<value objectType="KalturaEvalStringField">
+							<code>kConf::get("partner_notification_email")</code>
+						</value>
+					</item>
+					<item objectType="KalturaEventNotificationParameter">
+						<key>from_name</key>
+						<description>Sender name</description>
+						<value objectType="KalturaEvalStringField">
+							<code>kConf::get("partner_notification_name")</code>
+						</value>
+					</item>
+					<item objectType="KalturaEventNotificationParameter">
+						<key>entry_id</key>
+						<description>Entry ID</description>
+						<value objectType="KalturaEvalStringField">
+							<code>(($scope->getObject() instanceof entry) &amp;&amp; ($scope->getObject()->getIsTemporary()) &amp;&amp; ($scope->getObject()->getReplacedEntryId()))? $scope->getObject()->getReplacedEntryId():$scope->getObject()->getId()</code>
+						</value>
+					</item>
+					<item objectType="KalturaEventNotificationParameter">
+						<key>entry_name</key>
+						<description>Entry name</description>
+						<value objectType="KalturaEvalStringField">
+							<code>(($scope->getObject() instanceof entry) &amp;&amp; ($scope->getObject()->getIsTemporary()) &amp;&amp; ($scope->getObject()->getReplacedEntryId()))? entryPeer::retrieveByPK($scope->getObject()->getReplacedEntryId())->getName():$scope->getObject()->getName()</code>
+						</value>
+					</item>
+					<item objectType="KalturaEventNotificationParameter">
+						<key>creator_name</key>
+						<description>Entry creator name</description>
+						<value objectType="KalturaEvalStringField">
+							<code>$scope->getObject()->getkuser()->getFirstName() . ' ' . $scope->getObject()->getkuser()->getLastName()</code>
+						</value>
+					</item>
+					<item objectType="KalturaEventNotificationParameter">
+						<key>creator_id</key>
+						<description>Entry creator ID</description>
+						<value objectType="KalturaEvalStringField">
+							<code>$scope->getObject()->getKuserId()</code>
+						</value>
+					</item>
+					<item objectType="KalturaEventNotificationParameter">
+						<key>creator_email</key>
+						<description>Entry creator email</description>
+						<value objectType="KalturaEvalStringField">
+							<code>$scope->getObject()->getkuser()->getEmail()</code>
+						</value>
+					</item>
+					<item objectType="KalturaEventNotificationParameter">
+						<key>owner_name</key>
+						<description>Account owner name</description>
+						<value objectType="KalturaEvalStringField">
+							<code>!is_null(entryPeer::retrieveByPk($scope->getObject()->getEntryId())) ? entryPeer::retrieveByPk($scope->getObject()->getEntryId())->getPartner()->getPartnerName() : ''</code>
+						</value>
+					</item>
+					<item objectType="KalturaEventNotificationParameter">
+						<key>owner_email</key>
+						<description>Account owner email</description>
+						<value objectType="KalturaEvalStringField">
+							<code>!is_null(entryPeer::retrieveByPk($scope->getObject()->getEntryId())) ? entryPeer::retrieveByPk($scope->getObject()->getEntryId())->getPartner()->getAdminEmail() : ''</code>
+						</value>
+					</item>
+				</contentParameters>
+			</template>
+		</request>
+		<request service="eventNotificationTemplate" action="updateStatus" plugin="eventNotification" partnerId="0">
+			<id>{1:result:id}</id>
+			<status>1</status><!-- EventNotificationTemplateStatus::DISABLED -->
+		</request>
+	</multirequest>
+	<multirequest>
+		<!-- User was added to category as [role] -->
+		<request service="eventNotificationTemplate" action="add" plugin="eventNotification" partnerId="0">
+			<template objectType="KalturaEmailNotificationTemplate">
+				<name>User was added to category as [role]</name>
+				<systemName>User_Added_To_Category_As_Role</systemName>
+				<description>Email notification template to be sent when a used is added to a category with a specific role.</description>
+				<automaticDispatchEnabled>1</automaticDispatchEnabled>
+				<eventType>2</eventType> <!-- EventNotificationEventType::OBJECT_ADDED -->
+				<eventObjectType>12</eventObjectType> <!-- EventNotificationEventObjectType::CATEGORYKUSER -->
+				<eventConditions objectType="array">
+					<item objectType="KalturaEventFieldCondition">
+						<description>Status is active, See:KalturaCategoryUserStatus:/api_v3/testmeDoc/?object=KalturaCategoryUserStatus</description>
+						<field objectType="KalturaEvalBooleanField">
+							<code>$scope->getObject() instanceof categoryKuser &amp;&amp; $scope->getObject()->getStatus() == CategoryKuserStatus::ACTIVE</code>
+						</field>
+					</item>
+					<item objectType="KalturaEventFieldCondition">
+						<description>User has role, See:KalturaCategoryUserPermissionLevel:/api_v3/testmeDoc/?object=KalturaCategoryUserStatus</description>
+						<field objectType="KalturaEvalBooleanField">
+							<code>$scope->getObject() instanceof categoryKuser &amp;&amp; category::getPermissionLevelName($scope->getObject()->getPermissionLevel())</code>
+						</field>
+					</item>
+				</eventConditions>
+				<format>1</format>
+				<subject>[AppTitle] - You have been added to {category_name}</subject>
+				<body>You have been added as {role} to {category_name}</body>
+				<fromEmail>{from_email}</fromEmail>
+				<fromName>{from_name}</fromName>
+				<to objectType="KalturaEmailNotificationStaticRecipientProvider">
+					<emailRecipients objectType="array">
+						<item objectType = "KalturaEmailNotificationRecipient">
+							<email objectType="KalturaEvalStringField">
+								<code>!is_null($scope->getObject()->getkuser()) ? $scope->getObject()->getkuser()->getEmail() : ''</code>
+							</email>
+							<name objectType="KalturaEvalStringField">
+								<code>!is_null($scope->getObject()->getkuser()) ? $scope->getObject()->getkuser()->getFirstName().' '.$scope->getObject()->getkuser()->getLastName() : ''</code>
+							</name>
+						</item>
+					</emailRecipients>
+				</to>
+				<contentParameters objectType="array">
+					<item objectType="KalturaEventNotificationParameter">
+						<key>from_email</key>
+						<description>Server configuration: partner_notification_email</description>
+						<value objectType="KalturaEvalStringField">
+							<code>kConf::get("partner_notification_email")</code>
+						</value>
+					</item>
+					<item objectType="KalturaEventNotificationParameter">
+						<key>from_name</key>
+						<description>Server configuration: partner_notification_name</description>
+						<value objectType="KalturaEvalStringField">
+							<code>kConf::get("partner_notification_name")</code>
+						</value>
+					</item>
+					<item objectType="KalturaEventNotificationParameter">
+						<key>category_name</key>
+						<description>Category name</description>
+						<value objectType="KalturaEvalStringField">
+							<code>($scope->getObject()->getcategory()) ? $scope->getObject()->getcategory()->getName() : ''</code>
+						</value>
+					</item>
+					<item objectType="KalturaEventNotificationParameter">
+						<key>role</key>
+						<description>Role</description>
+						<value objectType="KalturaEvalStringField">
+							<code>ucfirst(strtolower(category::getPermissionLevelName($scope->getObject()->getPermissionLevel())))</code>
+						</value>
+					</item>
+				</contentParameters>
+			</template>
+		</request>
+		<request service="eventNotificationTemplate" action="updateStatus" plugin="eventNotification" partnerId="0">
+			<id>{1:result:id}</id>
+			<status>1</status><!-- EventNotificationTemplateStatus::DISABLED -->
+		</request>
+	</multirequest>
+	<multirequest>
+		<!-- User's role was changed in category -->
+		<request service="eventNotificationTemplate" action="add" plugin="eventNotification" partnerId="0">
+			<template objectType="KalturaEmailNotificationTemplate">
+				<name>User's role was changed in category</name>
+				<systemName>User_Role_Was_Changed_In_Category</systemName>
+				<description>Email notification template to be sent when user's role is changed in category.</description>
+				<automaticDispatchEnabled>1</automaticDispatchEnabled>
+				<eventType>3</eventType> <!-- EventNotificationEventType::OBJECT_CHANGED -->
+				<eventObjectType>12</eventObjectType> <!-- EventNotificationEventObjectType::CATEGORYKUSER -->
+				<eventConditions objectType="array">
+					<item objectType="KalturaEventFieldCondition">
+						<description>Permission level change, See:KalturaCategoryUserPermissionLevel:/api_v3/testmeDoc/?object=KalturaCategoryUserStatus, and status is active, See:KalturaCategoryUserStatus:/api_v3/testmeDoc/?object=KalturaCategoryUserStatus</description>
+						<field objectType="KalturaEvalBooleanField">
+							<code>$scope->getObject() instanceof categoryKuser &amp;&amp; in_array(categoryKuserPeer::PERMISSION_LEVEL, $scope->getEvent()->getModifiedColumns()) &amp;&amp; $scope->getObject()->getStatus() == CategoryKuserStatus::ACTIVE</code>
+						</field>
+					</item>
+				</eventConditions>
+				<format>1</format>
+				<subject>[AppTitle] - Your {category_name} role has changed</subject>
+				<body>Your role in {category_name} has changed and is now {role}</body>
+				<fromEmail>{from_email}</fromEmail>
+				<fromName>{from_name}</fromName>
+				<to objectType="KalturaEmailNotificationStaticRecipientProvider">
+					<emailRecipients objectType="array">
+						<item objectType = "KalturaEmailNotificationRecipient">
+							<email objectType="KalturaEvalStringField">
+								<code>!is_null($scope->getObject()->getkuser()) ? $scope->getObject()->getkuser()->getEmail() : ''</code>
+							</email>
+							<name objectType="KalturaEvalStringField">
+								<code>!is_null($scope->getObject()->getkuser()) ? $scope->getObject()->getkuser()->getFirstName().' '.$scope->getObject()->getkuser()->getLastName() : ''</code>
+							</name>
+						</item>
+					</emailRecipients>
+				</to>
+				<contentParameters objectType="array">
+					<item objectType="KalturaEventNotificationParameter">
+						<key>from_email</key>
+						<description>Server configuration: partner_notification_email</description>
+						<value objectType="KalturaEvalStringField">
+							<code>kConf::get("partner_notification_email")</code>
+						</value>
+					</item>
+					<item objectType="KalturaEventNotificationParameter">
+						<key>from_name</key>
+						<description>Server configuration: partner_notification_name</description>
+						<value objectType="KalturaEvalStringField">
+							<code>kConf::get("partner_notification_name")</code>
+						</value>
+					</item>
+					<item objectType="KalturaEventNotificationParameter">
+						<key>category_name</key>
+						<description>Category name</description>
+						<value objectType="KalturaEvalStringField">
+							<code>($scope->getObject()->getcategory()) ? $scope->getObject()->getcategory()->getName() : ''</code>
+						</value>
+					</item>
+					<item objectType="KalturaEventNotificationParameter">
+						<key>role</key>
+						<description>Role</description>
+						<value objectType="KalturaEvalStringField">
+							<code>ucfirst(strtolower(category::getPermissionLevelName($scope->getObject()->getPermissionLevel())))</code>
+						</value>
+					</item>
+				</contentParameters>
+			</template>
+		</request>
+		<request service="eventNotificationTemplate" action="updateStatus" plugin="eventNotification" partnerId="0">
+			<id>{1:result:id}</id>
+			<status>1</status><!-- EventNotificationTemplateStatus::DISABLED -->
+		</request>
+	</multirequest>
+	<multirequest>
+		<!-- User was removed from category -->
+		<request service="eventNotificationTemplate" action="add" plugin="eventNotification" partnerId="0">
+			<template objectType="KalturaEmailNotificationTemplate">
+				<name>User was removed from category</name>
+				<systemName>User_Was_Removed_From_Category</systemName>
+				<description>Email notification template to be sent when user was removed from category.</description>
+				<automaticDispatchEnabled>1</automaticDispatchEnabled>
+				<eventType>7</eventType> <!-- EventNotificationEventType::OBJECT_DELETED -->
+				<eventObjectType>12</eventObjectType> <!-- EventNotificationEventObjectType::CATEGORYKUSER -->
+				<eventConditions objectType="array">
+					<item objectType="KalturaEventFieldCondition">
+						<description>Object type verified</description>
+						<field objectType="KalturaEvalBooleanField">
+							<code>$scope->getObject() instanceof categoryKuser</code>
+						</field>
+					</item>
+				</eventConditions>
+				<format>1</format>
+				<subject>[AppTitle] - You have been removed from {category_name}</subject>
+				<body>You have been removed from {category_name}</body>
+				<fromEmail>{from_email}</fromEmail>
+				<fromName>{from_name}</fromName>
+				<to objectType="KalturaEmailNotificationStaticRecipientProvider">
+					<emailRecipients objectType="array">
+						<item objectType = "KalturaEmailNotificationRecipient">
+							<email objectType="KalturaEvalStringField">
+								<code>!is_null($scope->getObject()->getkuser()) ? $scope->getObject()->getkuser()->getEmail() : ''</code>
+							</email>
+							<name objectType="KalturaEvalStringField">
+								<code>!is_null($scope->getObject()->getkuser()) ? $scope->getObject()->getkuser()->getFirstName().' '.$scope->getObject()->getkuser()->getLastName() : ''</code>
+							</name>
+						</item>
+					</emailRecipients>
+				</to>
+				<contentParameters objectType="array">
+					<item objectType="KalturaEventNotificationParameter">
+						<key>from_email</key>
+						<description>Server configuration: partner_notification_email</description>
+						<value objectType="KalturaEvalStringField">
+							<code>kConf::get("partner_notification_email")</code>
+						</value>
+					</item>
+					<item objectType="KalturaEventNotificationParameter">
+						<key>from_name</key>
+						<description>Server configuration: partner_notification_name</description>
+						<value objectType="KalturaEvalStringField">
+							<code>kConf::get("partner_notification_name")</code>
+						</value>
+					</item>
+					<item objectType="KalturaEventNotificationParameter">
+						<key>category_name</key>
+						<description>Category name</description>
+						<value objectType="KalturaEvalStringField">
+							<code>($scope->getObject()->getcategory()) ? $scope->getObject()->getcategory()->getName() : ''</code>
+						</value>
+					</item>
+				</contentParameters>
+			</template>
+		</request>
+		<request service="eventNotificationTemplate" action="updateStatus" plugin="eventNotification" partnerId="0">
+			<id>{1:result:id}</id>
+			<status>1</status><!-- EventNotificationTemplateStatus::DISABLED -->
+		</request>
+	</multirequest>
+	<multirequest>
+		<!-- Entry was added to channel -->
+		<request service="eventNotificationTemplate" action="add" plugin="eventNotification" partnerId="0">
+			<template objectType="KalturaEmailNotificationTemplate">
+				<name>Entry was added to channel</name>
+				<systemName>Entry_Was_Added_To_Channel</systemName>
+				<description>Email notification template to be sent when entry is added to channel.</description>
+				<automaticDispatchEnabled>1</automaticDispatchEnabled>
+				<eventType>5</eventType> <!-- EventNotificationEventType::OBJECT_CREATED -->
+				<eventObjectType>37</eventObjectType> <!-- EventNotificationEventObjectType::CATEGORYENTRY -->
+				<eventConditions objectType="array">
+					<item objectType="KalturaEventFieldCondition">
+						<description>Status is active, See:KalturaCategoryEntryStatus:/api_v3/testmeDoc/?object=KalturaCategoryEntryStatus</description>
+						<field objectType="KalturaEvalBooleanField">
+							<code>$scope->getObject() instanceof categoryEntry &amp;&amp; $scope->getObject()->getStatus() == CategoryEntryStatus::ACTIVE</code>
+						</field>
+					</item>
+				</eventConditions>
+				<format>1</format>
+				<subject>[AppTitle] - A new media was added to {category_name}</subject>
+				<body>Media {entry_name} was added to {category_name}. You can see the media here: [AppEntryUrl]{entry_id}</body>
+				<fromEmail>{from_email}</fromEmail>
+				<fromName>{from_name}</fromName>
+				<bcc objectType="KalturaEmailNotificationCategoryRecipientProvider">
+					<categoryId objectType="KalturaEvalStringField">
+						<code>$scope->getObject()->getCategoryId()</code>
+					</categoryId>
+					<categoryUserFilter objectType="KalturaCategoryUserProviderFilter">
+						<permissionNamesMatchOr>CATEGORY_SUBSCRIBE</permissionNamesMatchOr>
+					</categoryUserFilter>
+				</bcc>
+				<contentParameters objectType="array">
+					<item objectType="KalturaEventNotificationParameter">
+						<key>from_email</key>
+						<description>Server configuration: partner_notification_email</description>
+						<value objectType="KalturaEvalStringField">
+							<code>kConf::get("partner_notification_email")</code>
+						</value>
+					</item>
+					<item objectType="KalturaEventNotificationParameter">
+						<key>from_name</key>
+						<description>Server configuration: partner_notification_name</description>
+						<value objectType="KalturaEvalStringField">
+							<code>kConf::get("partner_notification_name")</code>
+						</value>
+					</item>
+					<item objectType="KalturaEventNotificationParameter">
+						<key>category_name</key>
+						<description>Category name</description>
+						<value objectType="KalturaEvalStringField">
+							<code>!is_null(categoryPeer::retrieveByPk($scope->getObject()->getCategoryId())) ? categoryPeer::retrieveByPk($scope->getObject()->getCategoryId())->getName() : ''</code>
+						</value>
+					</item>
+					<item objectType="KalturaEventNotificationParameter">
+						<key>entry_id</key>
+						<description>Entry ID</description>
+						<value objectType="KalturaEvalStringField">
+							<code>$scope->getObject()->getEntryId()</code>
+						</value>
+					</item>
+					<item objectType="KalturaEventNotificationParameter">
+						<key>entry_name</key>
+						<description>Entry name</description>
+						<value objectType="KalturaEvalStringField">
+							<code>!is_null(entryPeer::retrieveByPk($scope->getObject()->getEntryId())) ? entryPeer::retrieveByPk($scope->getObject()->getEntryId())->getName() : ''</code>
+						</value>
+					</item>
+				</contentParameters>
+			</template>
+		</request>
+		<request service="eventNotificationTemplate" action="updateStatus" plugin="eventNotification" partnerId="0">
+			<id>{1:result:id}</id>
+			<status>1</status><!-- EventNotificationTemplateStatus::DISABLED -->
+		</request>
+	</multirequest>
+	<multirequest>
+		<!-- Comment was added to entry -->
+		<request service="eventNotificationTemplate" action="add" plugin="eventNotification" partnerId="0">
+			<template objectType="KalturaEmailNotificationTemplate">
+				<name>Comment was added to entry</name>
+				<systemName>Comment_Was_Added_To_Entry</systemName>
+				<description>Email notification template to be sent to entry creator when a comment is added to his entry.</description>
+				<automaticDispatchEnabled>1</automaticDispatchEnabled>
+				<eventType>5</eventType> <!-- EventNotificationEventType::OBJECT_CREATED -->
+				<eventObjectType>annotationEventNotifications.Annotation</eventObjectType>
+				<eventConditions objectType="array">
+					<item objectType="KalturaEventFieldCondition">
+						<description>An annotation object was created</description>
+						<field objectType="KalturaEvalBooleanField">
+							<code>$scope->getObject() instanceof Annotation</code>
+						</field>
+					</item>
+					<item objectType="KalturaOrCondition">
+						<description>Annotation tags contains at least one of the comment tags</description>
+						<conditions objectType="array">
+							<item objectType="KalturaEventFieldCondition">
+								<field objectType="KalturaEvalBooleanField">
+									<code>(strpos($scope->getObject()->getTags(),"KMS_public_comment") !== false)</code>
+								</field>
+							</item>
+							<item objectType="KalturaEventFieldCondition">
+								<field objectType="KalturaEvalBooleanField">
+									<code>(strpos($scope->getObject()->getTags(),"KMS_comment_context_") !== false)</code>
+								</field>
+							</item>
+						</conditions>
+					</item>
+				</eventConditions>
+				<format>1</format>
+				<subject>[AppTitle] - A new comment was added to your video {entry_name}</subject>
+				<body>A new comment was added to your video {entry_name}.Comment: {comment_text}. You can access the video page here: [AppEntryUrl]{entry_id}</body>
+				<fromEmail>{from_email}</fromEmail>
+				<fromName>{from_name}</fromName>
+				<bcc objectType="KalturaEmailNotificationStaticRecipientProvider">
+					<emailRecipients objectType="array">
+						<item objectType = "KalturaEmailNotificationRecipient">
+							<email objectType="KalturaEvalStringField">
+								<code>!is_null(entryPeer::retrieveByPk($scope->getObject()->getEntryId())) ? (!is_null(entryPeer::retrieveByPk($scope->getObject()->getEntryId())->getkuser()) ? entryPeer::retrieveByPk($scope->getObject()->getEntryId())->getkuser()->getEmail() : '') : ''</code>
+							</email>
+							<name objectType="KalturaEvalStringField">
+								<code>!is_null(entryPeer::retrieveByPk($scope->getObject()->getEntryId())) ? (!is_null(entryPeer::retrieveByPk($scope->getObject()->getEntryId())->getkuser()) ? entryPeer::retrieveByPk($scope->getObject()->getEntryId())->getkuser()->getFirstName().' '.entryPeer::retrieveByPk($scope->getObject()->getEntryId())->getkuser()->getLastName() : '') : ''</code>
+							</name>
+						</item>
+					</emailRecipients>
+				</bcc>
+				<contentParameters objectType="array">
+					<item objectType="KalturaEventNotificationParameter">
+						<key>from_email</key>
+						<value objectType="KalturaEvalStringField">
+							<code>kConf::get("partner_notification_email")</code>
+						</value>
+					</item>
+					<item objectType="KalturaEventNotificationParameter">
+						<key>from_name</key>
+						<value objectType="KalturaEvalStringField">
+							<code>kConf::get("partner_notification_name")</code>
+						</value>
+					</item>
+					<item objectType="KalturaEventNotificationParameter">
+						<key>entry_id</key>
+						<value objectType="KalturaEvalStringField">
+							<code>$scope->getObject()->getEntryId()</code>
+						</value>
+					</item>
+					<item objectType="KalturaEventNotificationParameter">
+						<key>entry_name</key>
+						<value objectType="KalturaEvalStringField">
+							<code>!is_null(entryPeer::retrieveByPk($scope->getObject()->getEntryId())) ? entryPeer::retrieveByPk($scope->getObject()->getEntryId())->getName() : ''</code>
+						</value>
+					</item>
+					<item objectType="KalturaEventNotificationParameter">
+						<key>comment_text</key>
+						<value objectType="KalturaEvalStringField">
+							<code>$scope->getObject()->getText()</code>
+						</value>
+					</item>
+					<item objectType="KalturaEventNotificationParameter">
+						<key>comment_id</key>
+						<value objectType="KalturaEvalStringField">
+							<code>$scope->getObject()->getId()</code>
+						</value>
+					</item>
+					<item objectType="KalturaEventNotificationParameter">
+						<key>comment_parent_id</key>
+						<value objectType="KalturaEvalStringField">
+							<code>$scope->getObject()->getParentId()</code>
+						</value>
+					</item>
+					<item objectType="KalturaEventNotificationParameter">
+						<key>comment_system_name</key>
+						<value objectType="KalturaEvalStringField">
+							<code>$scope->getObject()->getSystemName()</code>
+						</value>
+					</item>
+					<item objectType="KalturaEventNotificationParameter">
+						<key>comment_user_id</key>
+						<value objectType="KalturaEvalStringField">
+							<code>$scope->getObject()->getPuserId()</code>
+						</value>
+					</item>
+					<item objectType="KalturaEventNotificationParameter">
+						<key>comment_created_at</key>
+						<value objectType="KalturaEvalStringField">
+							<code>$scope->getObject()->getCreatedAt()</code>
+						</value>
+					</item>
+					<item objectType="KalturaEventNotificationParameter">
+						<key>comment_updated_at</key>
+						<value objectType="KalturaEvalStringField">
+							<code>$scope->getObject()->getUpdatedAt()</code>
+						</value>
+					</item>
+					<item objectType="KalturaEventNotificationParameter">
+						<key>comment_partner_data</key>
+						<value objectType="KalturaEvalStringField">
+							<code>$scope->getObject()->getPartnerData()</code>
+						</value>
+					</item>
+					<item objectType="KalturaEventNotificationParameter">
+						<key>comment_start_time</key>
+						<value objectType="KalturaEvalStringField">
+							<code>$scope->getObject()->getStartTime()</code>
+						</value>
+					</item>
+					<item objectType="KalturaEventNotificationParameter">
+						<key>comment_end_time</key>
+						<value objectType="KalturaEvalStringField">
+							<code>$scope->getObject()->getEndTime()</code>
+						</value>
+					</item>
+					<item objectType="KalturaEventNotificationParameter">
+						<key>comment_duration</key>
+						<value objectType="KalturaEvalStringField">
+							<code>$scope->getObject()->getDuration()</code>
+						</value>
+					</item>
+				</contentParameters>
+			</template>
+		</request>
+		<request service="eventNotificationTemplate" action="updateStatus" plugin="eventNotification" partnerId="0">
+			<id>{1:result:id}</id>
+			<status>1</status><!-- EventNotificationTemplateStatus::DISABLED -->
+		</request>
+	</multirequest>
+</xml>

--- a/tests/standAloneClient/uniqueMediaspaceNotificationsTemplates.xml
+++ b/tests/standAloneClient/uniqueMediaspaceNotificationsTemplates.xml
@@ -15,7 +15,7 @@
 		<request service="eventNotificationTemplate" action="add" plugin="eventNotification" partnerId="0">
 			<template objectType="KalturaEmailNotificationTemplate">
 				<name>New Item Pending Moderation</name>
-				<systemName>New_Item_Pending_Moderation</systemName>
+				<systemName>Unique_Kms_New_Item_Pending_Moderation</systemName>
 				<description>Email notification template to be sent when a new item is pending moderation in a specific category (channel).</description>
 				<automaticDispatchEnabled>1</automaticDispatchEnabled>
 				<eventType>5</eventType> <!-- EventNotificationEventType::OBJECT_CREATED -->
@@ -25,6 +25,12 @@
 						<description>Status is pending, See:KalturaCategoryEntryStatus:/api_v3/testmeDoc/?object=KalturaCategoryEntryStatus</description>
 						<field objectType="KalturaEvalBooleanField">
 							<code>$scope->getObject() instanceof categoryEntry &amp;&amp; $scope->getObject()->getStatus() == CategoryEntryStatus::PENDING</code>
+						</field>
+					</item>
+					<item objectType="KalturaEventFieldCondition">
+						<description>Category is inside of specified category root</description>
+						<field objectType="KalturaEvalBooleanField">
+							<code>in_array($scope->getDynamicValues()['root_category_id'], explode('>', $scope->getObject()->getCategoryFullIds()))</code>
 						</field>
 					</item>
 				</eventConditions>
@@ -85,6 +91,15 @@
 						</value>
 					</item>
 				</contentParameters>
+				<userParameters objectType="array">
+					<item objectType="KalturaEventNotificationParameter">
+						<key>root_category_id</key>
+						<description>KMS instance root category ID</description>
+						<value objectType="KalturaStringValue">
+							<value/>
+						</value>
+					</item>
+				</userParameters>
 			</template>
 		</request>
 		<request service="eventNotificationTemplate" action="updateStatus" plugin="eventNotification" partnerId="0">
@@ -97,7 +112,7 @@
 		<request service="eventNotificationTemplate" action="add" plugin="eventNotification" partnerId="0">
 			<template objectType="KalturaEmailNotificationTemplate">
 				<name>New Item Pending Moderation</name>
-				<systemName>New_Item_Pending_Moderation_2</systemName>
+				<systemName>Unique_Kms_New_Item_Pending_Moderation_2</systemName>
 				<description>Email notification template to be sent when a new item is pending moderation in a specific category (channel).</description>
 				<automaticDispatchEnabled>1</automaticDispatchEnabled>
 				<eventType>3</eventType> <!-- EventNotificationEventType::OBJECT_CHANGED -->
@@ -107,6 +122,12 @@
 						<description>Status changed to pending, See:KalturaCategoryEntryStatus:/api_v3/testmeDoc/?object=KalturaCategoryEntryStatus</description>
 						<field objectType="KalturaEvalBooleanField">
 							<code>$scope->getObject() instanceof categoryEntry &amp;&amp; in_array(categoryEntryPeer::STATUS, $scope->getEvent()->getModifiedColumns()) &amp;&amp; $scope->getObject()->getStatus() == CategoryEntryStatus::PENDING</code>
+						</field>
+					</item>
+					<item objectType="KalturaEventFieldCondition">
+						<description>Category is inside of specified category root</description>
+						<field objectType="KalturaEvalBooleanField">
+							<code>in_array($scope->getDynamicValues()['root_category_id'], explode('>', $scope->getObject()->getCategoryFullIds()))</code>
 						</field>
 					</item>
 				</eventConditions>
@@ -167,6 +188,15 @@
 						</value>
 					</item>
 				</contentParameters>
+				<userParameters objectType="array">
+					<item objectType="KalturaEventNotificationParameter">
+						<key>root_category_id</key>
+						<description>KMS instance root category ID</description>
+						<value objectType="KalturaStringValue">
+							<value/>
+						</value>
+					</item>
+				</userParameters>
 			</template>
 		</request>
 		<request service="eventNotificationTemplate" action="updateStatus" plugin="eventNotification" partnerId="0">
@@ -179,7 +209,7 @@
 		<request service="eventNotificationTemplate" action="add" plugin="eventNotification" partnerId="0">
 			<template objectType="KalturaEmailNotificationTemplate">
 				<name>Entry Approved In Category</name>
-				<systemName>Entry_Approved_In_Category</systemName>
+				<systemName>Unique_Kms_Entry_Approved_In_Category</systemName>
 				<description>Email notification template to be sent when a new entry is approved in a category.</description>
 				<automaticDispatchEnabled>1</automaticDispatchEnabled>
 				<eventType>3</eventType> <!-- EventNotificationEventType::OBJECT_CHANGED -->
@@ -189,6 +219,12 @@
 						<description>Status changed to active, See:KalturaCategoryEntryStatus:/api_v3/testmeDoc/?object=KalturaCategoryEntryStatus</description>
 						<field objectType="KalturaEvalBooleanField">
 							<code>$scope->getObject() instanceof categoryEntry &amp;&amp; in_array(categoryEntryPeer::STATUS, $scope->getEvent()->getModifiedColumns()) &amp;&amp; $scope->getObject()->getStatus() == CategoryEntryStatus::ACTIVE</code>
+						</field>
+					</item>
+					<item objectType="KalturaEventFieldCondition">
+						<description>Category is inside of specified category root</description>
+						<field objectType="KalturaEvalBooleanField">
+							<code>in_array($scope->getDynamicValues()['root_category_id'], explode('>', $scope->getObject()->getCategoryFullIds()))</code>
 						</field>
 					</item>
 				</eventConditions>
@@ -246,6 +282,15 @@
 						</value>
 					</item>
 				</contentParameters>
+				<userParameters objectType="array">
+					<item objectType="KalturaEventNotificationParameter">
+						<key>root_category_id</key>
+						<description>KMS instance root category ID</description>
+						<value objectType="KalturaStringValue">
+							<value/>
+						</value>
+					</item>
+				</userParameters>
 			</template>
 		</request>
 		<request service="eventNotificationTemplate" action="updateStatus" plugin="eventNotification" partnerId="0">
@@ -258,7 +303,7 @@
 		<request service="eventNotificationTemplate" action="add" plugin="eventNotification" partnerId="0">
 			<template objectType="KalturaEmailNotificationTemplate">
 				<name>Entry Rejected In Category</name>
-				<systemName>Entry_Rejected_In_Category</systemName>
+				<systemName>Unique_Kms_Entry_Rejected_In_Category</systemName>
 				<description>Email notification template to be sent when a new entry is rejected in a category.</description>
 				<automaticDispatchEnabled>1</automaticDispatchEnabled>
 				<eventType>3</eventType> <!-- EventNotificationEventType::OBJECT_CHANGED -->
@@ -268,6 +313,12 @@
 						<description>Status changed to rejected, See:KalturaCategoryEntryStatus:/api_v3/testmeDoc/?object=KalturaCategoryEntryStatus</description>
 						<field objectType="KalturaEvalBooleanField">
 							<code>$scope->getObject() instanceof categoryEntry &amp;&amp; in_array(categoryEntryPeer::STATUS, $scope->getEvent()->getModifiedColumns()) &amp;&amp; $scope->getObject()->getStatus() == CategoryEntryStatus::REJECTED</code>
+						</field>
+					</item>
+					<item objectType="KalturaEventFieldCondition">
+						<description>Category is inside of specified category root</description>
+						<field objectType="KalturaEvalBooleanField">
+							<code>in_array($scope->getDynamicValues()['root_category_id'], explode('>', $scope->getObject()->getCategoryFullIds()))</code>
 						</field>
 					</item>
 				</eventConditions>
@@ -325,6 +376,15 @@
 						</value>
 					</item>
 				</contentParameters>
+				<userParameters objectType="array">
+					<item objectType="KalturaEventNotificationParameter">
+						<key>root_category_id</key>
+						<description>KMS instance root category ID</description>
+						<value objectType="KalturaStringValue">
+							<value/>
+						</value>
+					</item>
+				</userParameters>
 			</template>
 		</request>
 		<request service="eventNotificationTemplate" action="updateStatus" plugin="eventNotification" partnerId="0">
@@ -337,7 +397,7 @@
 		<request service="eventNotificationTemplate" action="add" plugin="eventNotification" partnerId="0">
 			<template objectType="KalturaEmailNotificationTemplate">
 				<name>Entry Rejected</name>
-				<systemName>Entry_Rejected</systemName>
+				<systemName>Unique_Kms_Entry_Rejected</systemName>
 				<description>Email notification template to be sent when a new entry is rejected.</description>
 				<automaticDispatchEnabled>1</automaticDispatchEnabled>
 				<eventType>3</eventType> <!-- EventNotificationEventType::OBJECT_CHANGED -->
@@ -348,6 +408,16 @@
 						<field objectType="KalturaEvalBooleanField">
 							<code>$scope->getObject() instanceof entry &amp;&amp; in_array(entryPeer::MODERATION_STATUS, $scope->getEvent()->getModifiedColumns()) &amp;&amp; $scope->getObject()->getModerationStatus() == entry::ENTRY_MODERATION_STATUS_REJECTED</code>
 						</field>
+					</item>
+					<item objectType="KalturaMatchMetadataCondition">
+						<description>Custom metadata indicates that the entry belongs to the instance</description>
+						<xPath>//*[local-name()='Key' and text()='InstanceId']/following-sibling::*[local-name()='Value']</xPath>
+						<profileSystemName>EntryAdditionalInfo</profileSystemName>
+						<values objectType="array">
+							<item objectType="KalturaStringValue">
+								<value>{instance_id}</value>
+							</item>
+						</values>
 					</item>
 				</eventConditions>
 				<format>1</format>
@@ -390,6 +460,15 @@
 						</value>
 					</item>
 				</contentParameters>
+				<userParameters objectType="array">
+					<item objectType="KalturaEventNotificationParameter">
+						<key>instance_id</key>
+						<description>KMS instance ID</description>
+						<value objectType="KalturaStringValue">
+							<value/>
+						</value>
+					</item>
+				</userParameters>
 			</template>
 		</request>
 		<request service="eventNotificationTemplate" action="updateStatus" plugin="eventNotification" partnerId="0">
@@ -402,7 +481,7 @@
 		<request service="eventNotificationTemplate" action="add" plugin="eventNotification" partnerId="0">
 			<template objectType="KalturaEmailNotificationTemplate">
 				<name>Entry Approved</name>
-				<systemName>Entry_Approved</systemName>
+				<systemName>Unique_Kms_Entry_Approved</systemName>
 				<description>Email notification template to be sent when a new entry is approved.</description>
 				<automaticDispatchEnabled>1</automaticDispatchEnabled>
 				<eventType>3</eventType> <!-- EventNotificationEventType::OBJECT_CHANGED -->
@@ -413,6 +492,16 @@
 						<field objectType="KalturaEvalBooleanField">
 							<code>$scope->getObject() instanceof entry &amp;&amp; in_array(entryPeer::MODERATION_STATUS, $scope->getEvent()->getModifiedColumns()) &amp;&amp; $scope->getObject()->getModerationStatus() == entry::ENTRY_MODERATION_STATUS_APPROVED</code>
 						</field>
+					</item>
+					<item objectType="KalturaMatchMetadataCondition">
+						<description>Custom metadata indicates that the entry belongs to the instance</description>
+						<xPath>//*[local-name()='Key' and text()='InstanceId']/following-sibling::*[local-name()='Value']</xPath>
+						<profileSystemName>EntryAdditionalInfo</profileSystemName>
+						<values objectType="array">
+							<item objectType="KalturaStringValue">
+								<value>{instance_id}</value>
+							</item>
+						</values>
 					</item>
 				</eventConditions>
 				<format>1</format>
@@ -455,6 +544,15 @@
 						</value>
 					</item>
 				</contentParameters>
+				<userParameters objectType="array">
+					<item objectType="KalturaEventNotificationParameter">
+						<key>instance_id</key>
+						<description>KMS instance ID</description>
+						<value objectType="KalturaStringValue">
+							<value/>
+						</value>
+					</item>
+				</userParameters>
 			</template>
 		</request>
 		<request service="eventNotificationTemplate" action="updateStatus" plugin="eventNotification" partnerId="0">
@@ -467,7 +565,7 @@
 		<request service="eventNotificationTemplate" action="add" plugin="eventNotification" partnerId="0">
 			<template objectType="KalturaEmailNotificationTemplate">
 				<name>Entry Ready</name>
-				<systemName>Entry_Ready</systemName>
+				<systemName>Unique_Kms_Entry_Ready</systemName>
 				<description>Email notification template to be sent when a new entry is ready.</description>
 				<automaticDispatchEnabled>1</automaticDispatchEnabled>
 				<eventType>3</eventType> <!-- EventNotificationEventType::OBJECT_CHANGED -->
@@ -492,6 +590,19 @@
 								</field>
 							</item>
 						</conditions>
+					</item>
+					<item objectType="KalturaFieldMatchCondition">
+						<description>Custom metadata indicates that the entry belongs to the instance</description>
+						<field objectType="KalturaEvalStringField">
+							<!-- EntryReady event is out of partner context, so KalturaMatchMetadataCondition won't work here -->
+							<!-- parseMetadataValues() returns an array of 0 or 1 elements - implode the array to have a string value -->
+							<code>($metadata = MetadataPeer::retrieveByObject(MetadataProfilePeer::retrieveBySystemName('EntryAdditionalInfo', array($scope->getPartnerId()))->getId(), MetadataObjectType::ENTRY, $scope->getObject()->getId())) ? implode('', kMetadataManager::parseMetadataValues($metadata, "//*[local-name()='Key' and text()='InstanceId']/following-sibling::*[local-name()='Value']")) : ''</code>
+						</field>
+						<values objectType="array">
+							<item objectType="KalturaStringValue">
+								<value>{instance_id}</value>
+							</item>
+						</values>
 					</item>
 				</eventConditions>
 				<format>1</format>
@@ -588,6 +699,15 @@
 						</value>
 					</item>
 				</contentParameters>
+				<userParameters objectType="array">
+					<item objectType="KalturaEventNotificationParameter">
+						<key>instance_id</key>
+						<description>KMS instance ID</description>
+						<value objectType="KalturaStringValue">
+							<value/>
+						</value>
+					</item>
+				</userParameters>
 			</template>
 		</request>
 		<request service="eventNotificationTemplate" action="updateStatus" plugin="eventNotification" partnerId="0">
@@ -600,7 +720,7 @@
 		<request service="eventNotificationTemplate" action="add" plugin="eventNotification" partnerId="0">
 			<template objectType="KalturaEmailNotificationTemplate">
 				<name>User was added to category as [role]</name>
-				<systemName>User_Added_To_Category_As_Role</systemName>
+				<systemName>Unique_Kms_User_Added_To_Category_As_Role</systemName>
 				<description>Email notification template to be sent when a used is added to a category with a specific role.</description>
 				<automaticDispatchEnabled>1</automaticDispatchEnabled>
 				<eventType>2</eventType> <!-- EventNotificationEventType::OBJECT_ADDED -->
@@ -616,6 +736,12 @@
 						<description>User has role, See:KalturaCategoryUserPermissionLevel:/api_v3/testmeDoc/?object=KalturaCategoryUserStatus</description>
 						<field objectType="KalturaEvalBooleanField">
 							<code>$scope->getObject() instanceof categoryKuser &amp;&amp; category::getPermissionLevelName($scope->getObject()->getPermissionLevel())</code>
+						</field>
+					</item>
+					<item objectType="KalturaEventFieldCondition">
+						<description>Category is inside of specified category root</description>
+						<field objectType="KalturaEvalBooleanField">
+							<code>in_array($scope->getDynamicValues()['root_category_id'], explode('>', $scope->getObject()->getCategoryFullIds()))</code>
 						</field>
 					</item>
 				</eventConditions>
@@ -666,6 +792,15 @@
 						</value>
 					</item>
 				</contentParameters>
+				<userParameters objectType="array">
+					<item objectType="KalturaEventNotificationParameter">
+						<key>root_category_id</key>
+						<description>KMS instance root category ID</description>
+						<value objectType="KalturaStringValue">
+							<value/>
+						</value>
+					</item>
+				</userParameters>
 			</template>
 		</request>
 		<request service="eventNotificationTemplate" action="updateStatus" plugin="eventNotification" partnerId="0">
@@ -678,7 +813,7 @@
 		<request service="eventNotificationTemplate" action="add" plugin="eventNotification" partnerId="0">
 			<template objectType="KalturaEmailNotificationTemplate">
 				<name>User's role was changed in category</name>
-				<systemName>User_Role_Was_Changed_In_Category</systemName>
+				<systemName>Unique_Kms_User_Role_Was_Changed_In_Category</systemName>
 				<description>Email notification template to be sent when user's role is changed in category.</description>
 				<automaticDispatchEnabled>1</automaticDispatchEnabled>
 				<eventType>3</eventType> <!-- EventNotificationEventType::OBJECT_CHANGED -->
@@ -688,6 +823,12 @@
 						<description>Permission level change, See:KalturaCategoryUserPermissionLevel:/api_v3/testmeDoc/?object=KalturaCategoryUserStatus, and status is active, See:KalturaCategoryUserStatus:/api_v3/testmeDoc/?object=KalturaCategoryUserStatus</description>
 						<field objectType="KalturaEvalBooleanField">
 							<code>$scope->getObject() instanceof categoryKuser &amp;&amp; in_array(categoryKuserPeer::PERMISSION_LEVEL, $scope->getEvent()->getModifiedColumns()) &amp;&amp; $scope->getObject()->getStatus() == CategoryKuserStatus::ACTIVE</code>
+						</field>
+					</item>
+					<item objectType="KalturaEventFieldCondition">
+						<description>Category is inside of specified category root</description>
+						<field objectType="KalturaEvalBooleanField">
+							<code>in_array($scope->getDynamicValues()['root_category_id'], explode('>', $scope->getObject()->getCategoryFullIds()))</code>
 						</field>
 					</item>
 				</eventConditions>
@@ -738,6 +879,15 @@
 						</value>
 					</item>
 				</contentParameters>
+				<userParameters objectType="array">
+					<item objectType="KalturaEventNotificationParameter">
+						<key>root_category_id</key>
+						<description>KMS instance root category ID</description>
+						<value objectType="KalturaStringValue">
+							<value/>
+						</value>
+					</item>
+				</userParameters>
 			</template>
 		</request>
 		<request service="eventNotificationTemplate" action="updateStatus" plugin="eventNotification" partnerId="0">
@@ -750,7 +900,7 @@
 		<request service="eventNotificationTemplate" action="add" plugin="eventNotification" partnerId="0">
 			<template objectType="KalturaEmailNotificationTemplate">
 				<name>User was removed from category</name>
-				<systemName>User_Was_Removed_From_Category</systemName>
+				<systemName>Unique_Kms_User_Was_Removed_From_Category</systemName>
 				<description>Email notification template to be sent when user was removed from category.</description>
 				<automaticDispatchEnabled>1</automaticDispatchEnabled>
 				<eventType>7</eventType> <!-- EventNotificationEventType::OBJECT_DELETED -->
@@ -760,6 +910,12 @@
 						<description>Object type verified</description>
 						<field objectType="KalturaEvalBooleanField">
 							<code>$scope->getObject() instanceof categoryKuser</code>
+						</field>
+					</item>
+					<item objectType="KalturaEventFieldCondition">
+						<description>Category is inside of specified category root</description>
+						<field objectType="KalturaEvalBooleanField">
+							<code>in_array($scope->getDynamicValues()['root_category_id'], explode('>', $scope->getObject()->getCategoryFullIds()))</code>
 						</field>
 					</item>
 				</eventConditions>
@@ -803,6 +959,15 @@
 						</value>
 					</item>
 				</contentParameters>
+				<userParameters objectType="array">
+					<item objectType="KalturaEventNotificationParameter">
+						<key>root_category_id</key>
+						<description>KMS instance root category ID</description>
+						<value objectType="KalturaStringValue">
+							<value/>
+						</value>
+					</item>
+				</userParameters>
 			</template>
 		</request>
 		<request service="eventNotificationTemplate" action="updateStatus" plugin="eventNotification" partnerId="0">
@@ -815,7 +980,7 @@
 		<request service="eventNotificationTemplate" action="add" plugin="eventNotification" partnerId="0">
 			<template objectType="KalturaEmailNotificationTemplate">
 				<name>Entry was added to channel</name>
-				<systemName>Entry_Was_Added_To_Channel</systemName>
+				<systemName>Unique_Kms_Entry_Was_Added_To_Channel</systemName>
 				<description>Email notification template to be sent when entry is added to channel.</description>
 				<automaticDispatchEnabled>1</automaticDispatchEnabled>
 				<eventType>5</eventType> <!-- EventNotificationEventType::OBJECT_CREATED -->
@@ -825,6 +990,12 @@
 						<description>Status is active, See:KalturaCategoryEntryStatus:/api_v3/testmeDoc/?object=KalturaCategoryEntryStatus</description>
 						<field objectType="KalturaEvalBooleanField">
 							<code>$scope->getObject() instanceof categoryEntry &amp;&amp; $scope->getObject()->getStatus() == CategoryEntryStatus::ACTIVE</code>
+						</field>
+					</item>
+					<item objectType="KalturaEventFieldCondition">
+						<description>Category is inside of specified category root</description>
+						<field objectType="KalturaEvalBooleanField">
+							<code>in_array($scope->getDynamicValues()['root_category_id'], explode('>', $scope->getObject()->getCategoryFullIds()))</code>
 						</field>
 					</item>
 				</eventConditions>
@@ -878,6 +1049,15 @@
 						</value>
 					</item>
 				</contentParameters>
+				<userParameters objectType="array">
+					<item objectType="KalturaEventNotificationParameter">
+						<key>root_category_id</key>
+						<description>KMS instance root category ID</description>
+						<value objectType="KalturaStringValue">
+							<value/>
+						</value>
+					</item>
+				</userParameters>
 			</template>
 		</request>
 		<request service="eventNotificationTemplate" action="updateStatus" plugin="eventNotification" partnerId="0">
@@ -890,16 +1070,27 @@
 		<request service="eventNotificationTemplate" action="add" plugin="eventNotification" partnerId="0">
 			<template objectType="KalturaEmailNotificationTemplate">
 				<name>Comment was added to entry</name>
-				<systemName>Comment_Was_Added_To_Entry</systemName>
+				<systemName>Unique_Kms_Comment_Was_Added_To_Entry</systemName>
 				<description>Email notification template to be sent to entry creator when a comment is added to his entry.</description>
 				<automaticDispatchEnabled>1</automaticDispatchEnabled>
-				<eventType>5</eventType> <!-- EventNotificationEventType::OBJECT_CREATED -->
-				<eventObjectType>annotationEventNotifications.Annotation</eventObjectType>
+				<eventType>6</eventType> <!-- EventNotificationEventType::OBJECT_DATA_CHANGED -->
+				<eventObjectType>metadataEventNotifications.Metadata</eventObjectType> <!-- EventNotificationEventObjectType::METADATA -->
 				<eventConditions objectType="array">
+					<item objectType="KalturaFieldMatchCondition">
+						<description>Metadata profile ID matches user parameters</description>
+						<field objectType="KalturaEvalStringField">
+							<code>$scope->getObject()->getMetadataProfileId()</code>
+						</field>
+						<values objectType="array">
+							<item objectType="KalturaStringValue">
+								<value>{metadata_profile_id}</value>
+							</item>
+						</values>
+					</item>
 					<item objectType="KalturaEventFieldCondition">
-						<description>An annotation object was created</description>
+						<description>Object type is annotation</description>
 						<field objectType="KalturaEvalBooleanField">
-							<code>$scope->getObject() instanceof Annotation</code>
+							<code>CuePointPeer::retrieveByPK($scope->getObject()->getObjectId()) instanceof Annotation</code>
 						</field>
 					</item>
 					<item objectType="KalturaOrCondition">
@@ -907,30 +1098,42 @@
 						<conditions objectType="array">
 							<item objectType="KalturaEventFieldCondition">
 								<field objectType="KalturaEvalBooleanField">
-									<code>(strpos($scope->getObject()->getTags(),"KMS_public_comment") !== false)</code>
+									<code>(strpos(CuePointPeer::retrieveByPK($scope->getObject()->getObjectId())->getTags(),"KMS_public_comment") !== false)</code>
 								</field>
 							</item>
 							<item objectType="KalturaEventFieldCondition">
 								<field objectType="KalturaEvalBooleanField">
-									<code>(strpos($scope->getObject()->getTags(),"KMS_comment_context_") !== false)</code>
+									<code>(strpos(CuePointPeer::retrieveByPK($scope->getObject()->getObjectId())->getTags(),"KMS_comment_context_") !== false)</code>
 								</field>
 							</item>
 						</conditions>
 					</item>
+					<item objectType="KalturaFieldMatchCondition">
+						<description>Custom metadata indicates that the comment belongs to the instance</description>
+						<field objectType="KalturaEvalStringField">
+							<!-- getMetadataValueForField() returns an array of 0 or 1 elements - implode the array to have a string value -->
+							<code>implode('', kMetadataManager::getMetadataValueForField($scope->getObject(), 'InstanceId'))</code>
+						</field>
+						<values objectType="array">
+							<item objectType="KalturaStringValue">
+								<value>{instance_id}</value>
+							</item>
+						</values>
+					</item>
 				</eventConditions>
 				<format>1</format>
 				<subject>[AppTitle] - A new comment was added to your video {entry_name}</subject>
-				<body>A new comment was added to your video {entry_name}.Comment: {comment_text}. You can access the video page here: [AppEntryUrl]{entry_id}</body>
+				<body>A new comment was added to your video {entry_name}.Comment: {comment_text}. You can access the video page here: [AppEntryUrl]{entry_id}/{category_id}</body>
 				<fromEmail>{from_email}</fromEmail>
 				<fromName>{from_name}</fromName>
 				<bcc objectType="KalturaEmailNotificationStaticRecipientProvider">
 					<emailRecipients objectType="array">
 						<item objectType = "KalturaEmailNotificationRecipient">
 							<email objectType="KalturaEvalStringField">
-								<code>!is_null(entryPeer::retrieveByPk($scope->getObject()->getEntryId())) ? (!is_null(entryPeer::retrieveByPk($scope->getObject()->getEntryId())->getkuser()) ? entryPeer::retrieveByPk($scope->getObject()->getEntryId())->getkuser()->getEmail() : '') : ''</code>
+								<code>!is_null(entryPeer::retrieveByPk(CuePointPeer::retrieveByPK($scope->getObject()->getObjectId())->getEntryId())) ? (!is_null(entryPeer::retrieveByPk(CuePointPeer::retrieveByPK($scope->getObject()->getObjectId())->getEntryId())->getkuser()) ? entryPeer::retrieveByPk(CuePointPeer::retrieveByPK($scope->getObject()->getObjectId())->getEntryId())->getkuser()->getEmail() : '') : ''</code>
 							</email>
 							<name objectType="KalturaEvalStringField">
-								<code>!is_null(entryPeer::retrieveByPk($scope->getObject()->getEntryId())) ? (!is_null(entryPeer::retrieveByPk($scope->getObject()->getEntryId())->getkuser()) ? entryPeer::retrieveByPk($scope->getObject()->getEntryId())->getkuser()->getFirstName().' '.entryPeer::retrieveByPk($scope->getObject()->getEntryId())->getkuser()->getLastName() : '') : ''</code>
+								<code>!is_null(entryPeer::retrieveByPk(CuePointPeer::retrieveByPK($scope->getObject()->getObjectId())->getEntryId())) ? (!is_null(entryPeer::retrieveByPk(CuePointPeer::retrieveByPK($scope->getObject()->getObjectId())->getEntryId())->getkuser()) ? entryPeer::retrieveByPk(CuePointPeer::retrieveByPK($scope->getObject()->getObjectId())->getEntryId())->getkuser()->getFirstName().' '.entryPeer::retrieveByPk(CuePointPeer::retrieveByPK($scope->getObject()->getObjectId())->getEntryId())->getkuser()->getLastName() : '') : ''</code>
 							</name>
 						</item>
 					</emailRecipients>
@@ -951,82 +1154,106 @@
 					<item objectType="KalturaEventNotificationParameter">
 						<key>entry_id</key>
 						<value objectType="KalturaEvalStringField">
-							<code>$scope->getObject()->getEntryId()</code>
+							<code>CuePointPeer::retrieveByPK($scope->getObject()->getObjectId()) ? CuePointPeer::retrieveByPK($scope->getObject()->getObjectId())->getEntryId() : ''</code>
 						</value>
 					</item>
 					<item objectType="KalturaEventNotificationParameter">
 						<key>entry_name</key>
 						<value objectType="KalturaEvalStringField">
-							<code>!is_null(entryPeer::retrieveByPk($scope->getObject()->getEntryId())) ? entryPeer::retrieveByPk($scope->getObject()->getEntryId())->getName() : ''</code>
+							<code>CuePointPeer::retrieveByPK($scope->getObject()->getObjectId()) &amp;&amp; !is_null(entryPeer::retrieveByPk(CuePointPeer::retrieveByPK($scope->getObject()->getObjectId())->getEntryId())) ? entryPeer::retrieveByPk(CuePointPeer::retrieveByPK($scope->getObject()->getObjectId())->getEntryId())->getName() : ''</code>
 						</value>
 					</item>
 					<item objectType="KalturaEventNotificationParameter">
 						<key>comment_text</key>
 						<value objectType="KalturaEvalStringField">
-							<code>$scope->getObject()->getText()</code>
+							<code>CuePointPeer::retrieveByPK($scope->getObject()->getObjectId()) ? CuePointPeer::retrieveByPK($scope->getObject()->getObjectId())->getText() : ''</code>
 						</value>
 					</item>
 					<item objectType="KalturaEventNotificationParameter">
 						<key>comment_id</key>
 						<value objectType="KalturaEvalStringField">
-							<code>$scope->getObject()->getId()</code>
+							<code>CuePointPeer::retrieveByPK($scope->getObject()->getObjectId()) ? CuePointPeer::retrieveByPK($scope->getObject()->getObjectId())->getId() : ''</code>
 						</value>
 					</item>
 					<item objectType="KalturaEventNotificationParameter">
 						<key>comment_parent_id</key>
 						<value objectType="KalturaEvalStringField">
-							<code>$scope->getObject()->getParentId()</code>
+							<code>CuePointPeer::retrieveByPK($scope->getObject()->getObjectId()) ? CuePointPeer::retrieveByPK($scope->getObject()->getObjectId())->getParentId() : ''</code>
 						</value>
 					</item>
 					<item objectType="KalturaEventNotificationParameter">
 						<key>comment_system_name</key>
 						<value objectType="KalturaEvalStringField">
-							<code>$scope->getObject()->getSystemName()</code>
+							<code>CuePointPeer::retrieveByPK($scope->getObject()->getObjectId()) ? CuePointPeer::retrieveByPK($scope->getObject()->getObjectId())->getSystemName() : ''</code>
 						</value>
 					</item>
 					<item objectType="KalturaEventNotificationParameter">
 						<key>comment_user_id</key>
 						<value objectType="KalturaEvalStringField">
-							<code>$scope->getObject()->getPuserId()</code>
+							<code>CuePointPeer::retrieveByPK($scope->getObject()->getObjectId()) ? CuePointPeer::retrieveByPK($scope->getObject()->getObjectId())->getPuserId() : ''</code>
 						</value>
 					</item>
 					<item objectType="KalturaEventNotificationParameter">
 						<key>comment_created_at</key>
 						<value objectType="KalturaEvalStringField">
-							<code>$scope->getObject()->getCreatedAt()</code>
+							<code>CuePointPeer::retrieveByPK($scope->getObject()->getObjectId()) ? CuePointPeer::retrieveByPK($scope->getObject()->getObjectId())->getCreatedAt() : ''</code>
 						</value>
 					</item>
 					<item objectType="KalturaEventNotificationParameter">
 						<key>comment_updated_at</key>
 						<value objectType="KalturaEvalStringField">
-							<code>$scope->getObject()->getUpdatedAt()</code>
+							<code>CuePointPeer::retrieveByPK($scope->getObject()->getObjectId()) ? CuePointPeer::retrieveByPK($scope->getObject()->getObjectId())->getUpdatedAt() : ''</code>
 						</value>
 					</item>
 					<item objectType="KalturaEventNotificationParameter">
 						<key>comment_partner_data</key>
 						<value objectType="KalturaEvalStringField">
-							<code>$scope->getObject()->getPartnerData()</code>
+							<code>CuePointPeer::retrieveByPK($scope->getObject()->getObjectId()) ? CuePointPeer::retrieveByPK($scope->getObject()->getObjectId())->getPartnerData() : ''</code>
 						</value>
 					</item>
 					<item objectType="KalturaEventNotificationParameter">
 						<key>comment_start_time</key>
 						<value objectType="KalturaEvalStringField">
-							<code>$scope->getObject()->getStartTime()</code>
+							<code>CuePointPeer::retrieveByPK($scope->getObject()->getObjectId()) ? CuePointPeer::retrieveByPK($scope->getObject()->getObjectId())->getStartTime() : ''</code>
 						</value>
 					</item>
 					<item objectType="KalturaEventNotificationParameter">
 						<key>comment_end_time</key>
 						<value objectType="KalturaEvalStringField">
-							<code>$scope->getObject()->getEndTime()</code>
+							<code>CuePointPeer::retrieveByPK($scope->getObject()->getObjectId()) ? CuePointPeer::retrieveByPK($scope->getObject()->getObjectId())->getEndTime() : ''</code>
 						</value>
 					</item>
 					<item objectType="KalturaEventNotificationParameter">
 						<key>comment_duration</key>
 						<value objectType="KalturaEvalStringField">
-							<code>$scope->getObject()->getDuration()</code>
+							<code>CuePointPeer::retrieveByPK($scope->getObject()->getObjectId()) ? CuePointPeer::retrieveByPK($scope->getObject()->getObjectId())->getDuration() : ''</code>
+						</value>
+					</item>
+					<item objectType="KalturaEventNotificationParameter">
+						<key>category_id</key>
+						<description>Category ID</description>
+						<value objectType="KalturaEvalStringField">
+							<!-- getMetadataValueForField() returns an array of 0 or 1 elements - implode the array to have a string value -->
+							<code>implode('', kMetadataManager::getMetadataValueForField($scope->getObject(), 'CategoryId'))</code>
 						</value>
 					</item>
 				</contentParameters>
+				<userParameters objectType="array">
+					<item objectType="KalturaEventNotificationParameter">
+						<key>metadata_profile_id</key>
+						<description>Comment metadata profile ID</description>
+						<value objectType="KalturaStringValue">
+							<value/>
+						</value>
+					</item>
+					<item objectType="KalturaEventNotificationParameter">
+						<key>instance_id</key>
+						<description>KMS instance ID</description>
+						<value objectType="KalturaStringValue">
+							<value/>
+						</value>
+					</item>
+				</userParameters>
 			</template>
 		</request>
 		<request service="eventNotificationTemplate" action="updateStatus" plugin="eventNotification" partnerId="0">

--- a/tests/standAloneClient/uniqueMediaspaceNotificationsTemplates.xml
+++ b/tests/standAloneClient/uniqueMediaspaceNotificationsTemplates.xml
@@ -1123,7 +1123,7 @@
 				</eventConditions>
 				<format>1</format>
 				<subject>[AppTitle] - A new comment was added to your video {entry_name}</subject>
-				<body>A new comment was added to your video {entry_name}.Comment: {comment_text}. You can access the video page here: [AppEntryUrl]{entry_id}/{category_id}</body>
+				<body>A new comment was added to your media {entry_name}. Comment: {comment_text}. You can see the media here: [AppEntryUrl]{entry_id}/{category_id}</body>
 				<fromEmail>{from_email}</fromEmail>
 				<fromName>{from_name}</fromName>
 				<bcc objectType="KalturaEmailNotificationStaticRecipientProvider">


### PR DESCRIPTION
Requirements are here: https://kaltura.atlassian.net/browse/PSVAMB-4593
Tech design doc is attached to the Jira ticket as well.

Implementation is to deploy new email notifications: similar to what KMS has now, but with additional conditions.
The first commit contains an exact copy of existing KMS notifications (I took the actual content from prod). So if you want to see only the changes to the old notification templates instead of full notification template contents, you can find them in the second commit.

Dev notes:
- Entry_Ready notification is being triggered out of partner context (from a batch job), so KalturaMatchMetadataCondition won't work there. That's why I used php code snippet to fetch the metadata in this event
- Comment_Was_Added_To_Entry notification trigger has been changed: it was "comment (annotation) creation" before, now it's "annotation metadata object update", cause in the first case it will be triggered before the metadata object creation, so the condition would fail