### PR TITLE
feat(FEC-10291): Kaltura Player - Migrate Analytics Plugins Injection from Kaltura Player to Server

### DIFF
--- a/alpha/apps/kaltura/modules/extwidget/actions/embedPlaykitJsAction.class.php
+++ b/alpha/apps/kaltura/modules/extwidget/actions/embedPlaykitJsAction.class.php
@@ -528,7 +528,8 @@ class embedPlaykitJsAction extends sfAction
 			if ($playerVersion == self::LATEST || $playerVersion == self::BETA || $playerVersion == self::CANARY)
 			{
 				$this->bundleConfig[self::PLAYKIT_KAVA] = $playerVersion;
-				if ($tvPlayerConfig) {
+				if ($tvPlayerConfig)
+				{
 					$this->bundleConfig[self::PLAYKIT_OTT_ANALYTICS] = $playerVersion;
 				}
 			}
@@ -537,7 +538,8 @@ class embedPlaykitJsAction extends sfAction
 			{
 				$latestVersionMap = $this->getConfigByVersion("latest")[0];
 				$this->bundleConfig[self::PLAYKIT_KAVA] = $latestVersionMap[self::PLAYKIT_KAVA];
-				if ($tvPlayerConfig) {
+				if ($tvPlayerConfig)
+				{
 					$this->bundleConfig[self::PLAYKIT_OTT_ANALYTICS] = $latestVersionMap[self::PLAYKIT_OTT_ANALYTICS];
 				}
 			}

--- a/alpha/apps/kaltura/modules/extwidget/actions/embedPlaykitJsAction.class.php
+++ b/alpha/apps/kaltura/modules/extwidget/actions/embedPlaykitJsAction.class.php
@@ -523,11 +523,13 @@ class embedPlaykitJsAction extends sfAction
 		$tvPlayerConfig = isset($this->bundleConfig[self::KALTURA_TV_PLAYER]) ? $this->bundleConfig[self::KALTURA_TV_PLAYER] : "";
 		if (!isset($this->bundleConfig[self::PLAYKIT_KAVA]) && ($ovpPlayerConfig || $tvPlayerConfig)) {
 			$playerVersion = $ovpPlayerConfig ? $ovpPlayerConfig : $tvPlayerConfig;
+			// For player latest/beta/canary
 			if ($playerVersion == self::LATEST || $playerVersion == self::BETA || $playerVersion == self::CANARY) {
 				$this->bundleConfig[self::PLAYKIT_KAVA] = $playerVersion;
 				if ($tvPlayerConfig) {
 					$this->bundleConfig[self::PLAYKIT_OTT_ANALYTICS] = $playerVersion;
 				}
+			// For specific version >= 0.56.0
 			} else if (version_compare($playerVersion, self::NO_ANALYTICS_PLAYER_VERSION) >= 0) {
 				$latestVersionMap = $this->getConfigByVersion("latest")[0];
 				$this->bundleConfig[self::PLAYKIT_KAVA] = $latestVersionMap[self::PLAYKIT_KAVA];
@@ -536,6 +538,7 @@ class embedPlaykitJsAction extends sfAction
 				}
 			}
 
+			// Save to the uiconf
 			if (isset($confVarsArr[self::VERSIONS_PARAM_NAME])) {
 				$confVarsArr[self::VERSIONS_PARAM_NAME] = $this->bundleConfig;
 			} else {

--- a/alpha/apps/kaltura/modules/extwidget/actions/embedPlaykitJsAction.class.php
+++ b/alpha/apps/kaltura/modules/extwidget/actions/embedPlaykitJsAction.class.php
@@ -519,18 +519,22 @@ class embedPlaykitJsAction extends sfAction
 
 	private function maybeAddAnalyticsPlugins($confVarsArr)
 	{
-		$ovpPlayerConfig = isset($this->bundleConfig[self::KALTURA_OVP_PLAYER]) ? $this->bundleConfig[self::KALTURA_OVP_PLAYER] : "";
-		$tvPlayerConfig = isset($this->bundleConfig[self::KALTURA_TV_PLAYER]) ? $this->bundleConfig[self::KALTURA_TV_PLAYER] : "";
-		if (!isset($this->bundleConfig[self::PLAYKIT_KAVA]) && ($ovpPlayerConfig || $tvPlayerConfig)) {
+		$ovpPlayerConfig = isset($this->bundleConfig[self::KALTURA_OVP_PLAYER]) ? $this->bundleConfig[self::KALTURA_OVP_PLAYER] : '';
+		$tvPlayerConfig = isset($this->bundleConfig[self::KALTURA_TV_PLAYER]) ? $this->bundleConfig[self::KALTURA_TV_PLAYER] : '';
+		if (!isset($this->bundleConfig[self::PLAYKIT_KAVA]) && ($ovpPlayerConfig || $tvPlayerConfig))
+		{
 			$playerVersion = $ovpPlayerConfig ? $ovpPlayerConfig : $tvPlayerConfig;
 			// For player latest/beta/canary
-			if ($playerVersion == self::LATEST || $playerVersion == self::BETA || $playerVersion == self::CANARY) {
+			if ($playerVersion == self::LATEST || $playerVersion == self::BETA || $playerVersion == self::CANARY)
+			{
 				$this->bundleConfig[self::PLAYKIT_KAVA] = $playerVersion;
 				if ($tvPlayerConfig) {
 					$this->bundleConfig[self::PLAYKIT_OTT_ANALYTICS] = $playerVersion;
 				}
+			}
 			// For specific version >= 0.56.0
-			} else if (version_compare($playerVersion, self::NO_ANALYTICS_PLAYER_VERSION) >= 0) {
+			else if (version_compare($playerVersion, self::NO_ANALYTICS_PLAYER_VERSION) >= 0)
+			{
 				$latestVersionMap = $this->getConfigByVersion("latest")[0];
 				$this->bundleConfig[self::PLAYKIT_KAVA] = $latestVersionMap[self::PLAYKIT_KAVA];
 				if ($tvPlayerConfig) {
@@ -539,9 +543,12 @@ class embedPlaykitJsAction extends sfAction
 			}
 
 			// Save to the uiconf
-			if (isset($confVarsArr[self::VERSIONS_PARAM_NAME])) {
+			if (isset($confVarsArr[self::VERSIONS_PARAM_NAME]))
+			{
 				$confVarsArr[self::VERSIONS_PARAM_NAME] = $this->bundleConfig;
-			} else {
+			}
+		 	else
+		 	{
 				$confVarsArr = $this->bundleConfig;
 			}
 			$this->uiConf->setConfVars(json_encode($confVarsArr));

--- a/alpha/apps/kaltura/modules/extwidget/actions/embedPlaykitJsAction.class.php
+++ b/alpha/apps/kaltura/modules/extwidget/actions/embedPlaykitJsAction.class.php
@@ -47,7 +47,7 @@ class embedPlaykitJsAction extends sfAction
 	private $uiConfUpdatedAt = null;
 	private $regenerate = false;
 	private $uiConfTags = array(self::PLAYER_V3_VERSIONS_TAG);
-	private $bundleConfigUpdated = false;
+	private $bundleConfigToSave = null;
 	private $confVarsArr = null;
 
 	public function execute()
@@ -78,15 +78,15 @@ class embedPlaykitJsAction extends sfAction
 	public static function buildBundleLocked($context)
 	{
 		// Save to the uiconf if the bundle config has been updated with the analytics plugins
-		if ($context->bundleConfigUpdated)
+		if ($context->bundleConfigToSave)
 		{
 			if (isset($context->confVarsArr[self::VERSIONS_PARAM_NAME]))
 			{
-				$context->confVarsArr[self::VERSIONS_PARAM_NAME] = $context->bundleConfig;
+				$context->confVarsArr[self::VERSIONS_PARAM_NAME] = $context->bundleConfigToSave;
 			}
 			else
 			{
-				$context->confVarsArr = $context->bundleConfig;
+				$context->confVarsArr = $context->bundleConfigToSave;
 			}
 			$context->uiConf->setConfVars(json_encode($context->confVarsArr));
 			$context->uiConf->save();
@@ -556,7 +556,7 @@ class embedPlaykitJsAction extends sfAction
 				{
 					$this->bundleConfig[self::PLAYKIT_OTT_ANALYTICS] = $playerVersion;
 				}
-				$this->bundleConfigUpdated = true;
+				$this->bundleConfigToSave = $this->bundleConfig;
 			}
 			// For specific version >= 0.56.0
 			else if (version_compare($playerVersion, self::NO_ANALYTICS_PLAYER_VERSION) >= 0)
@@ -566,7 +566,7 @@ class embedPlaykitJsAction extends sfAction
 				{
 					$this->bundleConfig[self::PLAYKIT_OTT_ANALYTICS] = $latestVersionMap[self::PLAYKIT_OTT_ANALYTICS];
 				}
-				$this->bundleConfigUpdated = true;
+				$this->bundleConfigToSave = $this->bundleConfig;
 			}
 		}
 	}

--- a/alpha/apps/kaltura/modules/extwidget/actions/embedPlaykitJsAction.class.php
+++ b/alpha/apps/kaltura/modules/extwidget/actions/embedPlaykitJsAction.class.php
@@ -684,7 +684,7 @@ class embedPlaykitJsAction extends sfAction
 		}
 
 		$this->maybeAddAnalyticsPlugins($confVarsArr);
-        $this->setFixVersionsNumber();
+		$this->setFixVersionsNumber();
 		$this->setBundleName();
 	}
 


### PR DESCRIPTION
Add playkit-kava and playkit-ott-analytics to kaltura-player >= 0.56.0 which doesn't exist these plugins anymore.

Related to https://github.com/kaltura/kaltura-player-js/pull/337