### PR TITLE
feat(FEC-9147): pass KS to server preview template

### DIFF
--- a/alpha/apps/kaltura/modules/extwidget/templates/previewSuccess.php
+++ b/alpha/apps/kaltura/modules/extwidget/templates/previewSuccess.php
@@ -154,6 +154,11 @@ if (isPlaykit === '1') {
         }
         catch(ee){}
     }
+    if (typeof data.flashVars !== 'undefined') {
+        if (data.flashVars.hasOwnProperty('ks') && typeof data.flashVars.ks === 'string') {
+            playerConfig.provider.ks = data.flashVars.ks;
+        }
+    }
 	//default
     if (!height) {
         height = 400;
@@ -163,6 +168,11 @@ if (isPlaykit === '1') {
     }
     var codeUrl = "//" + data.securedHost + "/p/" + data.partnerId +"/embedPlaykitJs/uiconf_id/"+ data.uiConfId;
     var iframeURL = codeUrl + "/entry_id/" + data.entryId + "?iframeembed=true";
+    if (typeof data.flashVars !== 'undefined') {
+        if (data.flashVars.hasOwnProperty('ks') && typeof data.flashVars.ks === 'string') {
+            iframeURL += "&ks=" + data.flashVars.ks;
+        }
+    }
     var embedCode = '<scr'+'ipt src="'+ codeUrl +'"></scr'+'ipt><scr'+'ipt> var kalturaPlayer = KalturaPlayer.setup('+ JSON.stringify(playerConfig)+');	kalturaPlayer.loadMedia({entryId: "'+ data.entryId +'"})</scr'+'ipt>';
     code = embedCode;
     if (data.embedType === 'iframe') {

--- a/alpha/apps/kaltura/modules/extwidget/templates/previewSuccess.php
+++ b/alpha/apps/kaltura/modules/extwidget/templates/previewSuccess.php
@@ -154,11 +154,6 @@ if (isPlaykit === '1') {
         }
         catch(ee){}
     }
-    if (typeof data.flashVars !== 'undefined') {
-        if (data.flashVars.hasOwnProperty('ks') && typeof data.flashVars.ks === 'string') {
-            playerConfig.provider.ks = data.flashVars.ks;
-        }
-    }
 	//default
     if (!height) {
         height = 400;
@@ -168,9 +163,12 @@ if (isPlaykit === '1') {
     }
     var codeUrl = "//" + data.securedHost + "/p/" + data.partnerId +"/embedPlaykitJs/uiconf_id/"+ data.uiConfId;
     var iframeURL = codeUrl + "/entry_id/" + data.entryId + "?iframeembed=true";
-    if (typeof data.flashVars !== 'undefined') {
-        if (data.flashVars.hasOwnProperty('ks') && typeof data.flashVars.ks === 'string') {
+    var checkForKs = typeof data.flashVars !== 'undefined' ? data.flashVars.hasOwnProperty('ks') && typeof data.flashVars.ks === 'string' : false;
+    if (checkForKs) {
+        if (data.embedType === 'iframe') {
             iframeURL += "&ks=" + data.flashVars.ks;
+        } else {
+            playerConfig.provider.ks = data.flashVars.ks;
         }
     }
     var embedCode = '<scr'+'ipt src="'+ codeUrl +'"></scr'+'ipt><scr'+'ipt> var kalturaPlayer = KalturaPlayer.setup('+ JSON.stringify(playerConfig)+');	kalturaPlayer.loadMedia({entryId: "'+ data.entryId +'"})</scr'+'ipt>';


### PR DESCRIPTION
Added a way to pass KS on the preview template.

Checked with QA servers:
`https://qa-apache-php7.dev.kaltura.com/index.php/extwidget/preview/partner_id/6502/uiconf_id/15222758/entry_id/0_4x8h8feu/embed/dynamic?flashvars[ks]=`