### PR TITLE
eSearch - query boolean fields only with true/false

### DIFF
--- a/plugins/search/providers/elastic_search/lib/elasticSearchUtils.php
+++ b/plugins/search/providers/elastic_search/lib/elasticSearchUtils.php
@@ -11,7 +11,7 @@ class elasticSearchUtils
 	private static $html_chars_to_replace = array('<br />', '<br>',
 		'<br/>', '<div>', '</div>', '<div/>', '<p>', '</p>', '<p/>');
 
-	protected static $elastic_negation_booleans = array(0, '0', false, 'false', 'off', 'no');
+	protected static $elastic_negation_booleans = array('0', 'false', 'off', 'no');
 
     /**
      * return the analyzed language field name
@@ -178,11 +178,7 @@ class elasticSearchUtils
 
 	public static function getBooleanValue($value)
 	{
-		if (in_array(self::formatSearchTerm($value), self::$elastic_negation_booleans ,true))
-		{
-			return false;
-		}
-		return true;
+		return !in_array(self::formatSearchTerm($value), self::$elastic_negation_booleans);
 	}
 
 	/**

--- a/plugins/search/providers/elastic_search/lib/elasticSearchUtils.php
+++ b/plugins/search/providers/elastic_search/lib/elasticSearchUtils.php
@@ -11,6 +11,8 @@ class elasticSearchUtils
 	private static $html_chars_to_replace = array('<br />', '<br>',
 		'<br/>', '<div>', '</div>', '<div/>', '<p>', '</p>', '<p/>');
 
+	protected static $elastic_negation_booleans = array(0, '0', false, 'false', 'off', 'no');
+
     /**
      * return the analyzed language field name
      * @param $language
@@ -174,6 +176,14 @@ class elasticSearchUtils
 		return $numOfFragments;
 	}
 
+	public static function getBooleanValue($value)
+	{
+		if (in_array(self::formatSearchTerm($value), self::$elastic_negation_booleans ,true))
+		{
+			return false;
+		}
+		return true;
+	}
 
 	/**
 	 * Go over the array and decode html and strip tags from all of its leafs

--- a/plugins/search/providers/elastic_search/lib/model/items/ESearchEntryItem.php
+++ b/plugins/search/providers/elastic_search/lib/model/items/ESearchEntryItem.php
@@ -82,6 +82,11 @@ class ESearchEntryItem extends ESearchItem
 		ESearchEntryFieldName::TAGS,
 	);
 
+	protected static $booleanFields = array(
+		ESearchEntryFieldName::IS_LIVE,
+		ESearchEntryFieldName::IS_QUIZ,
+	);
+
 	/**
 	 * @return ESearchEntryFieldName
 	 */

--- a/plugins/search/providers/elastic_search/lib/model/items/ESearchItem.php
+++ b/plugins/search/providers/elastic_search/lib/model/items/ESearchItem.php
@@ -16,6 +16,11 @@ abstract class ESearchItem extends BaseObject implements IESearchItem
 	protected static $searchHistoryFields = array();
 
 	/**
+	 * @var array
+	 */
+	protected static $booleanFields = array();
+
+	/**
 	 * @var ESearchItemType
 	 */
 	protected $itemType;
@@ -158,6 +163,11 @@ abstract class ESearchItem extends BaseObject implements IESearchItem
 			return true;
 
 		return false;
+	}
+
+	public static function shouldReplaceBooleanValue($fieldName)
+	{
+		return in_array($fieldName, static::$booleanFields);
 	}
 
 }

--- a/plugins/search/providers/elastic_search/lib/model/search/kESearchQueryManager.php
+++ b/plugins/search/providers/elastic_search/lib/model/search/kESearchQueryManager.php
@@ -119,7 +119,14 @@ class kESearchQueryManager
 
 	public static function getExactMatchQuery($searchItem, $fieldName, $allowedSearchTypes, &$queryAttributes)
 	{
-		$searchTerm = elasticSearchUtils::formatSearchTerm($searchItem->getSearchTerm());
+		if ($searchItem::shouldReplaceBooleanValue($fieldName))
+		{
+			$searchTerm = elasticSearchUtils::getBooleanValue($searchItem->getSearchTerm());
+		}
+		else
+		{
+			$searchTerm = elasticSearchUtils::formatSearchTerm($searchItem->getSearchTerm());
+		}
 		$fieldBoostFactor = $searchItem::getFieldBoostFactor($fieldName);
 		$fieldSuffix = '';
 		$queryObject = 'kESearchTermQuery';


### PR DESCRIPTION
- query on boolean fields in elastic 6.x+ with values other then true/false is deprecated