### PR TITLE
LIV-167: add session type to playManifest url

### DIFF
--- a/alpha/lib/model/DeliveryProfileLive.php
+++ b/alpha/lib/model/DeliveryProfileLive.php
@@ -357,7 +357,7 @@ abstract class DeliveryProfileLive extends DeliveryProfile {
 		
 		$livePackagerUrl = "$livePackagerUrl/p/$partnerID/e/$entryId/";
 		$livePackagerUrl .= $serverNode->getSegmentDurationUrlString($segmentDuration);
-		$livePackagerUrl .= $serverNode->getSessionIdUrlString($entryServerNode);
+		$livePackagerUrl .= $serverNode->getSessionType($entryServerNode);
 
 		$entry = $this->getDynamicAttributes()->getEntry();
 		if ($entry->getExplicitLive())

--- a/alpha/lib/model/MediaServerNode.php
+++ b/alpha/lib/model/MediaServerNode.php
@@ -85,7 +85,7 @@ abstract class MediaServerNode extends DeliveryServerNode {
         return '';
     }
 
-	public function getSessionIdUrlString($entryServerNode)
+	public function getSessionType($entryServerNode)
 	{
 		return '';
 	}

--- a/plugins/media/live_cluster/lib/model/LiveClusterMediaServerNode.php
+++ b/plugins/media/live_cluster/lib/model/LiveClusterMediaServerNode.php
@@ -4,7 +4,7 @@
 class LiveClusterMediaServerNode extends MediaServerNode
 {
     const ENVIRONMENT = 'env';
-    const SESSION_ID = 'sid';
+    const SESSION_TYPE = 'st';
 
     /**
      * Applies default values to this object.
@@ -45,8 +45,8 @@ class LiveClusterMediaServerNode extends MediaServerNode
         return self::ENVIRONMENT . '/' . $this->getEnvironment();
     }
 
-    public function getSessionIdUrlString($entryServerNode)
+    public function getSessionType($entryServerNode)
     {
-        return self::SESSION_ID . '/' . $entryServerNode->getId() . '/';
+        return self::SESSION_TYPE . '/' . $entryServerNode->getServerType() .'/';
     }
 }


### PR DESCRIPTION
add session type to playManifest url (only in case of LiveClusterMediaServerNode)
remove session_id (sid) from playManifest url