### PR TITLE
query cache: increase query master thres

### DIFF
--- a/alpha/apps/kaltura/lib/cache/kQueryCache.php
+++ b/alpha/apps/kaltura/lib/cache/kQueryCache.php
@@ -41,7 +41,7 @@ class kQueryCache
 													// in order to compensate for clock differences
 	const SLAVE_LAG_TIME_MARGIN_SEC = 70;			// This value is added to the measured slave lag as a safety margin.
 													// it is composed of the lag measuring period (60) and the clock sync margin (10)
-	const MAX_QUERY_MASTER_TIME_MARGIN_SEC = 300;	// The maximum time frame after a DB change during which we should query the master
+	const MAX_QUERY_MASTER_TIME_MARGIN_SEC = 3600;	// The maximum time frame after a DB change during which we should query the master
 	
 	const MAX_CACHED_OBJECT_COUNT = 500;			// Select queries that return more objects than this const will not be cached
 													// 500 serialized entries take 110K after compression, well below the memcache 1M limit  


### PR DESCRIPTION
from 5m to 1h, this will make the system more resilient to slave lags at the expense of more queries to master