### PR TITLE
SUP-20245: fetch SUM(price) + price <> 0 to avoid reaching PHP memory_limit due to too many results + method improvements

### DIFF
--- a/plugins/reach/lib/model/data/kVendorCredit.php
+++ b/plugins/reach/lib/model/data/kVendorCredit.php
@@ -155,18 +155,19 @@ class kVendorCredit
 		$c->add(EntryVendorTaskPeer::QUEUE_TIME, $this->getSyncCreditStartDate(), Criteria::GREATER_EQUAL);
 		$c->add(EntryVendorTaskPeer::PRICE, 0, Criteria::NOT_EQUAL);
 		$c->add(EntryVendorTaskPeer::PARTNER_ID, $partnerId);
-		$c->addSelectColumn('SUM('. EntryVendorTaskPeer::PRICE .') as calculated_price');
+		$c->addSelectColumn('SUM('. EntryVendorTaskPeer::PRICE .')');
 		$this->addAdditionalCriteria($c);
 
 		$now = time();
 		$stmt = EntryVendorTaskPeer::doSelectStmt($c);
-		$rows = $stmt->fetchAll(PDO::FETCH_ASSOC);
+		$row = $stmt->fetch(PDO::FETCH_NUM);
 
 		$totalUsedCredit = $this->getSyncedCredit();
 
-		if($rows[0]['calculated_price'])
+		$totalPrice = $row[0];
+		if($totalPrice)
 		{
-			$totalUsedCredit += $rows[0]['calculated_price'];
+			$totalUsedCredit += $totalPrice;
 		}
 
 		$this->setSyncedCredit($totalUsedCredit);


### PR DESCRIPTION
@MosheMaorKaltura  , @erankor  , @yossipapi  I've added the modifications Eran suggested and also tested it. It works the same way as before (without returning matrix, returning regular array)

dev@pa-front-stg1 ~$ genks 2368011 | kalcli -i reach_entryvendortask add entryVendorTask:objectType=KalturaEntryVendorTask entryVendorTask:entryId=1_f7jhkkyf entryVendorTask:catalogItemId=852 entryVendorTask:reachProfileId=1981
HTTP/1.1 200 OK
Date: Fri, 22 Nov 2019 16:50:55 GMT
X-Me: pa-front-stg1
X-Kaltura-Session: 690891171

Array
(
[0] =>
)