### PR TITLE
PSVAMB-7641 Entry Vendor Task Finished HTTP notification

### DIFF
--- a/deployment/updates/scripts/2019_05_26_httpEntryVendorTaskDone.php
+++ b/deployment/updates/scripts/2019_05_26_httpEntryVendorTaskDone.php
@@ -1,0 +1,20 @@
+<?php
+/**
+ * @package deployment
+ */
+
+define('DEPLOYMENT_DIR', realpath(__DIR__ . '/../..'));
+
+require_once (DEPLOYMENT_DIR . '/bootstrap.php');
+
+$scriptPath = realpath(DEPLOYMENT_DIR . '/../tests/standAloneClient/exec.php');
+
+$templateUpdateXmlPath = realpath(DEPLOYMENT_DIR . '/updates/scripts/xml/notifications/2019_05_26_httpEntryVendorTaskDone.xml');
+
+if(!file_exists($templateUpdateXmlPath) || !file_exists($scriptPath))
+{
+    KalturaLog::err('Missing update script file');
+    return;
+}
+
+passthru("php $scriptPath $templateUpdateXmlPath");

--- a/deployment/updates/scripts/xml/notifications/2019_05_26_httpEntryVendorTaskDone.template.xml
+++ b/deployment/updates/scripts/xml/notifications/2019_05_26_httpEntryVendorTaskDone.template.xml
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xml>
+    <config>
+        <serviceUrl>@SERVICE_URL@</serviceUrl>
+        <partnerId>-2</partnerId>
+        <clientTag>Stand alone php 1.0.0</clientTag>
+        <curlTimeout>30</curlTimeout>
+        <userAgent>Stand alone php 1.0.0</userAgent>
+    </config>
+    <session>
+        <partnerId>-2</partnerId>
+        <secret>@ADMIN_CONSOLE_PARTNER_ADMIN_SECRET@</secret>
+        <sessionType>2</sessionType>
+    </session>
+
+    <multirequest>
+        <request service="eventNotificationTemplate" action="add" plugin="eventNotification" partnerId="0">
+            <template objectType="KalturaHttpNotificationTemplate">
+                <name>Task Finished Processing</name>
+                <systemName>Http_Entry_Vendor_Task_Finished_Processing</systemName>
+                <description>HTTP notification template to be sent when entry vendor task has finished processing.</description>
+                <automaticDispatchEnabled>1</automaticDispatchEnabled>
+                <eventType>3</eventType> <!-- EventNotificationEventType::OBJECT_CHANGED -->
+                <eventObjectType>42</eventObjectType> <!-- EventNotificationEventObjectType::ENTRY_VENDOR_TASK -->
+                <eventConditions objectType="array">
+                    <item objectType="KalturaEventFieldCondition">
+                        <field objectType="KalturaEvalBooleanField">
+                            <code>$scope->getObject() instanceof EntryVendorTask &amp;&amp; in_array(EntryVendorTaskPeer::STATUS, $scope->getEvent()->getModifiedColumns())</code>
+                        </field>
+                    </item>
+                    <item objectType="KalturaEventFieldCondition">
+                        <field objectType="KalturaEvalBooleanField">
+                            <code>$scope->getObject()->getStatus() == EntryVendorTaskStatus::READY</code>
+                        </field>
+                    </item>
+                </eventConditions>
+                <method>2</method> <!-- KalturaHttpNotificationMethod::POST -->
+            </template>
+        </request>
+        <request service="eventNotificationTemplate" action="updateStatus" plugin="eventNotification" partnerId="0">
+            <id>{1:result:id}</id>
+            <status>1</status> <!-- EventNotificationTemplateStatus::DISABLED -->
+        </request>
+    </multirequest>
+</xml>

--- a/plugins/event_notification/providers/http/admin/scripts/js/kObjects.js
+++ b/plugins/event_notification/providers/http/admin/scripts/js/kObjects.js
@@ -49,7 +49,8 @@ var kObjects = {
 	        UserLoginData:					{label:	'User Login Data', apiType: 'KalturaUserLoginData'},
 	        UserRole:						{label:	'User Role', apiType: 'KalturaUserRole'},
 	        widget:							{label:	'Widget', apiType: 'KalturaWidget'},
-	        categoryEntry:					{label:	'Category - Entry', apiType: 'KalturaCategoryEntry'}
+	        categoryEntry:					{label:	'Category - Entry', apiType: 'KalturaCategoryEntry'},
+	        entryVendorTask:					{label: 'Entry Vendor Task', apiType: 'KalturaEntryVendorTask'}
 		},
 		subLabel:		'Select Object Type',
 		getData:		function(subCode, variables){

--- a/release-notes.md
+++ b/release-notes.md
@@ -1,3 +1,21 @@
+# Orion 15.1.0 #
+
+## Deploy "Entry Vendor Task Finished Processing" HTTP notification (for MediaSpace) ##
+ - Issue Type: Feature
+ - Issue IDs: PSVAMB-7641
+
+### Configuration ###
+None
+
+### Deployment scripts ###
+First replace all tokens in the XML file below and remove ".template" from the file name:
+
+    /opt/kaltura/app/deployment/updates/scripts/xml/notifications/2019_05_26_httpEntryVendorTaskDone.template.xml
+
+Run deployment script:
+
+    php /opt/kaltura/app/deployment/updates/scripts/2019_05_26_httpEntryVendorTaskDone.php
+
 # Orion 15.0.0 #
 
 ## Add permission in Admin Console for analytics persistent session id ##


### PR DESCRIPTION
- add "Entry Vendor Task Finished" HTTP notification (similar to the existing email notification: https://github.com/kaltura/server/blob/Orion-15.1.0/deployment/updates/scripts/xml/notifications/2018_02_22_entry_vendor_task_done.template.xml)
- add an option to choose entry vendor task as an option for HTTP notification