### PR TITLE
PLAT-22565: simulive without specifying delivery profile - Old

### DIFF
--- a/alpha/apps/kaltura/lib/kSimuliveUtils.php
+++ b/alpha/apps/kaltura/lib/kSimuliveUtils.php
@@ -13,6 +13,8 @@ class kSimuliveUtils
 	const MINIMUM_TIME_TO_PLAYABLE_SEC = 18; // 3 * default segment duration
 	const SCHEDULE_TIME_OFFSET_URL_PARAM = 'timeOffset';
 	const SCHEDULE_TIME_URL_PARAM = 'time';
+	const DELIVERY_PROFILE_SYSTEM_NAME = 'simulive';
+	const SIMULIVE_PLAYBACK_PROTOCOLS = array(PlaybackProtocol::APPLE_HTTP);
 	/**
 	 * @param LiveEntry $entry
 	 * @param int $time
@@ -136,6 +138,23 @@ class kSimuliveUtils
 		}
 		// conditional cache should expire when event start
 		return max($playableStartTime - $nowEpoch, self::SIMULIVE_SCHEDULE_MARGIN);
+	}
+
+	/**
+	 * @param string partnerId
+	 * @return string
+	 * @throws Exception
+	 */
+	public static function getSimuliveDeliveryProfileId($partnerId)
+	{
+		$simuliveDeliveryProfiles = DeliveryProfilePeer::retrieveByPartnerAndSystemName($partnerId, self::DELIVERY_PROFILE_SYSTEM_NAME);
+		if (count($simuliveDeliveryProfiles))
+		{
+			/* @var $simuliveDeliveryProfile DeliveryProfile */
+			$simuliveDeliveryProfile = reset($simuliveDeliveryProfiles);
+			return $simuliveDeliveryProfile->getId();
+		}
+		return kConf::get('simulive_default_delivery_profile', 'live', null);
 	}
 
 }

--- a/alpha/apps/kaltura/lib/kSimuliveUtils.php
+++ b/alpha/apps/kaltura/lib/kSimuliveUtils.php
@@ -14,7 +14,7 @@ class kSimuliveUtils
 	const SCHEDULE_TIME_OFFSET_URL_PARAM = 'timeOffset';
 	const SCHEDULE_TIME_URL_PARAM = 'time';
 	const DELIVERY_PROFILE_SYSTEM_NAME = 'simulive';
-	const SIMULIVE_PLAYBACK_PROTOCOLS = array(PlaybackProtocol::APPLE_HTTP);
+
 	/**
 	 * @param LiveEntry $entry
 	 * @param int $time

--- a/alpha/apps/kaltura/modules/extwidget/actions/playManifestAction.class.php
+++ b/alpha/apps/kaltura/modules/extwidget/actions/playManifestAction.class.php
@@ -1524,11 +1524,9 @@ class playManifestAction extends kalturaAction
 		$this->entryId = $event->getSourceEntryId();
 		$sourceEntry = kSimuliveUtils::getSourceEntry($event);
 		$this->entry = $sourceEntry ? $sourceEntry : $this->entry;
-		$partner = $this->entry->getPartner();
-		$partnerHasDeliveryProfile = array_intersect(kSimuliveUtils::SIMULIVE_PLAYBACK_PROTOCOLS, array_keys($partner->getDeliveryProfileIds()));
-		if ($sourceEntry->getType() === entryType::MEDIA_CLIP && !$this->deliveryAttributes->getDeliveryProfileIds() && !$partnerHasDeliveryProfile)
+		if ($sourceEntry->getType() === entryType::MEDIA_CLIP && !$this->deliveryAttributes->getDeliveryProfileIds())
 		{
-			$this->deliveryAttributes->setDeliveryProfileIds(kSimuliveUtils::getSimuliveDeliveryProfileId($sourceEntry->getPartnerId()), false);
+			$this->deliveryAttributes->setDeliveryProfileIds(array(kSimuliveUtils::getSimuliveDeliveryProfileId($sourceEntry->getPartnerId())), false);
 		}
 	}
 }

--- a/alpha/lib/model/DeliveryProfileDynamicAttributes.php
+++ b/alpha/lib/model/DeliveryProfileDynamicAttributes.php
@@ -9,7 +9,7 @@
 class DeliveryProfileDynamicAttributes {
 	
 	/**
-	 * List of delivery profiles ids which should be enfroced due to an access control action
+	 * List of delivery profiles ids which should be enfroced
 	 * @var array
 	 */
 	protected $deliveryProfileIds = null;
@@ -367,7 +367,7 @@ class DeliveryProfileDynamicAttributes {
 	}
 
 	/**
-	 * @param string $deliveryProfileIds
+	 * @param array $deliveryProfileIds
 	 * @param bool $isBlockedList
 	 */
 	public function setDeliveryProfileIds($deliveryProfileIds, $isBlockedList) {

--- a/alpha/lib/model/DeliveryProfilePeer.php
+++ b/alpha/lib/model/DeliveryProfilePeer.php
@@ -872,5 +872,13 @@ class DeliveryProfilePeer extends BaseDeliveryProfilePeer {
 
 		return $deliveryIds;
 	}
+
+	public static function retrieveByPartnerAndSystemName($partnerId, $systemName)
+	{
+		$criteria = new Criteria();
+		$criteria->add(DeliveryProfilePeer::PARTNER_ID, $partnerId);
+		$criteria->add(DeliveryProfilePeer::SYSTEM_NAME, $systemName);
+		return DeliveryProfilePeer::doSelect($criteria);
+	}
 } // DeliveryProfilePeer
 


### PR DESCRIPTION
remove the Simulive code from playManifest:serveVodEntry and move the logic to execute (initEventData function)
add getSimuliveDeliveryProfileId to kSimuliveUtils
add "retrieveByPartnerAndSystemName" to DeliveryProfilePeer