### PR TITLE
VIRTC-801: simulive status on analytics dashboard

### DIFF
--- a/alpha/apps/kaltura/modules/extwidget/actions/serveFlavorAction.class.php
+++ b/alpha/apps/kaltura/modules/extwidget/actions/serveFlavorAction.class.php
@@ -417,7 +417,7 @@ class serveFlavorAction extends kalturaAction
 			if ($entry->hasCapability(LiveEntry::SIMULIVE_CAPABILITY) && $entry instanceof LiveEntry)
 			{
 				$offset = kConf::get('serve_flavor_accept_time_offset', 'live', 0) ? intval($this->getRequestParameter(kSimuliveUtils::SCHEDULE_TIME_OFFSET_URL_PARAM, 0)): 0;
-				list($durations, $flavors, $startTime, $endTime, $dvrWindow) = kSimuliveUtils::getSimuliveEventDetails($entry, time() + $offset);
+				list($durations, $flavors, $startTime, $endTime, $dvrWindow, $eventEndTime) = kSimuliveUtils::getSimuliveEventDetails($entry, time() + $offset);
 				if ($flavors)
 				{
 					$sequences = self::buildSequencesArray($flavors);
@@ -428,6 +428,10 @@ class serveFlavorAction extends kalturaAction
 					if ($offset)
 					{
 						$mediaSet[kSimuliveUtils::SCHEDULE_TIME_OFFSET_URL_PARAM] = $offset;
+					}
+					else
+					{
+						kSimuliveUtils::createEntryServerNode($entry, $eventEndTime);
 					}
 					$this->sendJson($mediaSet, false, true, $entry);
 				}

--- a/alpha/lib/model/ServerNode.php
+++ b/alpha/lib/model/ServerNode.php
@@ -16,6 +16,7 @@
 class ServerNode extends BaseServerNode {
 
 	const SERVER_NODE_TTL_TIME = 120;
+	const SIMULIVE_SERVER_NODE_ID = -1;
 
 	public function getCacheInvalidationKeys()
 	{


### PR DESCRIPTION
add createEntryServerNode to kSimulive utils and reindex the liveEntry in case of serverNode created
create entryServerNode by the first serveFlavor call
add storeEntryServerNodeInCache to LiveEntry to expose getEntryServerNodeCacheKey and storeInCache