### PR TITLE
Update KFeedDropFolderEngine.php

### DIFF
--- a/plugins/bulk_upload/drop_folder_xml/plugins/batch/Engine/KFeedDropFolderEngine.php
+++ b/plugins/bulk_upload/drop_folder_xml/plugins/batch/Engine/KFeedDropFolderEngine.php
@@ -301,10 +301,15 @@ class KFeedDropFolderEngine extends KDropFolderEngine
 		$dom = $doc->appendChild($dom);
 		$domXpath = new DOMXPath($doc);
 		
-		if (!is_object($domXpath->evaluate($fieldXpath))) {
-			$itemXPathRes = $domXpath->evaluate($fieldXpath);
-		} else {
-			$itemXPathRes = strval($domXpath->evaluate($fieldXpath)->item(0)->nodeValue);
+		$evalResult = $domXpath->evaluate($fieldXpath);
+		
+		if ($evalResult instanceof DOMNodeList)
+		{
+			$itemXPathRes = $evalResult->length > 0 ? strval($evalResult->item(0)->nodeValue) : null;
+		}
+		else
+		{
+			$itemXPathRes = $evalResult;
 		}
 		
 		return $itemXPathRes;

--- a/plugins/bulk_upload/drop_folder_xml/plugins/batch/Engine/KFeedDropFolderEngine.php
+++ b/plugins/bulk_upload/drop_folder_xml/plugins/batch/Engine/KFeedDropFolderEngine.php
@@ -179,7 +179,7 @@ class KFeedDropFolderEngine extends KDropFolderEngine
 		}
 		catch(Exception $e)
 		{
-			KalturaLog::err('Cannot add new drop folder file with name ['.$feedItem->guid.'] - '.$e->getMessage());
+			KalturaLog::err("Cannot add new drop folder file with name [uniqueId] - " . $e->getMessage());
 			return null;
 		}
 	}


### PR DESCRIPTION
When a feed item has no valid content URL or GUID, a drop folder file object should not be created.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kaltura/server/9163)
<!-- Reviewable:end -->
