### PR TITLE
Parse errors

### DIFF
--- a/deployment/base/scripts/init_data/01.Partner.template.ini
+++ b/deployment/base/scripts/init_data/01.Partner.template.ini
@@ -73,7 +73,7 @@ id=-7
 prefix=-7
 partnerName="Monitoring Proxy"
 adminSecret=@MONITORING_PROXY_ADMIN_SECRET@
-secret=@MONITORING_PROXY_SECRET"
+secret=@MONITORING_PROXY_SECRET@
 description="Monitoring Proxy"
 status=1
 


### PR DESCRIPTION
- quotes aren't needed and there was only a closing '"' char, which caused a parsing error
- token was missing the ending '@' char.