### PR TITLE
VIRTC-166: simulive - use retrieveByPKNoFilter in playManifest

### DIFF
--- a/alpha/apps/kaltura/modules/extwidget/actions/playManifestAction.class.php
+++ b/alpha/apps/kaltura/modules/extwidget/actions/playManifestAction.class.php
@@ -930,7 +930,7 @@ class playManifestAction extends kalturaAction
 				if ($event)
 				{
 					$this->entryId = $event->getSourceEntryId();
-					$sourceEntry = entryPeer::retrieveByPKNoFilter($this->entryId, null, false);
+					$sourceEntry = kSimuliveUtils::getSourceEntry($event);
 					$this->entry = $sourceEntry ? $sourceEntry : $this->entry;
 					$this->initFlavorAssetArray(true);
 				}

--- a/alpha/apps/kaltura/modules/extwidget/actions/playManifestAction.class.php
+++ b/alpha/apps/kaltura/modules/extwidget/actions/playManifestAction.class.php
@@ -930,7 +930,7 @@ class playManifestAction extends kalturaAction
 				if ($event)
 				{
 					$this->entryId = $event->getSourceEntryId();
-					$sourceEntry = BaseentryPeer::retrieveByPK($this->entryId);
+					$sourceEntry = entryPeer::retrieveByPKNoFilter($this->entryId, null, false);
 					$this->entry = $sourceEntry ? $sourceEntry : $this->entry;
 					$this->initFlavorAssetArray(true);
 				}


### PR DESCRIPTION
use retrieveByPKNoFilter in playManifest instead of retrieveByPK, to retrieve the source entry (as KMS doing playManifest request with KS that not entitled to the source entry)