### PR TITLE
servefile: return not found http status on err

### DIFF
--- a/alpha/apps/kaltura/modules/extwidget/actions/servefileAction.class.php
+++ b/alpha/apps/kaltura/modules/extwidget/actions/servefileAction.class.php
@@ -12,6 +12,8 @@ class servefileAction extends sfAction
 	{
 		try
 		{
+			KExternalErrors::setResponseErrorCode(KExternalErrors::HTTP_STATUS_NOT_FOUND);
+
 			requestUtils::handleConditionalGet();
 			
 			$file_sync_id = $this->getRequestParameter( "id" );


### PR DESCRIPTION
otherwise empty files can be cached in the packager/cdn