### PR TITLE
N-Plat: when building curr thumb path use the original thumbName with out the uniqid

### DIFF
--- a/alpha/apps/kaltura/lib/myEntryUtils.class.php
+++ b/alpha/apps/kaltura/lib/myEntryUtils.class.php
@@ -760,10 +760,10 @@ class myEntryUtils
 		$finalThumbPath = $contentPath . myContentStorage::getGeneralEntityPath("entry/".$thumbDirs[0], $entry->getIntId(), $thumbName, $entryThumbFilename , $version );;
 		
 		//Add unique id to the processing file path to avoid file being overwritten when several identical (with same parameters) calls are made before the final thumbnail is created
-		$thumbName .= "_" . uniqid() . "_";
+		$uniqueThumbName .= "_" . uniqid() . "_";
 		
 		//create path for processing thumbnail request
-		$processingThumbPath = $contentPath . myContentStorage::getGeneralEntityPath("entry/".$thumbDirs[0], $entry->getIntId(), $thumbName, $entryThumbFilename , $version );;
+		$processingThumbPath = $contentPath . myContentStorage::getGeneralEntityPath("entry/".$thumbDirs[0], $entry->getIntId(), $uniqueThumbName, $entryThumbFilename , $version );;
 		
 		if(!is_null($format))
 		{


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kaltura/server/9237)
<!-- Reviewable:end -->
