### PR TITLE
Incorrect concat() when running with PHP 5.3

### DIFF
--- a/plugins/event_notification/providers/email/lib/batch/recipients/KEMailNotificationGroupRecipientEngine.php
+++ b/plugins/event_notification/providers/email/lib/batch/recipients/KEMailNotificationGroupRecipientEngine.php
@@ -63,15 +63,16 @@ class KEMailNotificationGroupRecipientEngine extends  KEmailNotificationRecipien
 		
 		if(!($groupUserList->totalCount > 0))
 			return null;
+
 		
-		$groupUserIds = "";
-		foreach ($groupUserList->objects as $user)
-		{
-			$groupUserIds .= $user->userId;
-			if(next($groupUserList->objects) == true)
-				$groupUserIds .= ",";
-		}
+                $groupUserIds = array();
+                foreach ($groupUserList->objects as $user)
+                {
+                        $groupUserIds[]= $user->userId;
+                }
+                $groupUserIdsString = implode(',',$groupUserIds);
+
 		
-		return $groupUserIds;
+		return $groupUserIdsString;
 	}
 }


### PR DESCRIPTION
When running the `getGroupUserIds()` code with PHP 5.3, which is what's running on SaaS' batch servers, this code will NOT insert a comma [','] between the last two email addresses. In PHP 7, it will.
That means the last two email addrs will be concatenated like so:
`address@example.comaddress1@example.com`
rather than:
`address@example.com,address1@example.com`

This will result in a failure to notify the last two recipients as their addrs will be concatenated into one which will naturally be an invalid email addr.
The revised code will work equally well with both versions.