### PR TITLE
PLAT-10838: add entry server node id to the m3u8 url as sessionId

### DIFF
--- a/alpha/lib/model/DeliveryProfileLive.php
+++ b/alpha/lib/model/DeliveryProfileLive.php
@@ -135,7 +135,7 @@ abstract class DeliveryProfileLive extends DeliveryProfile {
 		$streams = $liveEntryServerNode->getStreams();
 		$this->sanitizeAndFilterStreamIdsByBitrate($streams);
 		
-		$this->liveStreamConfig->setUrl($this->getHttpUrl($liveEntryServerNode->serverNode));
+		$this->liveStreamConfig->setUrl($this->getHttpUrl($liveEntryServerNode));
 		$this->liveStreamConfig->setPrimaryStreamInfo($liveEntryServerNode->getStreams());
 		
 		$liveEntryServerNode = array_shift($liveEntryServerNodes);
@@ -145,7 +145,7 @@ abstract class DeliveryProfileLive extends DeliveryProfile {
 			$streams = array_merge($streams, $liveEntryServerNode->getStreams());
 			$this->sanitizeAndFilterStreamIdsByBitrate($streams);
 			
-			$this->liveStreamConfig->setBackupUrl($this->getHttpUrl($liveEntryServerNode->serverNode));
+			$this->liveStreamConfig->setBackupUrl($this->getHttpUrl($liveEntryServerNode));
 			$this->liveStreamConfig->setBackupStreamInfo($liveEntryServerNode->getStreams());
 		}
 	}
@@ -300,7 +300,7 @@ abstract class DeliveryProfileLive extends DeliveryProfile {
 		return $queryString;
 	}
 	
-	protected function getHttpUrl($serverNode)
+	protected function getHttpUrl($entryServerNode)
 	{
 		return "";
 	}
@@ -318,9 +318,10 @@ abstract class DeliveryProfileLive extends DeliveryProfile {
 		return $baseUrl;
 	}
 	
-	protected function getLivePackagerUrl($serverNode, $streamFormat = null)
+	protected function getLivePackagerUrl($entryServerNode, $streamFormat = null)
 	{
 		/* @var $serverNode MediaServerNode */
+		$serverNode = $entryServerNode->serverNode;
 		$protocol = $this->getDynamicAttributes()->getMediaProtocol();
 		$segmentDuration = $this->getDynamicAttributes()->getEntry()->getSegmentDuration();
 		
@@ -354,7 +355,10 @@ abstract class DeliveryProfileLive extends DeliveryProfile {
 			$entryId = $this->getDynamicAttributes()->getEntryId();
 		}
 		
-		$livePackagerUrl = "$livePackagerUrl/p/$partnerID/e/$entryId/" . $serverNode->getSegmentDurationUrlString($segmentDuration);
+		$livePackagerUrl = "$livePackagerUrl/p/$partnerID/e/$entryId/";
+		$livePackagerUrl .= $serverNode->getSegmentDurationUrlString($segmentDuration);
+		$livePackagerUrl .= $serverNode->getSessionIdUrlString($entryServerNode);
+
 		$entry = $this->getDynamicAttributes()->getEntry();
 		if ($entry->getExplicitLive())
 		{

--- a/alpha/lib/model/DeliveryProfileLiveAppleHttp.php
+++ b/alpha/lib/model/DeliveryProfileLiveAppleHttp.php
@@ -231,9 +231,9 @@ class DeliveryProfileLiveAppleHttp extends DeliveryProfileLive {
 	    return ($a['bitrate'] < $b['bitrate']) ? -1 : 1;
 	}
 
-	protected function getHttpUrl($serverNode)
+	protected function getHttpUrl($entryServerNode)
 	{
-		$httpUrl = $this->getBaseUrl($serverNode, PlaybackProtocol::HLS);
+		$httpUrl = $this->getBaseUrl($entryServerNode->serverNode, PlaybackProtocol::HLS);
 		$httpUrl = rtrim($httpUrl, "/") . "/" . $this->getStreamName() . "/playlist.m3u8" . $this->getQueryAttributes();
 
 		return $httpUrl;

--- a/alpha/lib/model/DeliveryProfileLiveDash.php
+++ b/alpha/lib/model/DeliveryProfileLiveDash.php
@@ -29,9 +29,9 @@ class DeliveryProfileLiveDash extends DeliveryProfileLive
 		return false;
 	}
 
-	protected function getHttpUrl($serverNode)
+	protected function getHttpUrl($entryServerNode)
 	{
-		$baseUrl = $this->getBaseUrl($serverNode);
+		$baseUrl = $this->getBaseUrl($entryServerNode->serverNode);
 		return rtrim($baseUrl, "/") . "/" . $this->getStreamName() . "/manifest.mpd" . $this->getQueryAttributes();
 	}
 	

--- a/alpha/lib/model/DeliveryProfileLiveHds.php
+++ b/alpha/lib/model/DeliveryProfileLiveHds.php
@@ -23,9 +23,9 @@ class DeliveryProfileLiveHds extends DeliveryProfileLive {
 		
 	}
 
-	protected function getHttpUrl($serverNode)
+	protected function getHttpUrl($entryServerNode)
 	{
-		$baseUrl = $this->getBaseUrl($serverNode);
+		$baseUrl = $this->getBaseUrl($entryServerNode->serverNode);
 		return rtrim($baseUrl, "/") . "/" . $this->getStreamName() . "/manifest.f4m" . $this->getQueryAttributes();
 	}
 	

--- a/alpha/lib/model/DeliveryProfileLivePackagerDash.php
+++ b/alpha/lib/model/DeliveryProfileLivePackagerDash.php
@@ -8,9 +8,9 @@ class DeliveryProfileLivePackagerDash extends DeliveryProfileLiveDash
 		$this->DEFAULT_RENDERER_CLASS = 'kRedirectManifestRenderer';
 	}
 	
-	protected function getHttpUrl($serverNode)
+	protected function getHttpUrl($entryServerNode)
 	{
-		$httpUrl = $this->getLivePackagerUrl($serverNode);
+		$httpUrl = $this->getLivePackagerUrl($entryServerNode);
 		$httpUrl .= "manifest";
 		
 		foreach($this->getDynamicAttributes()->getFlavorParamIds() as $flavorId)

--- a/alpha/lib/model/DeliveryProfileLivePackagerHds.php
+++ b/alpha/lib/model/DeliveryProfileLivePackagerHds.php
@@ -2,9 +2,9 @@
 
 class DeliveryProfileLivePackagerHds extends DeliveryProfileLiveHds {
 	
-	protected function getHttpUrl($serverNode)
+	protected function getHttpUrl($entryServerNode)
 	{
-		$httpUrl = $this->getLivePackagerUrl($serverNode);
+		$httpUrl = $this->getLivePackagerUrl($entryServerNode);
 		$httpUrl .= "manifest";
 		
 		foreach($this->getDynamicAttributes()->getFlavorParamIds() as $flavorId)

--- a/alpha/lib/model/DeliveryProfileLivePackagerHls.php
+++ b/alpha/lib/model/DeliveryProfileLivePackagerHls.php
@@ -2,9 +2,9 @@
 
 class DeliveryProfileLivePackagerHls extends DeliveryProfileLiveAppleHttp {
 	
-	protected function getHttpUrl($serverNode)
+	protected function getHttpUrl($entryServerNode)
 	{
-		$httpUrl = $this->getLivePackagerUrl($serverNode, PlaybackProtocol::HLS);
+		$httpUrl = $this->getLivePackagerUrl($entryServerNode, PlaybackProtocol::HLS);
 		
 		$httpUrl .= "master";
 		

--- a/alpha/lib/model/DeliveryProfileLivePackagerMss.php
+++ b/alpha/lib/model/DeliveryProfileLivePackagerMss.php
@@ -8,9 +8,9 @@ class DeliveryProfileLivePackagerMss extends DeliveryProfileLive
 		$this->DEFAULT_RENDERER_CLASS = 'kRedirectManifestRenderer';
 	}
 	
-	protected function getHttpUrl($serverNode)
+	protected function getHttpUrl($entryServerNode)
 	{
-		$httpUrl = $this->getLivePackagerUrl($serverNode);
+		$httpUrl = $this->getLivePackagerUrl($entryServerNode);
 		$httpUrl .= "manifest";
 		
 		foreach($this->getDynamicAttributes()->getFlavorParamIds() as $flavorId)

--- a/alpha/lib/model/MediaServerNode.php
+++ b/alpha/lib/model/MediaServerNode.php
@@ -85,4 +85,9 @@ abstract class MediaServerNode extends DeliveryServerNode {
         return '';
     }
 
+	public function getSessionIdUrlString($entryServerNode)
+	{
+		return '';
+	}
+
 } // MediaServerNode

--- a/plugins/media/live_cluster/lib/model/LiveClusterMediaServerNode.php
+++ b/plugins/media/live_cluster/lib/model/LiveClusterMediaServerNode.php
@@ -4,6 +4,7 @@
 class LiveClusterMediaServerNode extends MediaServerNode
 {
     const ENVIRONMENT = 'env';
+    const SESSION_ID = 'sid';
 
     /**
      * Applies default values to this object.
@@ -42,5 +43,10 @@ class LiveClusterMediaServerNode extends MediaServerNode
     public function getEnvDc()
     {
         return self::ENVIRONMENT . '/' . $this->getEnvironment();
+    }
+
+    public function getSessionIdUrlString($entryServerNode)
+    {
+        return self::SESSION_ID . '/' . $entryServerNode->getId() . '/';
     }
 }


### PR DESCRIPTION
- add entry server node id to the m3u8 url in case of MediaServerNode of type LiveCluster.
- change getHttpUrl function in DeliveryProfileLive.php to receive entryServerNode instead of serverNode

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kaltura/server/9380)
<!-- Reviewable:end -->
