### PR TITLE
PLAT-9763: in case of drm access error limit the time response stored…

### DIFF
--- a/plugins/drm/services/DrmLicenseAccessService.php
+++ b/plugins/drm/services/DrmLicenseAccessService.php
@@ -62,6 +62,7 @@ class DrmLicenseAccessService extends KalturaBaseService
                 }
             } catch (Exception $e) {
                 KalturaLog::err("Could not validate license access, returned with message '".$e->getMessage()."'");
+                kApiCache::setExpiry(60);
             }
         }
         else


### PR DESCRIPTION
… in cache