### PR TITLE
export script bug fix

### DIFF
--- a/alpha/scripts/utils/ExportToDifferentStorage.php
+++ b/alpha/scripts/utils/ExportToDifferentStorage.php
@@ -97,12 +97,12 @@ function handleRegularFileSyncs($assetId, $fileSyncs)
 	}
 
 	// create missing file sync
-	$newfileSync = $readyFileSync->cloneToAnotherStorage($targetDcId);
-	$newfileSync->setLinkCount(0);
-	$newfileSync->putInCustomData('srcDc', $readyFileSync->getDc());
-
 	try
 	{
+		$newfileSync = $readyFileSync->cloneToAnotherStorage($targetDcId);
+		$newfileSync->setLinkCount(0);
+		$newfileSync->putInCustomData('srcDc', $readyFileSync->getDc());
+
 		$syncKey = kFileSyncUtils::getKeyForFileSync($newfileSync);
 
 		KalturaLog::log("XXX $assetId: CREATED - creating file sync in dc $targetDcId key $syncKey");
@@ -193,7 +193,14 @@ function handleSyncKey($assetId, $syncKey, $depth = 0)
 		return;
 	}
 
-	$resolvedSyncKey = reset($resolvedFileSyncKeys);
+	if ($resolvedFileSyncKeys)
+	{
+		$resolvedSyncKey = reset($resolvedFileSyncKeys);
+	}
+	else
+	{
+		$resolvedSyncKey = $targetResolvedFileSyncKey;
+	}
 
 	if ($targetFileSync)
 	{


### PR DESCRIPTION
when there was a file sync only in the target dc but not in the source dcs, the script incorrectly thought the target file sync is wrong and deleted it.
also moved the call to clone to inside the try/catch since it can throw in some cases.