### PR TITLE
sphinx_log: add dc,id index and force it

### DIFF
--- a/deployment/base/sql/01.kaltura_sphinx_ce_tables.sql
+++ b/deployment/base/sql/01.kaltura_sphinx_ce_tables.sql
@@ -15,8 +15,9 @@ CREATE TABLE IF NOT EXISTS `sphinx_log` (
   `custom_data` TEXT,
   PRIMARY KEY (`id`),
   KEY `entry_id` (`entry_id`),
-  KEY `creatd_at` (`created_at`),
-  KEY `sphinx_log_FI_1` (`partner_id`)
+  KEY `created_at` (`created_at`),
+  KEY `partner_id` (`partner_id`),
+  KEY `dc_id` (`dc`,`id`)
 ) ENGINE=MYISAM AUTO_INCREMENT=0 DEFAULT CHARSET=utf8;
 
 /*Table structure for table `sphinx_log_server` */

--- a/deployment/updates/sql/2020_11_05_sphinx_log_dc_id_index.sql
+++ b/deployment/updates/sql/2020_11_05_sphinx_log_dc_id_index.sql
@@ -1,0 +1,1 @@
+ALTER TABLE sphinx_log ADD INDEX `dc_id` (`dc`,`id`);

--- a/plugins/search/lib/model/SphinxLogPeer.php
+++ b/plugins/search/lib/model/SphinxLogPeer.php
@@ -60,6 +60,7 @@ class SphinxLogPeer extends BaseSphinxLogPeer {
 		$baseCriteria->add(SphinxLogPeer::TYPE, $types, Criteria::IN);
 		$baseCriteria->addAscendingOrderByColumn(SphinxLogPeer::ID);
 		$baseCriteria->setLimit($limit);
+		$baseCriteria->setForceIndex('dc_id');
 
 		$result = array();
 

--- a/vendor/propel/util/BasePeer.php
+++ b/vendor/propel/util/BasePeer.php
@@ -756,6 +756,7 @@ class BasePeer
 		$orderByClause = array();
 		// redundant definition $groupByClause = array();
 
+		$forceIndex = $criteria->getForceIndex();
 		$orderBy = $criteria->getOrderByColumns();
 		$groupBy = $criteria->getGroupByColumns();
 		$ignoreCase = $criteria->isIgnoreCase();
@@ -1001,6 +1002,12 @@ class BasePeer
 		}
 		
 		$from .= $joinClause ? ' ' . implode(' ', $joinClause) : '';
+		if ($forceIndex) {
+			if ($db->useQuoteIdentifier()) {
+				$forceIndex = $db->quoteIdentifier($forceIndex);
+			}
+			$from .= " FORCE INDEX($forceIndex)";
+		}
 
 		// Build the SQL from the arrays we compiled
 		$sql =  "SELECT "

--- a/vendor/propel/util/Criteria.php
+++ b/vendor/propel/util/Criteria.php
@@ -131,6 +131,7 @@ class Criteria implements IteratorAggregate {
 	private $singleRecord = false;
 	private $selectModifiers = array();
 	private $selectColumns = array();
+	private $forceIndex = null;
 	private $orderByColumns = array();
 	private $groupByColumns = array();
 	private $having = null;
@@ -216,6 +217,7 @@ class Criteria implements IteratorAggregate {
 		$this->singleRecord = false;
 		$this->selectModifiers = array();
 		$this->selectColumns = array();
+		$this->forceIndex = null;
 		$this->orderByColumns = array();
 		$this->groupByColumns = array();
 		$this->having = null;
@@ -858,6 +860,26 @@ class Criteria implements IteratorAggregate {
 	}
 
 	/**
+	 * Get the forced index for this Criteria.
+	 *
+	 * @return     string
+	 */
+	public function getForceIndex()
+	{
+		return $this->forceIndex;
+	}
+
+	/**
+	 * Sets the forced index for this Criteria.
+	 *
+	 * @param      string $v
+	 */
+	public function setForceIndex($forceIndex)
+	{
+		$this->forceIndex = $forceIndex;
+	}
+
+	/**
 	 * Clears current select columns.
 	 *
 	 * @return     Criteria Modified Criteria object (for fluent API)
@@ -1045,6 +1067,7 @@ class Criteria implements IteratorAggregate {
 				&& $this->dbName === $criteria->getDbName()
 				&& $this->selectModifiers === $criteria->getSelectModifiers()
 				&& $this->selectColumns === $criteria->getSelectColumns()
+				&& $this->forceIndex === $criteria->getForceIndex()
 				&& $this->orderByColumns === $criteria->getOrderByColumns()
 				&& $this->groupByColumns === $criteria->getGroupByColumns()
 			   )


### PR DESCRIPTION
when one dc is inactive, the queries for fetching its updates can become very heavy. it seems mysql doesn't use dc,id index in this case, even though it's better than id, so we are forcing it.