### PR TITLE
Naos 14.13.0 remote media data

### DIFF
--- a/infra/media/mediaInfoParser/KBaseMediaParser.php
+++ b/infra/media/mediaInfoParser/KBaseMediaParser.php
@@ -42,9 +42,6 @@ abstract class KBaseMediaParser
 	 */
 	public function __construct($filePath)
 	{
-		if (!file_exists($filePath))
-			throw new kApplicativeException(KBaseMediaParser::ERROR_NFS_FILE_DOESNT_EXIST, "File not found at [$filePath]");
-
 		$this->filePath = $filePath;
 	}
 	

--- a/infra/media/mediaInfoParser/KFFMpegMediaParser.php
+++ b/infra/media/mediaInfoParser/KFFMpegMediaParser.php
@@ -35,6 +35,10 @@ class KFFMpegMediaParser extends KBaseMediaParser
 		else{
 			$this->ffprobeBin = "ffprobe";
 		}
+		if(strstr($filePath, "http")===false) {
+			if (!file_exists($filePath))
+				throw new kApplicativeException(KBaseMediaParser::ERROR_NFS_FILE_DOESNT_EXIST, "File not found at [$filePath]");
+		}
 		parent::__construct($filePath);
 	}
 	

--- a/infra/media/mediaInfoParser/KMediaInfoMediaParser.php
+++ b/infra/media/mediaInfoParser/KMediaInfoMediaParser.php
@@ -19,6 +19,8 @@ class KMediaInfoMediaParser extends KBaseMediaParser
 	public function __construct($filePath, $cmdPath="mediainfo")
 	{
 		$this->cmdPath = $cmdPath;
+		if (!file_exists($filePath))
+			throw new kApplicativeException(KBaseMediaParser::ERROR_NFS_FILE_DOESNT_EXIST, "File not found at [$filePath]");
 		parent::__construct($filePath);
 	}
 	


### PR DESCRIPTION
Do 'file_exist' check only for MediaInfo and FFMpeg with file path.
Avoid the check for FFmpeg with url