### PR TITLE
Propus-16.0.0-SUP-21515-start widget session

### DIFF
--- a/api_v3/services/SessionService.php
+++ b/api_v3/services/SessionService.php
@@ -300,13 +300,17 @@ class SessionService extends KalturaBaseService
 			!$widget->getEnforceEntitlement() && $widget->getEntryId())
 		{
 			$entryId = $widget->getEntryId();
-			$privileges .= ',' . kSessionBase::PRIVILEGE_DISABLE_ENTITLEMENT_FOR_ENTRY . ':' . $entryId;
 			$entry = entryPeer::retrieveByPKNoFilter($entryId, null, false);
 			if ($entry && $entry->getStatus() != entryStatus::DELETED && $entry->getType() == entryType::PLAYLIST
 				&& ks::isValidForPlaylistDisableEntitlement($entry->getMediaType()))
 			{
 				$privileges .= ',' . kSessionBase::PRIVILEGE_DISABLE_ENTITLEMENT_FOR_PLAYLIST . ':' . $entryId;
 			}
+			else
+			{
+				$privileges .= ',' . kSessionBase::PRIVILEGE_DISABLE_ENTITLEMENT_FOR_ENTRY . ':' . $entryId;
+			}
+
 		}
 			
 		if(PermissionPeer::isValidForPartner(PermissionName::FEATURE_ENTITLEMENT, $partnerId) &&


### PR DESCRIPTION
The start widget session generates ks that doesn't work with playlist execute
Changing it to generate either ks with PRIVILEGE_DISABLE_ENTITLEMENT_FOR_ENTRY  or with PRIVILEGE_DISABLE_ENTITLEMENT_FOR_PLAYLIST but not both

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kaltura/server/9311)
<!-- Reviewable:end -->
