### PR TITLE
Revert "REACH-727 - make sure only parent entry caption task is created"

### DIFF
--- a/plugins/reach/lib/kReachManager.php
+++ b/plugins/reach/lib/kReachManager.php
@@ -493,12 +493,6 @@ class kReachManager implements kObjectChangedEventConsumer, kObjectCreatedEventC
 			return true;
 		}
 
-		if($entry->getParentEntryId())
-		{
-			KalturaLog::log("Entry [{$entry->getId()}] is a child entry, entry vendor task object wont be created for it");
-			return true;
-		}
-
 		$entryVendorTask = self::addEntryVendorTask($entry, $reachProfile, $vendorCatalogItem, false, $sourceFlavorVersion, $context, EntryVendorTaskCreationMode::AUTOMATIC);
 		if($entryVendorTask)
 		{
@@ -514,6 +508,7 @@ class kReachManager implements kObjectChangedEventConsumer, kObjectCreatedEventC
 			KalturaLog::debug("Entry [{$entry->getId()}] is temporary, entry vendor task object wont be created for it");
 			return null;
 		}
+		
 		//Create new entry vendor task object
 		$entryVendorTask = new EntryVendorTask();
 


### PR DESCRIPTION
Reverts kaltura/server#9225

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kaltura/server/9235)
<!-- Reviewable:end -->
