### PR TITLE
Update restoreDeletedEntriesByEntryList.php

### DIFF
--- a/alpha/scripts/utils/restoreDeletedEntriesByEntryList.php
+++ b/alpha/scripts/utils/restoreDeletedEntriesByEntryList.php
@@ -25,6 +25,7 @@ foreach ($entries as $deletedEntryId){
 	KalturaLog::debug('undeleting entry id ['. $deletedEntry->getID().']');
 	if ($deletedEntry->getStatus() == entryStatus::DELETED){		
 		$deletedEntry->setStatus(entryStatus::READY);
+		$deletedEntry->setDefaultModerationStatus();
 	}
 	
 	$deletedEntry->setThumbnail($deletedEntry->getFromCustomData("deleted_original_thumb"), true);


### PR DESCRIPTION
Deleted entries acquire the DELETED moderation status upon deletion (in addition to the regular entryStatus::DELETED). The moderation status needs to be reverted for the entry to reappear in specific searches.