### PR TITLE
When using FPM, this directive triggers the following error:

### DIFF
--- a/vendor/symfony-data/config/php.yml
+++ b/vendor/symfony-data/config/php.yml
@@ -1,5 +1,4 @@
 set:
-  log_errors:                  on
   arg_separator.output:        |
     &amp;
 


### PR DESCRIPTION
> Configuration file "/opt/kaltura/app/vendor/symfony-data/config/php.yml" specifies key "log_errors" which cannot be overrided

This is more fatal than it sounds and it causes many things to malfunction.
Since I don't see why we need to specify it there (even when the Apache PHP prefork module is used, we have it set in php.ini), I suggest we remove it from this YAML file.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kaltura/server/9492)
<!-- Reviewable:end -->
