### PR TITLE
Fix Fatal: Call to undefined method kFileSyncUtils::getReadyKalturaInternalFileSyncsForKey()

### DIFF
--- a/api_v3/services/FlavorAssetService.php
+++ b/api_v3/services/FlavorAssetService.php
@@ -917,7 +917,7 @@ class FlavorAssetService extends KalturaAssetService
 		if (!$externalFileSyncs)
 			throw new KalturaAPIException(KalturaErrors::NO_EXTERNAL_CONTENT_EXISTS);
 
-		$fileSyncs = kFileSyncUtils::getReadyKalturaInternalFileSyncsForKey($srcSyncKey);
+		$fileSyncs = kFileSyncUtils::getReadyInternalFileSyncForKey($srcSyncKey);
 		foreach ($fileSyncs as $fileSync){
 			/* @var $fileSync FileSync*/
 			$fileSync->setStatus(FileSync::FILE_SYNC_STATUS_DELETED);


### PR DESCRIPTION


This method was removed as a part of larger refactor

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kaltura/server/9462)
<!-- Reviewable:end -->
