### PR TITLE
PLAT-22565: simulive without specifying delivery profile

### DIFF
--- a/admin_console/forms/Delivery/DeliveryProfileVodPackagerPlayServer.php
+++ b/admin_console/forms/Delivery/DeliveryProfileVodPackagerPlayServer.php
@@ -12,7 +12,11 @@ class Form_Delivery_DeliveryProfileVodPackagerPlayServer extends Form_Delivery_D
 			'label'			=> 'Enable ad stitching:',
 		));
 
-		return array('adStitchingEnabled');
+		$this->addElement('checkbox', 'simuliveSupport', array(
+			'label'			=> 'Simulive support:',
+		));
+
+		return array('adStitchingEnabled', 'simuliveSupport');
 	}
 
 }

--- a/alpha/apps/kaltura/modules/extwidget/actions/playManifestAction.class.php
+++ b/alpha/apps/kaltura/modules/extwidget/actions/playManifestAction.class.php
@@ -881,7 +881,7 @@ class playManifestAction extends kalturaAction
 			$cdnHost = $this->cdnHost;
 			$cdnHostOnly = trim(preg_replace('#https?://#', '', $cdnHost), '/');
 			
-			$isLive = !$this->isSimuliveFlow();
+			$isLive = $this->isSimuliveFlow() ? false : $this->entry->getType() === entryType::LIVE_STREAM;
 			return DeliveryProfilePeer::getLocalDeliveryByPartner($this->entryId, $this->deliveryAttributes->getFormat(), 
 					$this->deliveryAttributes, $cdnHostOnly, true, $isLive);
 		}

--- a/alpha/lib/model/DeliveryProfile.php
+++ b/alpha/lib/model/DeliveryProfile.php
@@ -182,6 +182,16 @@ abstract class DeliveryProfile extends BaseDeliveryProfile implements IBaseObjec
 		return $this->getFromCustomData("adStitchingEnabled", null, false);
 	}
 
+	public function setSimuliveSupport($v)
+	{
+		$this->putInCustomData("simuliveSupport", $v);
+	}
+
+	public function getSimuliveSupport()
+	{
+		return $this->getFromCustomData("simuliveSupport", null, false);
+	}
+
 	/**
 	 * This function returns the tokenizer this delivery profile is working with
 	 * @return kUrlRecognizer

--- a/alpha/lib/model/DeliveryProfilePeer.php
+++ b/alpha/lib/model/DeliveryProfilePeer.php
@@ -179,9 +179,10 @@ class DeliveryProfilePeer extends BaseDeliveryProfilePeer {
 	 * @param DeliveryProfileDynamicAttributes $deliveryAttributes - constraints on delivery such as media protocol, flv support, etc..
 	 * @param string $cdnHost - The requesting CdnHost if known / preffered.
 	 * @param boolean $checkSecured whether we should prefer secured delivery profiles.
+	 * @param boolean $isLive whether the entry is live (simulive does not considered as live)
 	 * @return DeliveryProfile
 	 */
-	public static function getLocalDeliveryByPartner($entryId, $streamerType = PlaybackProtocol::HTTP, DeliveryProfileDynamicAttributes $deliveryAttributes, $cdnHost = null, $checkSecured = true)
+	public static function getLocalDeliveryByPartner($entryId, $streamerType = PlaybackProtocol::HTTP, DeliveryProfileDynamicAttributes $deliveryAttributes, $cdnHost = null, $checkSecured = true, $isLive = null)
 	{
 		$entry = entryPeer::retrieveByPK($entryId);
 		if(!$entry)
@@ -199,7 +200,7 @@ class DeliveryProfilePeer extends BaseDeliveryProfilePeer {
 		}
 
 		$isSecured = $checkSecured ? self::isSecured($partner, $entry) : false;
-		$isLive = $entry->getType() == entryType::LIVE_STREAM;
+		$isLive = is_null($isLive) ? $entry->getType() == entryType::LIVE_STREAM : $isLive;
 
 		$delivery = self::getDeliveryByPartner($entry, $partner, $streamerType, $deliveryAttributes, $cdnHost, $isSecured, $isLive);
 		if($delivery)

--- a/alpha/lib/model/DeliveryProfileVod.php
+++ b/alpha/lib/model/DeliveryProfileVod.php
@@ -568,5 +568,25 @@ abstract class DeliveryProfileVod extends DeliveryProfile {
 			$this->params->setUsePlayServer($this->getAdStitchingEnabled());
 		}
 	}
+
+	/**
+	 * returns whether the delivery profile supports the passed deliveryAttributes such as mediaProtocol, flv support, etc..
+	 * @param DeliveryProfileDynamicAttributes $deliveryAttributes
+	 */
+	public function supportsDeliveryDynamicAttributes(DeliveryProfileDynamicAttributes $deliveryAttributes)
+	{
+		$result = parent::supportsDeliveryDynamicAttributes($deliveryAttributes);
+		if ($result == self::DYNAMIC_ATTRIBUTES_NO_SUPPORT)
+		{
+			return $result;
+		}
+		/* @var $entry Baseentry */
+		$entry = $deliveryAttributes->getEntry();
+		if ($entry->getType() === entryType::LIVE_STREAM && !$this->getSimuliveSupport())
+		{
+			return self::DYNAMIC_ATTRIBUTES_NO_SUPPORT;
+		}
+		return $result;
+	}
 }
 

--- a/api_v3/lib/types/delivery/KalturaDeliveryProfileVodPackagerPlayServer.php
+++ b/api_v3/lib/types/delivery/KalturaDeliveryProfileVodPackagerPlayServer.php
@@ -10,9 +10,15 @@ class KalturaDeliveryProfileVodPackagerPlayServer extends KalturaDeliveryProfile
 	 */
 	public $adStitchingEnabled;
 
+	/**
+	 * @var bool
+	 */
+	public $simuliveSupport;
+
 	private static $map_between_objects = array
 	(
 		'adStitchingEnabled',
+		'simuliveSupport'
 	);
 
 	public function getMapBetweenObjects ( )


### PR DESCRIPTION
avoid override the entry & entryId in playManifest in case of Simulive (add servedEntryType instead)
remove the Simulive code from playManifest:serveVodEntry and move the logic to execute (initEventData function)
change DeliveryProfilePeer::getLocalDeliveryByPartner to receive isLive param
add supportsDeliveryDynamicAttributes to DeliveryProfileVod
add "simuliveSupport" to deliveryProfile custom data (and add checkbox to admin-console)
add "isSimuliveFlow" function to playManifestAction to detect if we're on flow of serving simulive