### PR TITLE
Simulive: avoid index live status

### DIFF
--- a/alpha/lib/model/LiveEntry.php
+++ b/alpha/lib/model/LiveEntry.php
@@ -996,7 +996,7 @@ abstract class LiveEntry extends entry
 		$body = array(
 			'recorded_entry_id' => $this->getRecordedEntryId(),
 			'push_publish' => $this->getPushPublishEnabled(),
-			'is_live' => $this->isCurrentlyLive(),
+			'is_live' => false,
 		);
 		elasticSearchUtils::cleanEmptyValues($body);
 


### PR DESCRIPTION
Because the simulive we added sphinx query to the isCurrentlyLive check. This function cannot be use during the elastic index process.
Moreover, indexing entry state is wrong consider elastic use cases