### PR TITLE
export: make sure custom data fields are not lost

### DIFF
--- a/alpha/lib/model/FileSync.php
+++ b/alpha/lib/model/FileSync.php
@@ -457,6 +457,7 @@ class FileSync extends BaseFileSync implements IBaseObject
 	public function cloneToAnotherStorage($storageId)
 	{
 		$newfileSync = $this->copy(true);
+		$newfileSync->m_custom_data = null; // force reload of custom data
 		$newfileSync->setStatus(FileSync::FILE_SYNC_STATUS_PENDING);
 		$newfileSync->setSrcPath($this->getFullPath());
 		$newfileSync->setSrcEncKey($this->getSrcEncKey());


### PR DESCRIPTION
copyInto calls setStatus before setCustomData, setStatus loads the custom data by calling unsetOriginalId. since the custom data wasn't yet copied, m_custom_data is initialized to an empty object. setting it to null forces a reload of custom data on the next get/set.