### PR TITLE
explicitly close the memcache conn

### DIFF
--- a/infra/cache/kInfraMemcacheCacheWrapper.php
+++ b/infra/cache/kInfraMemcacheCacheWrapper.php
@@ -41,12 +41,26 @@ class kInfraMemcacheCacheWrapper extends kInfraBaseCacheWrapper
 		return $this->reconnect();
 	}
 	
+	public function __destruct()
+	{
+		$this->close();
+	}
+
+	protected function close()
+	{
+		if ($this->memcache)
+		{
+			$this->memcache->close();
+		}
+		$this->memcache = null;
+	}
+
 	/**
 	 * @return bool false on error
 	 */
 	protected function reconnect()
 	{
-		$this->memcache = null;
+		$this->close();
 		
 		if ($this->connectAttempts >= self::MAX_CONNECT_ATTEMPTS)
 		{


### PR DESCRIPTION
it seems that in some cases, removing references to the memcache object
is not enough