### PR TITLE
kava - table from keyed graphs fix

### DIFF
--- a/alpha/apps/kaltura/lib/reports/kKavaReportsMgr.class.php
+++ b/alpha/apps/kaltura/lib/reports/kKavaReportsMgr.class.php
@@ -4555,7 +4555,7 @@ class kKavaReportsMgr extends kKavaBase
 		
 		// convert the result to a table
 		$metric_headers = isset($report_def[self::REPORT_METRICS]) ? 
-			$report_def[self::REPORT_METRICS] : array_keys(reset($result));
+			$report_def[self::REPORT_METRICS] : array_keys(call_user_func_array('array_merge', $result));
 		$date_headers = $input_filter->interval != self::INTERVAL_ALL ? 
 			array(self::getDateColumnName($input_filter->interval)) : 
 			array();


### PR DESCRIPTION
do not assume the first dimension split has all headers - merge the headers of all splits