### PR TITLE
Elasticsearch is included in CE/OP and deployed as part of the base..

### DIFF
--- a/configurations/plugins.template.ini
+++ b/configurations/plugins.template.ini
@@ -123,7 +123,7 @@ FacebookDistribution
 Poll
 ViewHistory
 ;Beacon
-;ElasticSearch
+ElasticSearch
 ;SearchHistory
 ;Reach
 ;EntryVendorTaskSphinx


### PR DESCRIPTION
install so no reason why it should be disabled by default.