### PR TITLE
SUP-20262: Increase waitForVideoBeReady timeout from 5 min to 10 min

### DIFF
--- a/plugins/content_distribution/providers/youtube_api/lib/YoutubeApiDistributionEngine.php
+++ b/plugins/content_distribution/providers/youtube_api/lib/YoutubeApiDistributionEngine.php
@@ -30,7 +30,7 @@ class YoutubeApiDistributionEngine extends DistributionEngine implements
 {
 	protected $tempXmlPath;
 	protected $timeout = 90;
-	protected  $processedTimeout = 300;
+	protected  $processedTimeout = 600;
 
 	/* (non-PHPdoc)
 	 * @see DistributionEngine::configure()


### PR DESCRIPTION
due to large source getting timeout on our end
Example Entry ID: 1_lgjyf3jh "Distribution Submit" got timeout
Video is fine on YouTube's end: https://www.youtube.com/watch?v=gD7juv8VhSI