### PR TITLE
SUP-18848: update dumpApiRequest to support new PHP >= 5.5 CURLFile class

### DIFF
--- a/alpha/apps/kaltura/lib/storage/kFileUtils.php
+++ b/alpha/apps/kaltura/lib/storage/kFileUtils.php
@@ -101,12 +101,12 @@ class kFileUtils extends kFile
 		// we preserve the original file name by passing the extra ;filename=$_FILES[xxx][name]
 		foreach($_FILES as $key => $value)
 		{
-			$post_params[$key] = "@".$value['tmp_name'].";filename=".$value['name'];
+			$post_params[$key] = new \CURLFile($value['tmp_name'], $value['type'], $value['name']);
 			if(!is_uploaded_file($value['tmp_name'])) {
 				KExternalErrors::dieError(KExternalErrors::FILE_NOT_FOUND);
 			}
 		}
-		
+
 		foreach($_POST as $key => $value)
 		{
 			$post_params[$key] = $value;

--- a/api_v3/lib/KalturaRequestDeserializer.php
+++ b/api_v3/lib/KalturaRequestDeserializer.php
@@ -55,7 +55,7 @@ class KalturaRequestDeserializer
 
 	public function buildActionArguments(&$actionParams)
 	{
-		
+
 		$serviceArguments = array();
 		foreach($actionParams as &$actionParam)
 		{
@@ -89,7 +89,7 @@ class KalturaRequestDeserializer
 			{
 				if (array_key_exists($name, $this->paramsGrouped)) 
 				{
-					$fileData = $this->paramsGrouped[$name];
+					$fileData = $this->convertKeyArguments($this->paramsGrouped[$name]);
 					self::validateFile($fileData);
 					$serviceArguments[] = $fileData;
 					continue;
@@ -419,5 +419,31 @@ class KalturaRequestDeserializer
 		}
 		
 		return null;
+	}
+
+
+	/**
+	 * @param array $dataArray could hold CURLFile data sent by CURL
+	 * @return array if CURLFile object exits in $dataArray convert it to normal $_FILES data array. Else, we don't touch
+	 */
+	function convertKeyArguments($dataArray)
+	{
+		$ret = array();
+		foreach ($dataArray as $key => $dataItem)
+		{
+			if($dataItem instanceof CURLFile)
+			{
+				$fileData = array();
+				$fileData['name'] = $dataItem->postname;
+				$fileData['type'] = $dataItem->mime;
+				$fileData['tmp_name'] = $dataItem->name;
+				$ret[$key] = $fileData;
+			}
+			else
+			{
+				$ret[$key] = $dataItem;
+			}
+		}
+		return $ret;
 	}
 }


### PR DESCRIPTION
Also added a function "KalturaRequestDeserializer->convertKeyArguments($dataArray)" to convert CURLFile keys to previews keys (originally came from $_FILES super-global)