### PR TITLE
SUP-21801: stop processing old zoom event types

### DIFF
--- a/plugins/vendor/zoom/lib/model/kZoomEventHanlder.php
+++ b/plugins/vendor/zoom/lib/model/kZoomEventHanlder.php
@@ -43,6 +43,9 @@ class kZoomEventHanlder
 		switch($event->eventType)
 		{
 			case kEventType::RECORDING_VIDEO_COMPLETED:
+			case kEventType::RECORDING_TRANSCRIPT_COMPLETED:
+				KalturaLog::notice('This is an old Zoom event type - Not processing');
+				break;
 			case kEventType::NEW_RECORDING_VIDEO_COMPLETED:
 				/* @var kZoomRecording $recording */
 				$recording = $event->object;
@@ -58,7 +61,6 @@ class kZoomEventHanlder
 
 				$zoomRecordingProcessor->handleRecordingVideoComplete($event);
 				break;
-			case kEventType::RECORDING_TRANSCRIPT_COMPLETED:
 			case kEventType::NEW_RECORDING_TRANSCRIPT_COMPLETED:
 				$transcriptProcessor = new kZoomTranscriptProcessor();
 				$transcriptProcessor->handleRecordingTranscriptComplete($event);


### PR DESCRIPTION
Hi @MosheMaorKaltura @ZurKaltura 
@MosheMaorKaltura should I test the code in the All-In-One?

I thought that before removing the events from:
plugins/vendor/zoom/lib/model/kZoomEventHanlder.php
plugins/vendor/zoom/lib/model/data/kZoomEvent.php
plugins/vendor/zoom/lib/model/enums/kEventType.php

Just stop processing the event - I know it makes an obsolete code, we can remove it after confirming we haven't ruined anything.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kaltura/server/9353)
<!-- Reviewable:end -->
