### PR TITLE
apimon: ps2 cleanup

### DIFF
--- a/alpha/apps/kaltura/lib/cache/kApiCache.php
+++ b/alpha/apps/kaltura/lib/cache/kApiCache.php
@@ -787,16 +787,21 @@ class kApiCache extends kApiCacheBase
 
 			KalturaMonitorClient::usleep(50000);
 		}
-		
-		if(isset($this->_params['service']))
+
+		$action = null;
+		if (get_class($this) == 'kPlayManifestCacher')
+		{
+			$action = 'extwidget.playManifest';
+		}
+		else if (isset($this->_params['service']) && isset($this->_params['action']) && $this->_params['service'] != 'multirequest')
+		{
+			$action = $this->_params['service'] . '.' . $this->_params['action'];
+		}
+
+		if ($action)
 		{
 			$isInMultiRequest = isset($this->_params['multirequest']);
-			$action = $this->_params['service'];
-			if ($action != 'multirequest' && isset($this->_params['action']))
-			{
-				$action = $this->_params['service'] . '.' . $this->_params['action'];
-				KalturaMonitorClient::monitorApiStart($result !== false, $action, $this->_partnerId, $this->getCurrentSessionType(), $this->clientTag, $isInMultiRequest);
-			}
+			KalturaMonitorClient::monitorApiStart($result !== false, $action, $this->_partnerId, $this->getCurrentSessionType(), $this->clientTag, $isInMultiRequest);
 
 			foreach ($this->_monitorEvents as $event)
 			{

--- a/alpha/apps/kaltura/lib/monitor/KalturaMonitorClient.php
+++ b/alpha/apps/kaltura/lib/monitor/KalturaMonitorClient.php
@@ -231,7 +231,7 @@ class KalturaMonitorClient
 		}
 	}
 	
-	public static function monitorApiStart($cached, $action, $partnerId, $sessionType, $clientTag, $isInMultiRequest = false)
+	public static function monitorApiStart($cached, $action, $partnerId, $sessionType = null, $clientTag = null, $isInMultiRequest = false)
 	{
 		if ($partnerId == -1)		// cannot use BATCH_PARTNER_ID since this may run before the autoloader
 		{
@@ -278,8 +278,11 @@ class KalturaMonitorClient
 	{
 		$context = sfContext::getInstance();
 		$request = $context->getRequest();
-		$moduleName = $request->getParameter('module');
-		$actionName = $request->getParameter('action');
+		$action = $request->getParameter('module') . '.' . $request->getParameter('action');
+		if (strtolower($action) == 'extwidget.playmanifest')
+		{
+			return;		// handled by kApiCache
+		}
 
 		$partnerId = preg_match('#^/p/(\d+)/#', $_SERVER['REQUEST_URI'], $matches) ? $matches[1] : null;
 
@@ -287,7 +290,7 @@ class KalturaMonitorClient
 		$sessionType = isset($params['ks']) ? kSessionBase::SESSION_TYPE_USER : kSessionBase::SESSION_TYPE_NONE;	// assume user ks
 		$clientTag = isset($params['clientTag']) ? $params['clientTag'] : null;
 
-		self::monitorApiStart(false, "$moduleName.$actionName", $partnerId, $sessionType, $clientTag);
+		self::monitorApiStart(false, $action, $partnerId, $sessionType, $clientTag);
 	}
 
 	public static function monitorApiEnd($errorCode)

--- a/alpha/apps/kaltura/modules/extwidget/actions/downloadAction.class.php
+++ b/alpha/apps/kaltura/modules/extwidget/actions/downloadAction.class.php
@@ -55,8 +55,6 @@ class downloadAction extends sfAction
 				KExternalErrors::dieError(KExternalErrors::ENTRY_NOT_FOUND);
 		}
 		
-		KalturaMonitorClient::initApiMonitor(false, 'extwidget.download', $entry->getPartnerId());
-		
 		myPartnerUtils::blockInactivePartner($entry->getPartnerId());
 		
 		$shouldPreview = false;

--- a/alpha/apps/kaltura/modules/extwidget/actions/rawAction.class.php
+++ b/alpha/apps/kaltura/modules/extwidget/actions/rawAction.class.php
@@ -62,8 +62,6 @@ class rawAction extends sfAction
 				KExternalErrors::dieGracefully();
 		}
 
-		KalturaMonitorClient::initApiMonitor(false, 'extwidget.raw', $entry->getPartnerId());
-		
 		myPartnerUtils::blockInactivePartner($entry->getPartnerId());
 		
 		$securyEntryHelper = new KSecureEntryHelper($entry, $ks, $referrer, ContextType::DOWNLOAD);

--- a/alpha/apps/kaltura/modules/extwidget/actions/serveFlavorAction.class.php
+++ b/alpha/apps/kaltura/modules/extwidget/actions/serveFlavorAction.class.php
@@ -490,8 +490,6 @@ class serveFlavorAction extends kalturaAction
 			KExternalErrors::dieError(KExternalErrors::ENTRY_NOT_FOUND);
 		}
 		
-		KalturaMonitorClient::initApiMonitor(false, 'extwidget.serveFlavor', $flavorAsset->getPartnerId());
-			
 		myPartnerUtils::enforceDelivery($entry, $flavorAsset, self::$preferredStorageId);
 		
 		$version = $this->getRequestParameter( "v" );

--- a/alpha/apps/kaltura/modules/extwidget/actions/serveIsmAction.class.php
+++ b/alpha/apps/kaltura/modules/extwidget/actions/serveIsmAction.class.php
@@ -37,8 +37,6 @@ class serveIsmAction extends sfAction
 						
 		$syncKey = $this->getFileSyncKey($objectId, $type);
 				
-		KalturaMonitorClient::initApiMonitor(false, 'extwidget.serveIsm', $this->entry->getPartnerId());
-		
 		myPartnerUtils::enforceDelivery($this->entry, $this->flavorAsset);
 		
 		if (!kFileSyncUtils::file_exists($syncKey, false))

--- a/alpha/apps/kaltura/modules/extwidget/actions/serveManifestAction.class.php
+++ b/alpha/apps/kaltura/modules/extwidget/actions/serveManifestAction.class.php
@@ -37,8 +37,6 @@ class serveManifestAction extends sfAction
 						
 		$syncKey = $this->getFileSyncKey($objectId, $type);
 		
-		KalturaMonitorClient::initApiMonitor(false, 'extwidget.serveManifest', $this->entry->getPartnerId());
-		
 		myPartnerUtils::enforceDelivery($this->entry, $this->flavorAsset);
 		
 		if (!kFileSyncUtils::file_exists($syncKey, false))

--- a/alpha/apps/kaltura/modules/extwidget/actions/serveMultiFileAction.class.php
+++ b/alpha/apps/kaltura/modules/extwidget/actions/serveMultiFileAction.class.php
@@ -26,10 +26,6 @@ class serveMultiFileAction extends sfAction
 		
 		// load file syncs
 		$fileSyncs = FileSyncPeer::retrieveByPks(explode(',', $fileSyncIds));
-		if ($fileSyncs)
-		{
-			KalturaMonitorClient::initApiMonitor(false, 'extwidget.serveMultiFile', $fileSyncs[0]->getPartnerId());
-		}
 		
 		// resolve file syncs
 		$resolvedFileSyncs = array();

--- a/alpha/apps/kaltura/modules/extwidget/actions/servefileAction.class.php
+++ b/alpha/apps/kaltura/modules/extwidget/actions/servefileAction.class.php
@@ -32,8 +32,6 @@ class servefileAction extends sfAction
 				KExternalErrors::dieError(KExternalErrors::FILE_NOT_FOUND);
 			}
 			
-			KalturaMonitorClient::initApiMonitor(false, 'extwidget.serveFile', $file_sync->getPartnerId());
-			
 			kDataCenterMgr::serveFileToRemoteDataCenter ( $file_sync , $hash, $file_name );
 			die();
 		}

--- a/alpha/apps/kaltura/modules/extwidget/actions/thumbnailAction.class.php
+++ b/alpha/apps/kaltura/modules/extwidget/actions/thumbnailAction.class.php
@@ -218,7 +218,6 @@ class thumbnailAction extends sfAction
 
 				if ($partner)
 				{
-					KalturaMonitorClient::initApiMonitor(false, 'extwidget.thumbnail', $partner->getId());
 					myPartnerUtils::blockInactivePartner($partner->getId());
 
 					if ($quality == 0)
@@ -318,7 +317,6 @@ class thumbnailAction extends sfAction
 			}
 		}
 
-		KalturaMonitorClient::initApiMonitor(false, 'extwidget.thumbnail', $entry->getPartnerId());
 		myPartnerUtils::blockInactivePartner($entry->getPartnerId());
 		
 		if ( $nearest_aspect_ratio )

--- a/alpha/apps/kaltura/modules/keditorservices/actions/flvclipperAction.class.php
+++ b/alpha/apps/kaltura/modules/keditorservices/actions/flvclipperAction.class.php
@@ -81,8 +81,6 @@ class flvclipperAction extends kalturaAction
 			KExternalErrors::dieError(KExternalErrors::ENTRY_NOT_FOUND);
 		}
 		
-		KalturaMonitorClient::initApiMonitor(false, 'keditorservices.flvclipper', $entry->getPartnerId());
-		
 		myPartnerUtils::blockInactivePartner($entry->getPartnerId());
 		
 		if(PermissionPeer::isValidForPartner(PermissionName::FEATURE_BLOCK_FLVCLIPPER_ACTION, $entry->getPartnerId()))

--- a/alpha/web/index.php
+++ b/alpha/web/index.php
@@ -208,7 +208,7 @@ function checkCache()
 				}
 				
 				require_once(dirname(__FILE__) . '/../apps/kaltura/lib/monitor/KalturaMonitorClient.php');
-				KalturaMonitorClient::initApiMonitor(true, 'extwidget.thumbnail', $renderer->partnerId);
+				KalturaMonitorClient::monitorApiStart(true, 'extwidget.thumbnail', $renderer->partnerId);
 				header("X-Kaltura:cached-dispatcher-thumb");
 				$renderer->output();
 				die;
@@ -247,7 +247,7 @@ function checkCache()
 		$renderer = apc_fetch($cacheKey);
 		if ($renderer)
 		{
-			KalturaMonitorClient::initApiMonitor(true, 'extwidget.serveFlavor', $renderer->partnerId);
+			KalturaMonitorClient::monitorApiStart(true, 'extwidget.serveFlavor', $renderer->partnerId);
 			header("X-Kaltura:cached-dispatcher");
 			$renderer->output();
 			die;


### PR DESCRIPTION
- generate events for cached playManifest, serveFlavor and thumbnail
- remove unneeded initApiMonitor calls (initialized by ps2 bootstrap)