### PR TITLE
Fix "PHP Fatal error:  Uncaught exception 'Zend_Config_Exception' wit…

### DIFF
--- a/configurations/kRemoteMemCacheConf.template.ini
+++ b/configurations/kRemoteMemCacheConf.template.ini
@@ -7,6 +7,3 @@ host=@HOSTNAME@
 ; This is usefull if you use LB for the memcache servers with one
 ; adress for read, but when you need to write you must do it to all of them
 1=@HOSTNAME_FOR_WRITE@
-
-~
-


### PR DESCRIPTION
…h message 'syntax error, unexpected '~' in

/opt/kaltura/app/configurations/kRemoteMemCacheConf.ini on line 7"