### PR TITLE
SUP-17551: fix ability to update categoryUser when updateMethod is manual

### DIFF
--- a/api_v3/services/CategoryUserService.php
+++ b/api_v3/services/CategoryUserService.php
@@ -114,7 +114,7 @@ class CategoryUserService extends KalturaBaseService
 			throw new KalturaAPIException(KalturaErrors::INVALID_CATEGORY_USER_ID, $categoryId, $userId);
 			
 		if(!$override && 
-			($categoryUser->updateMethod == null || $categoryUser->updateMethod == KalturaUpdateMethodType::AUTOMATIC) && 
+			($categoryUser->updateMethod === null || $categoryUser->updateMethod == KalturaUpdateMethodType::AUTOMATIC) &&
 			$dbCategoryKuser->getUpdateMethod() == KalturaUpdateMethodType::MANUAL)
 			throw new KalturaAPIException(KalturaErrors::CANNOT_OVERRIDE_MANUAL_CHANGES);
 		


### PR DESCRIPTION
Change the condition to check if `categoryUser->updateMethod` is `0` or truly `null` when trying to update.