### PR TITLE
write the unique session id to apache note

### DIFF
--- a/infra/log/UniqueId.php
+++ b/infra/log/UniqueId.php
@@ -18,7 +18,14 @@ class UniqueId
 		{
 			self::$_uniqueId = (string)rand();
 			if (php_sapi_name() !== 'cli')
+			{
 				header('X-Kaltura-Session:'.self::$_uniqueId, false);
+
+				if (function_exists('apache_note'))
+				{
+					apache_note('Kaltura_SessionId', self::$_uniqueId);
+				}
+			}
 		}
 			
 		return self::$_uniqueId;


### PR DESCRIPTION
enables writing the session to the error log in apache 2.4 (using ErrorLogFormat)