### PR TITLE
compat check fixes

### DIFF
--- a/alpha/scripts/compatCheck.php
+++ b/alpha/scripts/compatCheck.php
@@ -185,7 +185,7 @@ function print_r_reverse($in) {
         array_pop($lines); // )
         $in = implode("\n", $lines);
         // make sure we only match stuff with 4 preceding spaces (stuff for this array and not a nested one)
-        preg_match_all('/^\s{4}\[(.+?)\] \=\> /m', $in, $matches, PREG_OFFSET_CAPTURE | PREG_SET_ORDER);
+        preg_match_all('/^\s{4}\[(.+?)\] \=\> ?/m', $in, $matches, PREG_OFFSET_CAPTURE | PREG_SET_ORDER);
         $pos = array();
         $previous_key = '';
         $in_length = strlen($in);
@@ -1000,9 +1000,29 @@ function isActionApproved($fullActionName, $action)
 	return false;
 }
 
+function flattenArray($input, $prefix)
+{
+	$result = array();
+	foreach ($input as $key => $value)
+	{
+		if (is_array($value))
+		{
+			$result = array_merge($result, flattenArray($value, $prefix . "$key:"));
+		}
+		else
+		{
+			$result[$prefix . $key] = $value;
+		}
+	}
+	return $result;
+}
+
 function generateKalcliCommand($ipAddress, $service, $action, $parsedParams)
 {
 	$kalcliCmd = "kalcli -x -H`genipheader {$ipAddress}` {$service} {$action}";
+
+	$parsedParams = flattenArray($parsedParams, '');
+
 	foreach ($parsedParams as $key => $value)
 	{
 		if (in_array($key, array('action', 'service')))


### PR DESCRIPTION
1. fixed the print_r_reverse regex - when an array key has no value, there is no space after the '=>'
2. when the api gets nested params in json format, need to flatten them out before generating a kalcli command