### PR TITLE
Add log file len printout to detect pre-crash status

### DIFF
--- a/batch/batches/Convert/KAsyncConvert.class.php
+++ b/batch/batches/Convert/KAsyncConvert.class.php
@@ -223,6 +223,7 @@ class KAsyncConvert extends KJobHandlerWorker
 		{
 			$data = $this->operationEngine->getData();
 			$log = $this->operationEngine->getLogData();
+			KalturaLog::log("Log strlen: ".strlen($log));
 			//removing unsuported XML chars
 			$log  = preg_replace('/[^\t\n\r\x{20}-\x{d7ff}\x{e000}-\x{fffd}\x{10000}-\x{10ffff}]/u','',$log);
 			if($log && strlen($log))


### PR DESCRIPTION
Occasionally there are crashes on 'preg_replace' with allegedly small log files.
This printout will show what was the real size of the log file that caused the crash.