### PR TITLE
partner->getSecrets() should accept the optional $otp and pass it on to userLoginByEmail()

### DIFF
--- a/api_v3/services/PartnerService.php
+++ b/api_v3/services/PartnerService.php
@@ -210,18 +210,19 @@ class PartnerService extends KalturaBaseService
 	 * @param int $partnerId
 	 * @param string $adminEmail
 	 * @param string $cmsPassword
+	 * @param string $otp
 	 * @return KalturaPartner
 	 * @ksIgnored
 	 *
 	 * @throws APIErrors::ADMIN_KUSER_NOT_FOUND
 	 */
-	public function getSecretsAction( $partnerId , $adminEmail , $cmsPassword )
+	public function getSecretsAction( $partnerId , $adminEmail , $cmsPassword, $otp = null )
 	{
 		KalturaResponseCacher::disableCache();
 
 		$adminKuser = null;
 		try {
-			$adminKuser = UserLoginDataPeer::userLoginByEmail($adminEmail, $cmsPassword, $partnerId);
+			$adminKuser = UserLoginDataPeer::userLoginByEmail($adminEmail, $cmsPassword, $partnerId, $otp);
 		}
 		catch (kUserException $e) {
 			throw new KalturaAPIException ( APIErrors::ADMIN_KUSER_NOT_FOUND, "The data you entered is invalid" );


### PR DESCRIPTION
At the moment, attempting to call this function when OTP was enabled on the partner will fail.