### PR TITLE
SUP-17265

### DIFF
--- a/alpha/lib/model/DeliveryProfileLive.php
+++ b/alpha/lib/model/DeliveryProfileLive.php
@@ -409,19 +409,19 @@ abstract class DeliveryProfileLive extends DeliveryProfile {
 	
 	protected function filterStreamIdsByBitrate ($streams)
 	{
-		$streamIds = array();
-		
-		$this->sanitizeRequestedFlavorParamsIds($streams);
-		
 		if (!$streams || !count($streams))
 		{
 			return;
 		}
-		elseif (!$this->getDynamicAttributes()->getMaxBitrate() && !$this->getDynamicAttributes()->getMinBitrate())
+		
+		$this->sanitizeRequestedFlavorParamsIds($streams);
+		
+		if (!$this->getDynamicAttributes()->getMaxBitrate() && !$this->getDynamicAttributes()->getMinBitrate())
 		{
 			return;
 		}
 		
+		$streamIds = array();
 		foreach ($streams as $stream)
 		{
 			/* @var $stream kLiveStreamParams */
@@ -446,7 +446,7 @@ abstract class DeliveryProfileLive extends DeliveryProfile {
 		if (!count($streamIds))
 		{
 			// If the stream info is available to us, min and/or max bitrate params were passed, and no streams comply with them - issue warning and cancel restrictions
-			KalturaLog::warning("Entry [". $this->getDynamicAttributes()->getEntryId() ."] has no streams which comply with the min/max bitrate limitations.");
+			KalturaLog::warning('Entry ['. $this->getDynamicAttributes()->getEntryId() .'] has no streams which comply with the min/max bitrate limitations.');
 		}
 		
 		$this->params->setFlavorParamIds($streamIds);
@@ -458,11 +458,6 @@ abstract class DeliveryProfileLive extends DeliveryProfile {
 	 */
 	protected function sanitizeRequestedFlavorParamsIds($streams)
 	{
-		if (!$streams || !count($streams))
-		{
-			return;
-		}
-		
 		$allStreamIds = array();
 		
 		foreach ($streams as $stream)

--- a/alpha/lib/model/DeliveryProfileLive.php
+++ b/alpha/lib/model/DeliveryProfileLive.php
@@ -420,18 +420,16 @@ abstract class DeliveryProfileLive extends DeliveryProfile {
 		foreach ($streams as $stream)
 		{
 			/* @var $stream kLiveStreamParams */
-			$allStreamIds[] = $stream->getFlavorId();
-			
-			if ($this->getDynamicAttributes()->getMinBitrate() && $stream->getBitrate()/1024 < $this->getDynamicAttributes()->getMinBitrate())
-			{
-				continue;
-			}
-			if ($this->getDynamicAttributes()->getMaxBitrate() && $stream->getBitrate()/1024 > $this->getDynamicAttributes()->getMaxBitrate())
-			{
-				continue;
-			}
-			
-			$streamIds[] = $stream->getFlavorId();
+                        $allStreamIds[] = $stream->getFlavorId();
+
+                        if ($this->getDynamicAttributes()->getMinBitrate() && $stream->getBitrate()/1024 > $this->getDynamicAttributes()->getMinBitrate())
+                        {
+                                $streamIds[] = $stream->getFlavorId();
+                        }
+                        if ($this->getDynamicAttributes()->getMaxBitrate() && $stream->getBitrate()/1024 < $this->getDynamicAttributes()->getMaxBitrate())
+                        {
+                                $streamIds[] = $stream->getFlavorId();
+                        }
 			
 		}
 		


### PR DESCRIPTION
Eliminate situation where a client requests non-existent flavor param ID from the server and gets empty manifest as result; downgrade thrown errors to warnings.