### PR TITLE
playManifest beacon non-base64 encoded referrers

### DIFF
--- a/alpha/apps/kaltura/lib/kManifestRenderers.php
+++ b/alpha/apps/kaltura/lib/kManifestRenderers.php
@@ -246,8 +246,13 @@ abstract class kManifestRenderer
 
 		if (isset($params['referrer']))
 		{
-			$base64Referrer = $params['referrer'];
-			$referrer = base64_decode(str_replace(array('-', '_', ' '), array('+', '/', '+'), $base64Referrer));
+			$base64Referrer = trim($params['referrer']);
+			$referrer = base64_decode(str_replace(array('-', '_', ' '), array('+', '/', '+'), $base64Referrer), true);
+			if (!$referrer || !mb_check_encoding($referrer, 'utf-8'))
+			{
+				$referrer = $base64Referrer;
+			}
+
 			if ($referrer)
 			{
 				$output['referrer'] = $referrer;


### PR DESCRIPTION
some apps are not base64-encoding the referrer, detect it by -
1. running base64_decode in strict mode
2. checking whether the result is valid utf8
when this happens, send the referrer as is on the beacon (without b64decode)