### PR TITLE
SUP-16865-HF-to-support-FFM4-audio-syntax-change

### DIFF
--- a/infra/cdl/kdl/KDLOperatorFfmpeg2_1_3.php
+++ b/infra/cdl/kdl/KDLOperatorFfmpeg2_1_3.php
@@ -360,7 +360,7 @@ class KDLOperatorFfmpeg2_1_3 extends KDLOperatorFfmpeg1_1_1 {
 				 */
 			switch($inputs){
 				case 1:
-					$mapStr.= "pan=stereo:c0=c0:c1=c1";
+					$mapStr.= "pan=stereo|c0=c0|c1=c1";
 					break;
 /*
 Disabled 'amix', for better stereo by 'amerge'


### PR DESCRIPTION
FFmpeg 4.0.2 failed on  audio channel filter desc, that worked for prev versions