### PR TITLE
SUP-17322: Added null arguments when calling 'parent::updateLoginDataImpl'

### DIFF
--- a/api_v3/lib/KalturaBaseUserService.php
+++ b/api_v3/lib/KalturaBaseUserService.php
@@ -38,6 +38,8 @@ class KalturaBaseUserService extends KalturaBaseService
 	 * @param string $password
 	 * @param string $newEmail Optional, provide only when you want to update the email
 	 * @param string $newPassword
+	 * @param string $newFirstName Optional, provide only when you want to update the first name
+	 * @param string $newLastName Optional, provide only when you want to update the last name
 	 *
 	 * @throws KalturaErrors::INVALID_FIELD_VALUE
 	 * @throws KalturaErrors::LOGIN_DATA_NOT_FOUND
@@ -46,7 +48,7 @@ class KalturaBaseUserService extends KalturaBaseService
 	 * @throws KalturaErrors::PASSWORD_ALREADY_USED
 	 * @throws KalturaErrors::LOGIN_ID_ALREADY_USED
 	 */
-	protected function updateLoginDataImpl( $email , $password , $newEmail = "" , $newPassword = "", $newFirstName, $newLastName)
+	protected function updateLoginDataImpl( $email , $password , $newEmail = "" , $newPassword = "", $newFirstName = null, $newLastName = null)
 	{
 		KalturaResponseCacher::disableCache();
 


### PR DESCRIPTION
 Added null arguments when calling "parent::updateLoginDataImpl" from "AdminUserService->updatePasswordAction" as PHP7 will not tolerate call a function with less arguments then expected