### PR TITLE
Update thumbnail locations and file sizes to fit origin.

### DIFF
--- a/deployment/base/scripts/init_data/06.FileSync.template.ini
+++ b/deployment/base/scripts/init_data/06.FileSync.template.ini
@@ -26,7 +26,7 @@ fileType=1
 fileRoot=@WEB_DIR@
 
 objectId=_KMCLOGO
-filePath=/content/templates/entry/data/kmc_logo.jpg
+filePath=/content/templates/entry/thumbnail/kmc_logo.jpg
 fileSize=36676
 
 
@@ -57,7 +57,7 @@ fileType=1
 fileRoot=@WEB_DIR@
 
 objectId=_KMCLOGO1
-filePath=/content/templates/entry/data/kaltura_logo_animated_black.jpg
+filePath=/content/templates/entry/thumbnail/kaltura_logo_animated_black.jpg
 fileSize=19521
 
 
@@ -88,7 +88,7 @@ fileType=1
 fileRoot=@WEB_DIR@
 
 objectId=_KMCLOGO2
-filePath=/content/templates/entry/data/kaltura_logo_animated_blue.jpg
+filePath=/content/templates/entry/thumbnail/kaltura_logo_animated_blue.jpg
 fileSize=18463
 
 
@@ -119,7 +119,7 @@ fileType=1
 fileRoot=@WEB_DIR@
 
 objectId=_KMCLOGO3
-filePath=/content/templates/entry/data/kaltura_logo_animated_green.jpg
+filePath=/content/templates/entry/thumbnail/kaltura_logo_animated_green.jpg
 fileSize=17572
 
 
@@ -150,7 +150,7 @@ fileType=1
 fileRoot=@WEB_DIR@
 
 objectId=_KMCLOGO4
-filePath=/content/templates/entry/data/kaltura_logo_animated_pink.jpg
+filePath=/content/templates/entry/thumbnail/kaltura_logo_animated_pink.jpg
 fileSize=16985
 
 
@@ -181,7 +181,7 @@ fileType=1
 fileRoot=@WEB_DIR@
 
 objectId=_KMCLOGO5
-filePath=/content/templates/entry/data/kaltura_logo_animated_red.jpg
+filePath=/content/templates/entry/thumbnail/kaltura_logo_animated_red.jpg
 fileSize=19930
 
 
@@ -198,7 +198,7 @@ fileRoot=@WEB_DIR@
 
 objectId=_KMCSPL1
 filePath=/content/templates/entry/data/kmc_template_playlist1.txt
-fileSize=49
+fileSize=50
 
 
 [data._KMCSPL2]
@@ -214,4 +214,4 @@ fileRoot=@WEB_DIR@
 
 objectId=_KMCSPL2
 filePath=/content/templates/entry/data/kmc_template_playlist2.txt
-fileSize=49
+fileSize=50


### PR DESCRIPTION
Origin: https://github.com/kaltura/platform-install-packages/blob/Orion-15.10.0/RPM/SOURCES/entry_and_uiconf_templates.tar.gz