### PR TITLE
PLAT-10100: The trim() function is not, by default, unicode safe.

### DIFF
--- a/plugins/bulk_upload/csv/batch/BulkUploadEngineCsv.php
+++ b/plugins/bulk_upload/csv/batch/BulkUploadEngineCsv.php
@@ -237,7 +237,7 @@ abstract class BulkUploadEngineCsv extends KBulkUploadEngine
 	 */
 	protected function trimArray(&$item)
 	{
-		$item = trim($item);
+		$item = trim($item, " \t\n\r\0\x0B\xC2\xA0");
 	}
 	
 	abstract protected function getUploadResultInstance ();


### PR DESCRIPTION
Thus, on certain machines, if such trailing Unicode characters exist, a complete failure will occur as described in https://kaltura.atlassian.net/browse/PLAT-10100

This change fixes it. Verified on qa-apache-php7 where, before the
change, I was able to reproduce it.