### PR TITLE
Support working with PHP FPM (the default PHP SAPI with RHEL/CentOS 8)

### DIFF
--- a/configurations/apache/conf.d/enabled.kaltura.conf.template
+++ b/configurations/apache/conf.d/enabled.kaltura.conf.template
@@ -207,7 +207,7 @@ Alias /content "@WEB_DIR@/content"
 	<IfModule mod_php5.c>
 	    php_flag engine off
 	</IfModule>
-	<IfModule !mod_php7.c>
+	<IfModule mod_php7.c>
 	    php_flag engine off
 	</IfModule>
 	ExpiresActive On

--- a/configurations/apache/conf.d/enabled.kaltura.conf.template
+++ b/configurations/apache/conf.d/enabled.kaltura.conf.template
@@ -248,6 +248,11 @@ Alias /flash "@WEB_DIR@/flash"
     <FilesMatch \.(php|phar)$>
         SetHandler "proxy:unix:/run/php-fpm/www.sock|fcgi://localhost"
     </FilesMatch>
+        <Directory "@WEB_DIR@/content">
+                    <FilesMatch ".+\.*$">
+                            SetHandler !
+                    </FilesMatch>
+        </Directory>
   </IfModule>
 </IfModule>
 

--- a/configurations/apache/conf.d/enabled.kaltura.conf.template
+++ b/configurations/apache/conf.d/enabled.kaltura.conf.template
@@ -204,7 +204,12 @@ Alias /content "@WEB_DIR@/content"
 <Directory "@WEB_DIR@/content">
 	Options -ExecCGI -Indexes
 	SetEnv force-no-vary
-	php_flag engine off
+	<IfModule mod_php5.c>
+	    php_flag engine off
+	</IfModule>
+	<IfModule !mod_php7.c>
+	    php_flag engine off
+	</IfModule>
 	ExpiresActive On
 	ExpiresDefault "access plus 3 month"
 	Header unset ETag
@@ -234,6 +239,18 @@ Alias /flash "@WEB_DIR@/flash"
 	    Require all granted
 	</IfVersion>
 </Directory>
+
+<IfModule !mod_php5.c>
+  <IfModule !mod_php7.c>
+    # Enable http authorization headers
+    SetEnvIfNoCase ^Authorization$ "(.+)" HTTP_AUTHORIZATION=$1
+
+    <FilesMatch \.(php|phar)$>
+        SetHandler "proxy:unix:/run/php-fpm/www.sock|fcgi://localhost"
+    </FilesMatch>
+  </IfModule>
+</IfModule>
+
 
 # ------------------------------------------------------------------------------
 # | Web fonts access                                                           |

--- a/configurations/php/kaltura-fpm.template.ini
+++ b/configurations/php/kaltura-fpm.template.ini
@@ -1,0 +1,11 @@
+php_value[memory_limit] = 256M
+php_value[upload_tmp_dir] = "@WEB_DIR@/tmp"
+php_value[request_order] = "CGP"
+php_value[display_errors] = off
+php_value[max_execution_time] = 60
+php_value[post_max_size] = 2024M
+php_value[upload_max_filesize] = 2000M
+php_value[variables_order] = "EGPCS"
+php_value[max_input_vars] = 10000
+php_value[magic_quotes_gpc] = off
+php_value[date.timezone]='@TIME_ZONE@'


### PR DESCRIPTION
With FPM, `php_flag` cannot work so check whether the PHP 5 or PHP 7 modules are enabled (logical or is not supported with `ifModule` so you need two blocks) and only set it if so.