### PR TITLE
SUP-21560: fix captionAsset list where the entry's 'parentEntryId' is empty string

### DIFF
--- a/alpha/apps/kaltura/lib/kParentChildEntryUtils.php
+++ b/alpha/apps/kaltura/lib/kParentChildEntryUtils.php
@@ -37,7 +37,14 @@ class kParentChildEntryUtils
 		foreach ($entries as $entry)
 		{
 			/** @var $entry entry */
-			$parentEntryIds[] = !is_null($entry->getParentEntryId()) ? $entry->getParentEntryId() : $entry->getId();
+			if (!is_null($entry->getParentEntryId()) && $entry->getParentEntryId() !== '')
+			{
+				$parentEntryIds[] = $entry->getParentEntryId();
+			}
+			else
+			{
+				$parentEntryIds[] = $entry->getId();
+			}
 		}
 		myDbHelper::$use_alternative_con = null;
 		return array_unique($parentEntryIds);


### PR DESCRIPTION
The bug was introduced here:
https://kaltura.atlassian.net/browse/REACH2-727

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kaltura/server/9366)
<!-- Reviewable:end -->
