### PR TITLE
VIRTC-801: add entry server nodes to simulive entries

### DIFF
--- a/alpha/lib/model/LiveEntry.php
+++ b/alpha/lib/model/LiveEntry.php
@@ -511,11 +511,6 @@ abstract class LiveEntry extends entry
 				return false;
 		}
 
-		if (kSimuliveUtils::getPlayableSimuliveEvent($this))
-		{
-			return true;
-		}
-
 		$liveEntryServerNodes = $this->getPlayableEntryServerNodes();
 		if(!count($liveEntryServerNodes))
 			return false;
@@ -723,10 +718,6 @@ abstract class LiveEntry extends entry
 
 	public function getLiveStatus()
 	{
-		if (kSimuliveUtils::getPlayableSimuliveEvent($this))
-		{
-			return EntryServerNodeStatus::PLAYABLE;
-		}
 
 		$entryServerNodes = EntryServerNodePeer::retrieveByEntryId($this->getId());
 

--- a/batch/batches/ValidateLiveMediaServers/KAsyncValidateLiveMediaServers.class.php
+++ b/batch/batches/ValidateLiveMediaServers/KAsyncValidateLiveMediaServers.class.php
@@ -13,7 +13,10 @@
 class KAsyncValidateLiveMediaServers extends KPeriodicWorker
 {
 	const ENTRY_SERVER_NODE_MIN_CREATION_TIME = 120;
-	
+	const EVENT_TIME_MARGIN_SEC = 60 * 60; // 1 hour
+	const SIMULIVE_HOSTNAME = 'simulive';
+	const MINIMUM_TIME_TO_PLAYABLE_SEC = 18; // 3 * default segment duration
+
 	/* (non-PHPdoc)
 	 * @see KBatchBase::getType()
 	 */
@@ -22,83 +25,280 @@ class KAsyncValidateLiveMediaServers extends KPeriodicWorker
 		return KalturaBatchJobType::CLEANUP;
 	}
 
-    protected function getFilter()
-    {
-        $entryServerNodeMinCreationTime = $this->getAdditionalParams("minCreationTime");
-        if(!$entryServerNodeMinCreationTime)
-            $entryServerNodeMinCreationTime = self::ENTRY_SERVER_NODE_MIN_CREATION_TIME;
-
-        $entryServerNodeFilter = new KalturaEntryServerNodeFilter();
-        $entryServerNodeFilter->orderBy = KalturaEntryServerNodeOrderBy::CREATED_AT_ASC;
-        $entryServerNodeFilter->createdAtLessThanOrEqual = time() - $entryServerNodeMinCreationTime;
-
-        $excludeServerIds = $this->getExcludeServerIds();
-        if ($excludeServerIds)
-        {
-            $entryServerNodeFilter->serverNodeIdNotIn = implode(',', $excludeServerIds);
-        }
-        return $entryServerNodeFilter;
-    }
-
-    public static function getExcludeServerNodesFromAPI($serverTypesNotIn)
-    {
-        $serverNodeFilter = new KalturaServerNodeFilter();
-        $serverNodeFilter->typeIn = $serverTypesNotIn;
-        return self::$kClient->serverNode->listAction($serverNodeFilter);
-    }
-
-
-    protected function getExcludeServerIds()
-    {
-        $excludeServerIds = array();
-        $serverTypesNotIn = $this->getAdditionalParams('serverTypesNotIn');
-        if ($serverTypesNotIn)
-        {
-            $serverNodes = KBatchBase::tryExecuteApiCall(array('KAsyncValidateLiveMediaServers','getExcludeServerNodesFromAPI'), array($serverTypesNotIn));
-            if ($serverNodes && $serverNodes->objects)
-            {
-                foreach($serverNodes->objects as $serverNode)
-                {
-                    $excludeServerIds[] = $serverNode->id;
-                }
-            }
-        }
-        return $excludeServerIds;
-    }
-	
 	/* (non-PHPdoc)
 	 * @see KBatchBase::run()
 	*/
 	public function run($jobs = null)
 	{
-		$entryServerNodeFilter = $this->getFilter();
-		
-		$entryServerNodePager = new KalturaFilterPager();
-		$entryServerNodePager->pageSize = 500;
-		$entryServerNodePager->pageIndex = 1;
-		
+		$this->validateLiveEntryServerNode();
+		$this->validateSimuliveEntryServerNode();
+	}
+
+	protected function validateLiveEntryServerNode()
+	{
+		$entryServerNodeFilter = $this->getLiveEntryServerNodesFilter();
+
+		$entryServerNodePager = self::getDefaultPager();
+
 		$entryServerNodes = self::$kClient->entryServerNode->listAction($entryServerNodeFilter, $entryServerNodePager);
-		
+
 		while($entryServerNodes->objects && count($entryServerNodes->objects))
 		{
 			foreach($entryServerNodes->objects as $entryServerNode)
 			{
-				try
-				{
-					/* @var $entryServerNode KalturaEntryServerNode */
-					self::impersonate($entryServerNode->partnerId);
-					self::$kClient->entryServerNode->validateRegisteredEntryServerNode($entryServerNode->id);
-					self::unimpersonate();
-				}
-				catch (KalturaException $e)
-				{
-					self::unimpersonate();
-					KalturaLog::err("Caught exception with message [" . $e->getMessage()."]");
-				}
+				/* @var $entryServerNode KalturaEntryServerNode */
+				KBatchBase::tryExecuteApiCall(array('KAsyncValidateLiveMediaServers', 'validateRegisteredEntryServerNode'), array($entryServerNode->partnerId, $entryServerNode->id));
 			}
-			
+
 			$entryServerNodePager->pageIndex++;
 			$entryServerNodes = self::$kClient->entryServerNode->listAction($entryServerNodeFilter, $entryServerNodePager);
 		}
 	}
+
+	protected function validateSimuliveEntryServerNode()
+	{
+		// getting simulive serverNode
+		$simuliveServerNode = KBatchBase::tryExecuteApiCall(array('KAsyncValidateLiveMediaServers', 'getSimuliveServerNode'), array());
+		if (!$simuliveServerNode)
+		{
+			KalturaLog::info('no simulive server node found');
+			return;
+		}
+
+		//getting all esn of the simulive serverNode
+		$entryServerNodes = KBatchBase::tryExecuteApiCall(array('KAsyncValidateLiveMediaServers', 'getEntryServerNodes'), array($simuliveServerNode->id));
+
+		// getting currently live events
+		$currentlyLiveEvents = KBatchBase::tryExecuteApiCall(array('KAsyncValidateLiveMediaServers', 'getSimulivePlayableEvents'), array());
+
+		// map between templateEntryId to sourceEntryId
+		$eventsMap = self::arrayColumn($currentlyLiveEvents, 'templateEntryId', 'sourceEntryId');
+		// map between entryId to entryServerNode object
+		$entryServerNodesMap = self::arrayColumn($entryServerNodes, 'entryId');
+
+		foreach ($eventsMap as $templateEntryId => $sourceEntryId)
+		{
+			// event exist but there's no entry serverNode - create the entryServerNode (only for simulve - has sourceEntryId)
+			if ($templateEntryId && $sourceEntryId && !array_key_exists($templateEntryId, $entryServerNodesMap))
+			{
+				KBatchBase::tryExecuteApiCall(array('KAsyncValidateLiveMediaServers', 'registerMediaServer'), array($templateEntryId));
+			}
+		}
+
+		foreach ($entryServerNodesMap as $liveEntryId => $entryServerNode)
+		{
+			// entryServerNode exist but there's no event - delete the entryServerNode
+			if (!array_key_exists($liveEntryId, $eventsMap))
+			{
+				/* @var $entryServerNode KalturaEntryServerNode */
+				KBatchBase::tryExecuteApiCall(array('KAsyncValidateLiveMediaServers', 'validateRegisteredEntryServerNode'), array($entryServerNode->partnerId, $entryServerNode->id));
+			}
+		}
+	}
+
+	/**
+	 * Return filter for live entry server nodes
+	 * @return KalturaEntryServerNodeFilter
+	 */
+	protected function getLiveEntryServerNodesFilter()
+	{
+		$entryServerNodeMinCreationTime = $this->getAdditionalParams("minCreationTime");
+		if(!$entryServerNodeMinCreationTime)
+		{
+			$entryServerNodeMinCreationTime = self::ENTRY_SERVER_NODE_MIN_CREATION_TIME;
+		}
+
+		$entryServerNodeFilter = new KalturaEntryServerNodeFilter();
+		$entryServerNodeFilter->orderBy = KalturaEntryServerNodeOrderBy::CREATED_AT_ASC;
+		$entryServerNodeFilter->createdAtLessThanOrEqual = time() - $entryServerNodeMinCreationTime;
+
+		$excludeServerIds = $this->getExcludeServerIds();
+		if ($excludeServerIds)
+		{
+			$entryServerNodeFilter->serverNodeIdNotIn = implode(',', $excludeServerIds);
+		}
+		return $entryServerNodeFilter;
+	}
+
+	/**
+	 * Return LiveStreamScheduleEvent filter
+	 * @return KalturaLiveStreamScheduleEventFilter
+	 */
+	protected static function getSimuliveEventsFilter()
+	{
+		$now = time();
+		$scheduleEventFilter = new KalturaLiveStreamScheduleEventFilter();
+		$scheduleEventFilter->orderBy = KalturaLiveStreamScheduleEventOrderBy::START_DATE_ASC;
+		$scheduleEventFilter->startDateLessThanOrEqual = $now + self::EVENT_TIME_MARGIN_SEC;
+		$scheduleEventFilter->endDateGreaterThanOrEqual = $now - self::EVENT_TIME_MARGIN_SEC;
+		return $scheduleEventFilter;
+	}
+
+	/**
+	 * Return default pager (pageSize : 500, pageIndex : 1)
+	 * @return KalturaFilterPager
+	 */
+	protected static function getDefaultPager()
+	{
+		$entryServerNodePager = new KalturaFilterPager();
+		$entryServerNodePager->pageSize = 500;
+		$entryServerNodePager->pageIndex = 1;
+		return $entryServerNodePager;
+	}
+
+	public static function getExcludeServerNodesFromAPI($serverTypesNotIn)
+	{
+		$serverNodeFilter = new KalturaServerNodeFilter();
+		$serverNodeFilter->typeIn = $serverTypesNotIn;
+		return self::$kClient->serverNode->listAction($serverNodeFilter);
+	}
+
+
+	protected function getExcludeServerIds()
+	{
+		$excludeServerIds = array();
+		$serverTypesNotIn = $this->getAdditionalParams('serverTypesNotIn');
+		if ($serverTypesNotIn)
+		{
+			$serverNodes = KBatchBase::tryExecuteApiCall(array('KAsyncValidateLiveMediaServers', 'getExcludeServerNodesFromAPI'), array($serverTypesNotIn));
+			if ($serverNodes && $serverNodes->objects)
+			{
+				foreach($serverNodes->objects as $serverNode)
+				{
+					$excludeServerIds[] = $serverNode->id;
+				}
+			}
+		}
+		return $excludeServerIds;
+	}
+
+	/**
+	 * Filter and take only the events that currently live and playable (considering preStart / postEnd)
+	 * @param array<KalturaLiveStreamScheduleEvent> $events
+	 * @return array<KalturaLiveStreamScheduleEvent>
+	 */
+	protected static function filterPlayableEvents($events)
+	{
+		return array_filter($events, function ($event) {
+			$now = time();
+			/* @var $event KalturaLiveStreamScheduleEvent */
+			return $now >= ($event->startDate - $event->preStartTime + self::MINIMUM_TIME_TO_PLAYABLE_SEC) && $now <= ($event->endDate + $event->postEndTime);
+		});
+	}
+
+	/**
+	 * Return the serverNode with hostName == SIMULIVE_HOSTNAME
+	 * @return KalturaServerNode or null if not found
+	 */
+	protected static function getSimuliveServerNode()
+	{
+		$serverNodeFilter = new KalturaLiveClusterMediaServerNodeFilter();
+		$serverNodeFilter->hostNameLike = self::SIMULIVE_HOSTNAME;
+		$serverNodes = self::$kClient->serverNode->listAction($serverNodeFilter);
+		if (!$serverNodes || !count($serverNodes->objects))
+		{
+			return null;
+		}
+		foreach ($serverNodes->objects as $serverNode)
+		{
+			/* @var $serverNode KalturaServerNode */
+			if ($serverNode->hostName == self::SIMULIVE_HOSTNAME)
+			{
+				return $serverNode;
+			}
+		}
+		return null;
+	}
+
+	/**
+	 * Return events that currently live (considering preStart / postEnd and minTimeToPlayable)
+	 * @return array<KalturaLiveStreamScheduleEvent> or null
+	 */
+	protected static function getSimulivePlayableEvents()
+	{
+		$simuliveEventsMerged = array();
+		$simuliveEventsFilter = self::getSimuliveEventsFilter();
+		$simuliveEventsPager = self::getDefaultPager();
+		$simuliveEvents = self::$kClient->scheduleEvent->listAction($simuliveEventsFilter, $simuliveEventsPager);
+
+		while ($simuliveEvents->objects && count($simuliveEvents->objects))
+		{
+			$simuliveEventsMerged = array_merge($simuliveEventsMerged, self::filterPlayableEvents($simuliveEvents->objects));
+			$simuliveEventsPager->pageIndex++;
+			$simuliveEvents = self::$kClient->scheduleEvent->listAction($simuliveEventsFilter, $simuliveEventsPager);
+		}
+		return $simuliveEventsMerged;
+	}
+
+	/**
+	 * Return the entryServerNodes with serverNodeId == $serverNodeId
+	 * @param string $serverNodeId
+	 * @return array<KalturaEntryServerNode>
+	 */
+	protected static function getEntryServerNodes($serverNodeId)
+	{
+		$entryServerNodesMerged = array();
+		$entryServerNodeFilter = new KalturaEntryServerNodeFilter();
+		$entryServerNodeFilter->serverNodeIdEqual = $serverNodeId;
+		$entryServerNodePager = self::getDefaultPager();
+		$entryServerNodes = self::$kClient->entryServerNode->listAction($entryServerNodeFilter, $entryServerNodePager);
+		while ($entryServerNodes->objects && count($entryServerNodes->objects))
+		{
+			$entryServerNodesMerged = array_merge($entryServerNodesMerged, $entryServerNodes->objects);
+			$entryServerNodePager->pageIndex++;
+			$entryServerNodes = self::$kClient->entryServerNode->listAction($entryServerNodeFilter, $entryServerNodePager);
+		}
+		return $entryServerNodesMerged;
+	}
+
+	/**
+	 * Return the new array with key as $id and value as $value (or the object as value if $value not given)
+	 * (this function exists in PHP versions of >=5.5.0)
+	 * @param array $arr - the array to manipulate on
+	 * @param $id - the new id
+	 * @param $value - the new value
+	 * @return array or empty array if $arr isn't array
+	 */
+	protected static function arrayColumn($arr, $id, $value = null)
+	{
+		$res = array();
+		if (is_array($arr))
+		{
+			foreach ($arr as $e)
+			{
+				$res[$e->$id] = $value ? $e->$value : $e;
+			}
+		}
+		return $res;
+	}
+
+	/**
+	 * Static function to call to LiveStreamService->registerMediaServer
+	 * @param string $entryId
+	 */
+	protected static function registerMediaServer($entryId)
+	{
+		self::$kClient->liveStream->registerMediaServer($entryId, self::SIMULIVE_HOSTNAME, KalturaEntryServerNodeType::LIVE_PRIMARY, null, KalturaEntryServerNodeStatus::PLAYABLE, false);
+	}
+
+	/**
+	 * Static function to call to EntryServerNodeService->validateRegisteredEntryServerNode as impersonated partner
+	 * @param int $impersonatedPartnerId
+	 * @param int $entryServerNodeId
+	 */
+	protected static function validateRegisteredEntryServerNode($impersonatedPartnerId, $entryServerNodeId)
+	{
+		try
+		{
+			self::impersonate($impersonatedPartnerId);
+			self::$kClient->entryServerNode->validateRegisteredEntryServerNode($entryServerNodeId);
+			self::unimpersonate();
+		}
+		catch (KalturaException $e)
+		{
+			self::unimpersonate();
+			KalturaLog::err("Caught exception with message [" . $e->getMessage()."]");
+		}
+	}
+
 }

--- a/deployment/permissions/service.livestream.ini
+++ b/deployment/permissions/service.livestream.ini
@@ -74,7 +74,7 @@ permissionItem8.permissions = CONTENT_MANAGE_THUMBNAIL, BASE_USER_SESSION_PERMIS
 permissionItem9.service = livestream
 permissionItem9.action = registerMediaServer
 permissionItem9.partnerId = 0
-permissionItem9.permissions = -5>MEDIA_SERVER_BASE, -5>PARTNER_-5_GROUP_*_PERMISSION,MEDIA_SERVER_PARTNER_LEVEL
+permissionItem9.permissions = -5>MEDIA_SERVER_BASE, -5>PARTNER_-5_GROUP_*_PERMISSION,MEDIA_SERVER_PARTNER_LEVEL, -1>BATCH_BASE, -1>PARTNER_-1_GROUP_*_PERMISSION
 
 permissionItem10.service = livestream
 permissionItem10.action = unregisterMediaServer

--- a/deployment/updates/scripts/add_permissions/2020_11_10_add_permission_batch_registerMediaServer.php
+++ b/deployment/updates/scripts/add_permissions/2020_11_10_add_permission_batch_registerMediaServer.php
@@ -1,0 +1,12 @@
+<?php
+
+
+/**
+ * @package deployment
+ *
+ * Add permissions to batch client to registerMediaServer
+ */
+
+$script = realpath(dirname(__FILE__) . '/../../../../') . '/alpha/scripts/utils/permissions/addPermissionsAndItems.php';
+$config = realpath(dirname(__FILE__)) . '/../../../permissions/service.livestream.ini';
+passthru("php $script $config");


### PR DESCRIPTION
change KAsyncValidateLiveMediaServer batch to add / remove entry server nodes according to simulive events
add permission to batch partner to liveStream->registerMediaServerAction (and add the appropriate script)
cancel simulive "isCurrentlyLive" & "getLiveStatus" implementation (as it is already checking live entry server nodes)