### PR TITLE
SUP-17322: add null arguments when calling 'parent::updateLoginDataImpl'

### DIFF
--- a/api_v3/lib/KalturaBaseUserService.php
+++ b/api_v3/lib/KalturaBaseUserService.php
@@ -38,6 +38,8 @@ class KalturaBaseUserService extends KalturaBaseService
 	 * @param string $password
 	 * @param string $newEmail Optional, provide only when you want to update the email
 	 * @param string $newPassword
+     * @param string $newFirstName Optional, provide only when you want to update the first name
+     * @param string $newLastName Optional, provide only when you want to update the last name
 	 *
 	 * @throws KalturaErrors::INVALID_FIELD_VALUE
 	 * @throws KalturaErrors::LOGIN_DATA_NOT_FOUND

--- a/api_v3/services/AdminUserService.php
+++ b/api_v3/services/AdminUserService.php
@@ -77,7 +77,7 @@ class AdminUserService extends KalturaBaseUserService
 	{
 		try
 		{
-			parent::updateLoginDataImpl($email, $password, $newEmail, $newPassword);
+			parent::updateLoginDataImpl($email, $password, $newEmail, $newPassword, null, null);
 			
 			// copy required parameters to a KalturaAdminUser object for backward compatibility
 			$adminUser = new KalturaAdminUser();


### PR DESCRIPTION
Added null arguments when calling 'parent::updateLoginDataImpl' from 'AdminUserService->updatePasswordAction'  as PHP7 will not tolerate call a function with less arguments then expected.