### PR TITLE
Fixes the below PHP errors

### DIFF
--- a/alpha/apps/kaltura/lib/monitor/KalturaMonitorClient.php
+++ b/alpha/apps/kaltura/lib/monitor/KalturaMonitorClient.php
@@ -399,7 +399,7 @@ class KalturaMonitorClient
 			return null;		// ignore multibyte range
 	
 		$end = $size - 1;
-		if ($range{0} == '-')
+		if ($range[0] == '-')
 		{
 			// The n-number of the last bytes is requested
 			$start = $size - substr($range, 1);

--- a/alpha/apps/kaltura/lib/request/infraRequestUtils.class.php
+++ b/alpha/apps/kaltura/lib/request/infraRequestUtils.class.php
@@ -67,7 +67,7 @@ class infraRequestUtils
 			// If the range starts with an '-' we start from the beginning
 			// If not, we forward the file pointer
 			// And make sure to get the end byte if spesified
-			if ($range{0} == '-')
+			if ($range[0] == '-')
 			{
 				// The n-number of the last bytes is requested
 				$c_start = $size - substr($range, 1);

--- a/alpha/apps/kaltura/lib/request/kIpAddressUtils.php
+++ b/alpha/apps/kaltura/lib/request/kIpAddressUtils.php
@@ -195,7 +195,7 @@ class kIpAddressUtils
 				$d = strpos($range, self::IP_ADDRESS_RANGE_CHAR);
 				$fromIp = ip2long(substr($range, 0, $d));
 				$toIp = ip2long(substr($range, $d + 1));
-				continue;
+				break;
 
 			case self::IP_ADDRESS_TYPE_MASK_ADDRESS:
 				list (, $rangeMask) = array_map('trim', explode(self::IP_ADDRESS_MASK_CHAR, $range));


### PR DESCRIPTION
PHP Deprecated:  Array and string offset access syntax with curly braces is deprecated in /opt/kaltura/app/alpha/apps/kaltura/lib/request/infraRequestUtils.class.php on line 70
PHP Warning:  "continue" targeting switch is equivalent to "break". Did you mean to use "continue 2"? in /opt/kaltura/app/alpha/apps/kaltura/lib/request/kIpAddressUtils.php on line 198
PHP Deprecated:  Array and string offset access syntax with curly braces is deprecated in /opt/kaltura/app/alpha/apps/kaltura/lib/monitor/KalturaMonitorClient.php on line 402

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kaltura/server/9496)
<!-- Reviewable:end -->
