### PR TITLE
query cache: when caching use the hydration time

### DIFF
--- a/alpha/apps/kaltura/lib/cache/kQueryCache.php
+++ b/alpha/apps/kaltura/lib/cache/kQueryCache.php
@@ -363,6 +363,17 @@ class kQueryCache
 		$debugInfo .= "[$uniqueId]";
 		
 		$queryTime = time();
+		if (is_array($queryResult))
+		{
+			foreach ($queryResult as $object)
+			{
+				if (is_callable(array($object, 'getLastHydrateTime')) && $object->getLastHydrateTime())
+				{
+					$queryTime = min($queryTime, $object->getLastHydrateTime());
+				}
+			}
+		}
+
 		$key = $cacheKey->getKey();
 		KalturaLog::debug("kQueryCache: Updating memcache, key=$key queryTime=$queryTime");
 		self::$s_memcacheQueries->set($key, array($queryResult, $queryTime, $debugInfo), self::CACHED_QUERIES_EXPIRY_SEC);

--- a/alpha/apps/kaltura/lib/propel/php5/KalturaObjectBuilder.php
+++ b/alpha/apps/kaltura/lib/propel/php5/KalturaObjectBuilder.php
@@ -192,6 +192,8 @@ abstract class ".$this->getClassname()." extends ".ClassTools::classname($this->
 
 		$table = $this->getTable();
 		$customDataColumn = $table->getColumn(self::KALTURA_COLUMN_CUSTOM_DATA);
+
+		$script .= $newLine . '$this->last_hydrate_time = time();' . $newLine;
 		if($customDataColumn) {
 			$script .= $newLine . "// Nullify cached objects";
 			$script .= $newLine . "\$this->m_custom_data = null;" . $newLine;
@@ -893,6 +895,15 @@ abstract class ".$this->getClassname()." extends ".ClassTools::classname($this->
 		$customDataColumn = $table->getColumn(self::KALTURA_COLUMN_CUSTOM_DATA);
 		if($customDataColumn)
 			$this->addCustomDataMethods($script);
+
+		$script .= '
+	protected $last_hydrate_time;
+
+	public function getLastHydrateTime()
+	{
+		return $this->last_hydrate_time;
+	}
+';
 	}
 
 	/**

--- a/alpha/lib/model/om/BaseApiServer.php
+++ b/alpha/lib/model/om/BaseApiServer.php
@@ -398,6 +398,8 @@ abstract class BaseApiServer extends BaseObject  implements Persistent {
 	 */
 	public function hydrate($row, $startcol = 0, $rehydrate = false)
 	{
+		$this->last_hydrate_time = time();
+
 		try {
 
 			$this->id = ($row[$startcol + 0] !== null) ? (int) $row[$startcol + 0] : null;
@@ -1267,4 +1269,11 @@ abstract class BaseApiServer extends BaseObject  implements Persistent {
 	
 	/* ---------------------- CustomData functions ------------------------- */
 	
+	protected $last_hydrate_time;
+
+	public function getLastHydrateTime()
+	{
+		return $this->last_hydrate_time;
+	}
+
 } // BaseApiServer

--- a/alpha/lib/model/om/BaseAppToken.php
+++ b/alpha/lib/model/om/BaseAppToken.php
@@ -847,6 +847,8 @@ abstract class BaseAppToken extends BaseObject  implements Persistent {
 	 */
 	public function hydrate($row, $startcol = 0, $rehydrate = false)
 	{
+		$this->last_hydrate_time = time();
+
 		// Nullify cached objects
 		$this->m_custom_data = null;
 		
@@ -1945,4 +1947,11 @@ abstract class BaseAppToken extends BaseObject  implements Persistent {
 	
 	/* ---------------------- CustomData functions ------------------------- */
 	
+	protected $last_hydrate_time;
+
+	public function getLastHydrateTime()
+	{
+		return $this->last_hydrate_time;
+	}
+
 } // BaseAppToken

--- a/alpha/lib/model/om/BaseBatchJob.php
+++ b/alpha/lib/model/om/BaseBatchJob.php
@@ -1519,6 +1519,8 @@ abstract class BaseBatchJob extends BaseObject  implements Persistent {
 	 */
 	public function hydrate($row, $startcol = 0, $rehydrate = false)
 	{
+		$this->last_hydrate_time = time();
+
 		try {
 
 			$this->id = ($row[$startcol + 0] !== null) ? (int) $row[$startcol + 0] : null;
@@ -3132,4 +3134,11 @@ abstract class BaseBatchJob extends BaseObject  implements Persistent {
 	
 	/* ---------------------- CustomData functions ------------------------- */
 	
+	protected $last_hydrate_time;
+
+	public function getLastHydrateTime()
+	{
+		return $this->last_hydrate_time;
+	}
+
 } // BaseBatchJob

--- a/alpha/lib/model/om/BaseBatchJobLock.php
+++ b/alpha/lib/model/om/BaseBatchJobLock.php
@@ -1258,6 +1258,8 @@ abstract class BaseBatchJobLock extends BaseObject  implements Persistent {
 	 */
 	public function hydrate($row, $startcol = 0, $rehydrate = false)
 	{
+		$this->last_hydrate_time = time();
+
 		try {
 
 			$this->id = ($row[$startcol + 0] !== null) ? (int) $row[$startcol + 0] : null;
@@ -2544,4 +2546,11 @@ abstract class BaseBatchJobLock extends BaseObject  implements Persistent {
 	
 	/* ---------------------- CustomData functions ------------------------- */
 	
+	protected $last_hydrate_time;
+
+	public function getLastHydrateTime()
+	{
+		return $this->last_hydrate_time;
+	}
+
 } // BaseBatchJobLock

--- a/alpha/lib/model/om/BaseBatchJobLockSuspend.php
+++ b/alpha/lib/model/om/BaseBatchJobLockSuspend.php
@@ -1248,6 +1248,8 @@ abstract class BaseBatchJobLockSuspend extends BaseObject  implements Persistent
 	 */
 	public function hydrate($row, $startcol = 0, $rehydrate = false)
 	{
+		$this->last_hydrate_time = time();
+
 		try {
 
 			$this->id = ($row[$startcol + 0] !== null) ? (int) $row[$startcol + 0] : null;
@@ -2341,4 +2343,11 @@ abstract class BaseBatchJobLockSuspend extends BaseObject  implements Persistent
 	
 	/* ---------------------- CustomData functions ------------------------- */
 	
+	protected $last_hydrate_time;
+
+	public function getLastHydrateTime()
+	{
+		return $this->last_hydrate_time;
+	}
+
 } // BaseBatchJobLockSuspend

--- a/alpha/lib/model/om/BaseBatchJobLog.php
+++ b/alpha/lib/model/om/BaseBatchJobLog.php
@@ -2391,6 +2391,8 @@ abstract class BaseBatchJobLog extends BaseObject  implements Persistent {
 	 */
 	public function hydrate($row, $startcol = 0, $rehydrate = false)
 	{
+		$this->last_hydrate_time = time();
+
 		try {
 
 			$this->id = ($row[$startcol + 0] !== null) ? (int) $row[$startcol + 0] : null;
@@ -3665,6 +3667,13 @@ abstract class BaseBatchJobLog extends BaseObject  implements Persistent {
 		if ($deep) {
 		} // if ($deep)
 
+	}
+
+	protected $last_hydrate_time;
+
+	public function getLastHydrateTime()
+	{
+		return $this->last_hydrate_time;
 	}
 
 } // BaseBatchJobLog

--- a/alpha/lib/model/om/BaseBulkUploadResult.php
+++ b/alpha/lib/model/om/BaseBulkUploadResult.php
@@ -1601,6 +1601,8 @@ abstract class BaseBulkUploadResult extends BaseObject  implements Persistent {
 	 */
 	public function hydrate($row, $startcol = 0, $rehydrate = false)
 	{
+		$this->last_hydrate_time = time();
+
 		try {
 
 			$this->id = ($row[$startcol + 0] !== null) ? (int) $row[$startcol + 0] : null;
@@ -2794,4 +2796,11 @@ abstract class BaseBulkUploadResult extends BaseObject  implements Persistent {
 	
 	/* ---------------------- CustomData functions ------------------------- */
 	
+	protected $last_hydrate_time;
+
+	public function getLastHydrateTime()
+	{
+		return $this->last_hydrate_time;
+	}
+
 } // BaseBulkUploadResult

--- a/alpha/lib/model/om/BaseControlPanelCommand.php
+++ b/alpha/lib/model/om/BaseControlPanelCommand.php
@@ -908,6 +908,8 @@ abstract class BaseControlPanelCommand extends BaseObject  implements Persistent
 	 */
 	public function hydrate($row, $startcol = 0, $rehydrate = false)
 	{
+		$this->last_hydrate_time = time();
+
 		try {
 
 			$this->id = ($row[$startcol + 0] !== null) ? (int) $row[$startcol + 0] : null;
@@ -1746,6 +1748,13 @@ abstract class BaseControlPanelCommand extends BaseObject  implements Persistent
 		if ($deep) {
 		} // if ($deep)
 
+	}
+
+	protected $last_hydrate_time;
+
+	public function getLastHydrateTime()
+	{
+		return $this->last_hydrate_time;
 	}
 
 } // BaseControlPanelCommand

--- a/alpha/lib/model/om/BaseConversionParams.php
+++ b/alpha/lib/model/om/BaseConversionParams.php
@@ -827,6 +827,8 @@ abstract class BaseConversionParams extends BaseObject  implements Persistent {
 	 */
 	public function hydrate($row, $startcol = 0, $rehydrate = false)
 	{
+		$this->last_hydrate_time = time();
+
 		try {
 
 			$this->id = ($row[$startcol + 0] !== null) ? (int) $row[$startcol + 0] : null;
@@ -1828,4 +1830,11 @@ abstract class BaseConversionParams extends BaseObject  implements Persistent {
 	
 	/* ---------------------- CustomData functions ------------------------- */
 	
+	protected $last_hydrate_time;
+
+	public function getLastHydrateTime()
+	{
+		return $this->last_hydrate_time;
+	}
+
 } // BaseConversionParams

--- a/alpha/lib/model/om/BaseConversionProfile.php
+++ b/alpha/lib/model/om/BaseConversionProfile.php
@@ -817,6 +817,8 @@ abstract class BaseConversionProfile extends BaseObject  implements Persistent {
 	 */
 	public function hydrate($row, $startcol = 0, $rehydrate = false)
 	{
+		$this->last_hydrate_time = time();
+
 		try {
 
 			$this->id = ($row[$startcol + 0] !== null) ? (int) $row[$startcol + 0] : null;
@@ -1683,6 +1685,13 @@ abstract class BaseConversionProfile extends BaseObject  implements Persistent {
 		if ($deep) {
 		} // if ($deep)
 
+	}
+
+	protected $last_hydrate_time;
+
+	public function getLastHydrateTime()
+	{
+		return $this->last_hydrate_time;
 	}
 
 } // BaseConversionProfile

--- a/alpha/lib/model/om/BaseDeliveryProfile.php
+++ b/alpha/lib/model/om/BaseDeliveryProfile.php
@@ -982,6 +982,8 @@ abstract class BaseDeliveryProfile extends BaseObject  implements Persistent {
 	 */
 	public function hydrate($row, $startcol = 0, $rehydrate = false)
 	{
+		$this->last_hydrate_time = time();
+
 		// Nullify cached objects
 		$this->m_custom_data = null;
 		
@@ -2129,4 +2131,11 @@ abstract class BaseDeliveryProfile extends BaseObject  implements Persistent {
 	
 	/* ---------------------- CustomData functions ------------------------- */
 	
+	protected $last_hydrate_time;
+
+	public function getLastHydrateTime()
+	{
+		return $this->last_hydrate_time;
+	}
+
 } // BaseDeliveryProfile

--- a/alpha/lib/model/om/BaseDynamicEnum.php
+++ b/alpha/lib/model/om/BaseDynamicEnum.php
@@ -250,6 +250,8 @@ abstract class BaseDynamicEnum extends BaseObject  implements Persistent {
 	 */
 	public function hydrate($row, $startcol = 0, $rehydrate = false)
 	{
+		$this->last_hydrate_time = time();
+
 		try {
 
 			$this->id = ($row[$startcol + 0] !== null) ? (int) $row[$startcol + 0] : null;
@@ -966,6 +968,13 @@ abstract class BaseDynamicEnum extends BaseObject  implements Persistent {
 		if ($deep) {
 		} // if ($deep)
 
+	}
+
+	protected $last_hydrate_time;
+
+	public function getLastHydrateTime()
+	{
+		return $this->last_hydrate_time;
 	}
 
 } // BaseDynamicEnum

--- a/alpha/lib/model/om/BaseEmailIngestionProfile.php
+++ b/alpha/lib/model/om/BaseEmailIngestionProfile.php
@@ -697,6 +697,8 @@ abstract class BaseEmailIngestionProfile extends BaseObject  implements Persiste
 	 */
 	public function hydrate($row, $startcol = 0, $rehydrate = false)
 	{
+		$this->last_hydrate_time = time();
+
 		try {
 
 			$this->id = ($row[$startcol + 0] !== null) ? (int) $row[$startcol + 0] : null;
@@ -1650,4 +1652,11 @@ abstract class BaseEmailIngestionProfile extends BaseObject  implements Persiste
 	
 	/* ---------------------- CustomData functions ------------------------- */
 	
+	protected $last_hydrate_time;
+
+	public function getLastHydrateTime()
+	{
+		return $this->last_hydrate_time;
+	}
+
 } // BaseEmailIngestionProfile

--- a/alpha/lib/model/om/BaseEntryServerNode.php
+++ b/alpha/lib/model/om/BaseEntryServerNode.php
@@ -554,6 +554,8 @@ abstract class BaseEntryServerNode extends BaseObject  implements Persistent {
 	 */
 	public function hydrate($row, $startcol = 0, $rehydrate = false)
 	{
+		$this->last_hydrate_time = time();
+
 		// Nullify cached objects
 		$this->m_custom_data = null;
 		
@@ -1595,4 +1597,11 @@ abstract class BaseEntryServerNode extends BaseObject  implements Persistent {
 	
 	/* ---------------------- CustomData functions ------------------------- */
 	
+	protected $last_hydrate_time;
+
+	public function getLastHydrateTime()
+	{
+		return $this->last_hydrate_time;
+	}
+
 } // BaseEntryServerNode

--- a/alpha/lib/model/om/BaseFileAsset.php
+++ b/alpha/lib/model/om/BaseFileAsset.php
@@ -674,6 +674,8 @@ abstract class BaseFileAsset extends BaseObject  implements Persistent {
 	 */
 	public function hydrate($row, $startcol = 0, $rehydrate = false)
 	{
+		$this->last_hydrate_time = time();
+
 		try {
 
 			$this->id = ($row[$startcol + 0] !== null) ? (int) $row[$startcol + 0] : null;
@@ -1507,6 +1509,13 @@ abstract class BaseFileAsset extends BaseObject  implements Persistent {
 		if ($deep) {
 		} // if ($deep)
 
+	}
+
+	protected $last_hydrate_time;
+
+	public function getLastHydrateTime()
+	{
+		return $this->last_hydrate_time;
 	}
 
 } // BaseFileAsset

--- a/alpha/lib/model/om/BaseFileSync.php
+++ b/alpha/lib/model/om/BaseFileSync.php
@@ -1081,6 +1081,8 @@ abstract class BaseFileSync extends BaseObject  implements Persistent {
 	 */
 	public function hydrate($row, $startcol = 0, $rehydrate = false)
 	{
+		$this->last_hydrate_time = time();
+
 		// Nullify cached objects
 		$this->m_custom_data = null;
 		
@@ -2251,5 +2253,12 @@ abstract class BaseFileSync extends BaseObject  implements Persistent {
 	}
 	
 	/* ---------------------- CustomData functions ------------------------- */
-	
+
+	protected $last_hydrate_time;
+
+	public function getLastHydrateTime()
+	{
+		return $this->last_hydrate_time;
+	}
+
 } // BaseFileSync

--- a/alpha/lib/model/om/BaseKceInstallationError.php
+++ b/alpha/lib/model/om/BaseKceInstallationError.php
@@ -484,6 +484,8 @@ abstract class BaseKceInstallationError extends BaseObject  implements Persisten
 	 */
 	public function hydrate($row, $startcol = 0, $rehydrate = false)
 	{
+		$this->last_hydrate_time = time();
+
 		try {
 
 			$this->id = ($row[$startcol + 0] !== null) ? (int) $row[$startcol + 0] : null;
@@ -1272,6 +1274,13 @@ abstract class BaseKceInstallationError extends BaseObject  implements Persisten
 		if ($deep) {
 		} // if ($deep)
 
+	}
+
+	protected $last_hydrate_time;
+
+	public function getLastHydrateTime()
+	{
+		return $this->last_hydrate_time;
 	}
 
 } // BaseKceInstallationError

--- a/alpha/lib/model/om/BaseKshowKuser.php
+++ b/alpha/lib/model/om/BaseKshowKuser.php
@@ -307,6 +307,8 @@ abstract class BaseKshowKuser extends BaseObject  implements Persistent {
 	 */
 	public function hydrate($row, $startcol = 0, $rehydrate = false)
 	{
+		$this->last_hydrate_time = time();
+
 		try {
 
 			$this->kshow_id = ($row[$startcol + 0] !== null) ? (string) $row[$startcol + 0] : null;
@@ -1183,6 +1185,13 @@ abstract class BaseKshowKuser extends BaseObject  implements Persistent {
 
 			$this->akshow = null;
 			$this->akuser = null;
+	}
+
+	protected $last_hydrate_time;
+
+	public function getLastHydrateTime()
+	{
+		return $this->last_hydrate_time;
 	}
 
 } // BaseKshowKuser

--- a/alpha/lib/model/om/BaseKuserKgroup.php
+++ b/alpha/lib/model/om/BaseKuserKgroup.php
@@ -611,6 +611,8 @@ abstract class BaseKuserKgroup extends BaseObject  implements Persistent {
 	 */
 	public function hydrate($row, $startcol = 0, $rehydrate = false)
 	{
+		$this->last_hydrate_time = time();
+
 		// Nullify cached objects
 		$this->m_custom_data = null;
 		
@@ -1795,4 +1797,11 @@ abstract class BaseKuserKgroup extends BaseObject  implements Persistent {
 	
 	/* ---------------------- CustomData functions ------------------------- */
 	
+	protected $last_hydrate_time;
+
+	public function getLastHydrateTime()
+	{
+		return $this->last_hydrate_time;
+	}
+
 } // BaseKuserKgroup

--- a/alpha/lib/model/om/BaseKuserToUserRole.php
+++ b/alpha/lib/model/om/BaseKuserToUserRole.php
@@ -419,6 +419,8 @@ abstract class BaseKuserToUserRole extends BaseObject  implements Persistent {
 	 */
 	public function hydrate($row, $startcol = 0, $rehydrate = false)
 	{
+		$this->last_hydrate_time = time();
+
 		try {
 
 			$this->id = ($row[$startcol + 0] !== null) ? (int) $row[$startcol + 0] : null;
@@ -1310,6 +1312,13 @@ abstract class BaseKuserToUserRole extends BaseObject  implements Persistent {
 
 			$this->akuser = null;
 			$this->aUserRole = null;
+	}
+
+	protected $last_hydrate_time;
+
+	public function getLastHydrateTime()
+	{
+		return $this->last_hydrate_time;
 	}
 
 } // BaseKuserToUserRole

--- a/alpha/lib/model/om/BaseLiveChannelSegment.php
+++ b/alpha/lib/model/om/BaseLiveChannelSegment.php
@@ -873,6 +873,8 @@ abstract class BaseLiveChannelSegment extends BaseObject  implements Persistent 
 	 */
 	public function hydrate($row, $startcol = 0, $rehydrate = false)
 	{
+		$this->last_hydrate_time = time();
+
 		// Nullify cached objects
 		$this->m_custom_data = null;
 		
@@ -2597,4 +2599,11 @@ abstract class BaseLiveChannelSegment extends BaseObject  implements Persistent 
 	
 	/* ---------------------- CustomData functions ------------------------- */
 	
+	protected $last_hydrate_time;
+
+	public function getLastHydrateTime()
+	{
+		return $this->last_hydrate_time;
+	}
+
 } // BaseLiveChannelSegment

--- a/alpha/lib/model/om/BasePartner.php
+++ b/alpha/lib/model/om/BasePartner.php
@@ -1904,6 +1904,8 @@ abstract class BasePartner extends BaseObject  implements Persistent {
 	 */
 	public function hydrate($row, $startcol = 0, $rehydrate = false)
 	{
+		$this->last_hydrate_time = time();
+
 		// Nullify cached objects
 		$this->m_custom_data = null;
 		
@@ -3715,4 +3717,11 @@ abstract class BasePartner extends BaseObject  implements Persistent {
 	
 	/* ---------------------- CustomData functions ------------------------- */
 	
+	protected $last_hydrate_time;
+
+	public function getLastHydrateTime()
+	{
+		return $this->last_hydrate_time;
+	}
+
 } // BasePartner

--- a/alpha/lib/model/om/BasePartnerActivity.php
+++ b/alpha/lib/model/om/BasePartnerActivity.php
@@ -699,6 +699,8 @@ abstract class BasePartnerActivity extends BaseObject  implements Persistent {
 	 */
 	public function hydrate($row, $startcol = 0, $rehydrate = false)
 	{
+		$this->last_hydrate_time = time();
+
 		try {
 
 			$this->id = ($row[$startcol + 0] !== null) ? (int) $row[$startcol + 0] : null;
@@ -1535,6 +1537,13 @@ abstract class BasePartnerActivity extends BaseObject  implements Persistent {
 		if ($deep) {
 		} // if ($deep)
 
+	}
+
+	protected $last_hydrate_time;
+
+	public function getLastHydrateTime()
+	{
+		return $this->last_hydrate_time;
 	}
 
 } // BasePartnerActivity

--- a/alpha/lib/model/om/BasePartnerLoad.php
+++ b/alpha/lib/model/om/BasePartnerLoad.php
@@ -429,6 +429,8 @@ abstract class BasePartnerLoad extends BaseObject  implements Persistent {
 	 */
 	public function hydrate($row, $startcol = 0, $rehydrate = false)
 	{
+		$this->last_hydrate_time = time();
+
 		try {
 
 			$this->job_type = ($row[$startcol + 0] !== null) ? (int) $row[$startcol + 0] : null;
@@ -1272,4 +1274,11 @@ abstract class BasePartnerLoad extends BaseObject  implements Persistent {
 	
 	/* ---------------------- CustomData functions ------------------------- */
 	
+	protected $last_hydrate_time;
+
+	public function getLastHydrateTime()
+	{
+		return $this->last_hydrate_time;
+	}
+
 } // BasePartnerLoad

--- a/alpha/lib/model/om/BasePartnerStats.php
+++ b/alpha/lib/model/om/BasePartnerStats.php
@@ -866,6 +866,8 @@ abstract class BasePartnerStats extends BaseObject  implements Persistent {
 	 */
 	public function hydrate($row, $startcol = 0, $rehydrate = false)
 	{
+		$this->last_hydrate_time = time();
+
 		try {
 
 			$this->partner_id = ($row[$startcol + 0] !== null) ? (int) $row[$startcol + 0] : null;
@@ -1874,4 +1876,11 @@ abstract class BasePartnerStats extends BaseObject  implements Persistent {
 	
 	/* ---------------------- CustomData functions ------------------------- */
 	
+	protected $last_hydrate_time;
+
+	public function getLastHydrateTime()
+	{
+		return $this->last_hydrate_time;
+	}
+
 } // BasePartnerStats

--- a/alpha/lib/model/om/BasePermission.php
+++ b/alpha/lib/model/om/BasePermission.php
@@ -681,6 +681,8 @@ abstract class BasePermission extends BaseObject  implements Persistent {
 	 */
 	public function hydrate($row, $startcol = 0, $rehydrate = false)
 	{
+		$this->last_hydrate_time = time();
+
 		try {
 
 			$this->id = ($row[$startcol + 0] !== null) ? (int) $row[$startcol + 0] : null;
@@ -1874,4 +1876,11 @@ abstract class BasePermission extends BaseObject  implements Persistent {
 	
 	/* ---------------------- CustomData functions ------------------------- */
 	
+	protected $last_hydrate_time;
+
+	public function getLastHydrateTime()
+	{
+		return $this->last_hydrate_time;
+	}
+
 } // BasePermission

--- a/alpha/lib/model/om/BasePermissionItem.php
+++ b/alpha/lib/model/om/BasePermissionItem.php
@@ -681,6 +681,8 @@ abstract class BasePermissionItem extends BaseObject  implements Persistent {
 	 */
 	public function hydrate($row, $startcol = 0, $rehydrate = false)
 	{
+		$this->last_hydrate_time = time();
+
 		try {
 
 			$this->id = ($row[$startcol + 0] !== null) ? (int) $row[$startcol + 0] : null;
@@ -1874,4 +1876,11 @@ abstract class BasePermissionItem extends BaseObject  implements Persistent {
 	
 	/* ---------------------- CustomData functions ------------------------- */
 	
+	protected $last_hydrate_time;
+
+	public function getLastHydrateTime()
+	{
+		return $this->last_hydrate_time;
+	}
+
 } // BasePermissionItem

--- a/alpha/lib/model/om/BasePermissionToPermissionItem.php
+++ b/alpha/lib/model/om/BasePermissionToPermissionItem.php
@@ -419,6 +419,8 @@ abstract class BasePermissionToPermissionItem extends BaseObject  implements Per
 	 */
 	public function hydrate($row, $startcol = 0, $rehydrate = false)
 	{
+		$this->last_hydrate_time = time();
+
 		try {
 
 			$this->id = ($row[$startcol + 0] !== null) ? (int) $row[$startcol + 0] : null;
@@ -1310,6 +1312,13 @@ abstract class BasePermissionToPermissionItem extends BaseObject  implements Per
 
 			$this->aPermission = null;
 			$this->aPermissionItem = null;
+	}
+
+	protected $last_hydrate_time;
+
+	public function getLastHydrateTime()
+	{
+		return $this->last_hydrate_time;
 	}
 
 } // BasePermissionToPermissionItem

--- a/alpha/lib/model/om/BasePriorityGroup.php
+++ b/alpha/lib/model/om/BasePriorityGroup.php
@@ -557,6 +557,8 @@ abstract class BasePriorityGroup extends BaseObject  implements Persistent {
 	 */
 	public function hydrate($row, $startcol = 0, $rehydrate = false)
 	{
+		$this->last_hydrate_time = time();
+
 		try {
 
 			$this->id = ($row[$startcol + 0] !== null) ? (int) $row[$startcol + 0] : null;
@@ -1287,6 +1289,13 @@ abstract class BasePriorityGroup extends BaseObject  implements Persistent {
 		if ($deep) {
 		} // if ($deep)
 
+	}
+
+	protected $last_hydrate_time;
+
+	public function getLastHydrateTime()
+	{
+		return $this->last_hydrate_time;
 	}
 
 } // BasePriorityGroup

--- a/alpha/lib/model/om/BasePuserKuser.php
+++ b/alpha/lib/model/om/BasePuserKuser.php
@@ -648,6 +648,8 @@ abstract class BasePuserKuser extends BaseObject  implements Persistent {
 	 */
 	public function hydrate($row, $startcol = 0, $rehydrate = false)
 	{
+		$this->last_hydrate_time = time();
+
 		try {
 
 			$this->id = ($row[$startcol + 0] !== null) ? (int) $row[$startcol + 0] : null;
@@ -2127,4 +2129,11 @@ abstract class BasePuserKuser extends BaseObject  implements Persistent {
 	
 	/* ---------------------- CustomData functions ------------------------- */
 	
+	protected $last_hydrate_time;
+
+	public function getLastHydrateTime()
+	{
+		return $this->last_hydrate_time;
+	}
+
 } // BasePuserKuser

--- a/alpha/lib/model/om/BasePuserRole.php
+++ b/alpha/lib/model/om/BasePuserRole.php
@@ -571,6 +571,8 @@ abstract class BasePuserRole extends BaseObject  implements Persistent {
 	 */
 	public function hydrate($row, $startcol = 0, $rehydrate = false)
 	{
+		$this->last_hydrate_time = time();
+
 		try {
 
 			$this->id = ($row[$startcol + 0] !== null) ? (int) $row[$startcol + 0] : null;
@@ -1569,6 +1571,13 @@ abstract class BasePuserRole extends BaseObject  implements Persistent {
 			$this->akshow = null;
 			$this->aPuserKuserRelatedByPartnerId = null;
 			$this->aPuserKuserRelatedByPuserId = null;
+	}
+
+	protected $last_hydrate_time;
+
+	public function getLastHydrateTime()
+	{
+		return $this->last_hydrate_time;
 	}
 
 } // BasePuserRole

--- a/alpha/lib/model/om/BaseReport.php
+++ b/alpha/lib/model/om/BaseReport.php
@@ -654,6 +654,8 @@ abstract class BaseReport extends BaseObject  implements Persistent {
 	 */
 	public function hydrate($row, $startcol = 0, $rehydrate = false)
 	{
+		$this->last_hydrate_time = time();
+
 		try {
 
 			$this->id = ($row[$startcol + 0] !== null) ? (int) $row[$startcol + 0] : null;
@@ -1448,6 +1450,13 @@ abstract class BaseReport extends BaseObject  implements Persistent {
 		if ($deep) {
 		} // if ($deep)
 
+	}
+
+	protected $last_hydrate_time;
+
+	public function getLastHydrateTime()
+	{
+		return $this->last_hydrate_time;
 	}
 
 } // BaseReport

--- a/alpha/lib/model/om/BaseResponseProfile.php
+++ b/alpha/lib/model/om/BaseResponseProfile.php
@@ -554,6 +554,8 @@ abstract class BaseResponseProfile extends BaseObject  implements Persistent {
 	 */
 	public function hydrate($row, $startcol = 0, $rehydrate = false)
 	{
+		$this->last_hydrate_time = time();
+
 		// Nullify cached objects
 		$this->m_custom_data = null;
 		
@@ -1581,4 +1583,11 @@ abstract class BaseResponseProfile extends BaseObject  implements Persistent {
 	
 	/* ---------------------- CustomData functions ------------------------- */
 	
+	protected $last_hydrate_time;
+
+	public function getLastHydrateTime()
+	{
+		return $this->last_hydrate_time;
+	}
+
 } // BaseResponseProfile

--- a/alpha/lib/model/om/BaseScheduler.php
+++ b/alpha/lib/model/om/BaseScheduler.php
@@ -738,6 +738,8 @@ abstract class BaseScheduler extends BaseObject  implements Persistent {
 	 */
 	public function hydrate($row, $startcol = 0, $rehydrate = false)
 	{
+		$this->last_hydrate_time = time();
+
 		try {
 
 			$this->id = ($row[$startcol + 0] !== null) ? (int) $row[$startcol + 0] : null;
@@ -1492,6 +1494,13 @@ abstract class BaseScheduler extends BaseObject  implements Persistent {
 		if ($deep) {
 		} // if ($deep)
 
+	}
+
+	protected $last_hydrate_time;
+
+	public function getLastHydrateTime()
+	{
+		return $this->last_hydrate_time;
 	}
 
 } // BaseScheduler

--- a/alpha/lib/model/om/BaseSchedulerConfig.php
+++ b/alpha/lib/model/om/BaseSchedulerConfig.php
@@ -830,6 +830,8 @@ abstract class BaseSchedulerConfig extends BaseObject  implements Persistent {
 	 */
 	public function hydrate($row, $startcol = 0, $rehydrate = false)
 	{
+		$this->last_hydrate_time = time();
+
 		try {
 
 			$this->id = ($row[$startcol + 0] !== null) ? (int) $row[$startcol + 0] : null;
@@ -1644,6 +1646,13 @@ abstract class BaseSchedulerConfig extends BaseObject  implements Persistent {
 		if ($deep) {
 		} // if ($deep)
 
+	}
+
+	protected $last_hydrate_time;
+
+	public function getLastHydrateTime()
+	{
+		return $this->last_hydrate_time;
 	}
 
 } // BaseSchedulerConfig

--- a/alpha/lib/model/om/BaseSchedulerStatus.php
+++ b/alpha/lib/model/om/BaseSchedulerStatus.php
@@ -674,6 +674,8 @@ abstract class BaseSchedulerStatus extends BaseObject  implements Persistent {
 	 */
 	public function hydrate($row, $startcol = 0, $rehydrate = false)
 	{
+		$this->last_hydrate_time = time();
+
 		try {
 
 			$this->id = ($row[$startcol + 0] !== null) ? (int) $row[$startcol + 0] : null;
@@ -1440,6 +1442,13 @@ abstract class BaseSchedulerStatus extends BaseObject  implements Persistent {
 		if ($deep) {
 		} // if ($deep)
 
+	}
+
+	protected $last_hydrate_time;
+
+	public function getLastHydrateTime()
+	{
+		return $this->last_hydrate_time;
 	}
 
 } // BaseSchedulerStatus

--- a/alpha/lib/model/om/BaseSchedulerWorker.php
+++ b/alpha/lib/model/om/BaseSchedulerWorker.php
@@ -810,6 +810,8 @@ abstract class BaseSchedulerWorker extends BaseObject  implements Persistent {
 	 */
 	public function hydrate($row, $startcol = 0, $rehydrate = false)
 	{
+		$this->last_hydrate_time = time();
+
 		try {
 
 			$this->id = ($row[$startcol + 0] !== null) ? (int) $row[$startcol + 0] : null;
@@ -1588,6 +1590,13 @@ abstract class BaseSchedulerWorker extends BaseObject  implements Persistent {
 		if ($deep) {
 		} // if ($deep)
 
+	}
+
+	protected $last_hydrate_time;
+
+	public function getLastHydrateTime()
+	{
+		return $this->last_hydrate_time;
 	}
 
 } // BaseSchedulerWorker

--- a/alpha/lib/model/om/BaseServerNode.php
+++ b/alpha/lib/model/om/BaseServerNode.php
@@ -951,6 +951,8 @@ abstract class BaseServerNode extends BaseObject  implements Persistent {
 	 */
 	public function hydrate($row, $startcol = 0, $rehydrate = false)
 	{
+		$this->last_hydrate_time = time();
+
 		// Nullify cached objects
 		$this->m_custom_data = null;
 		
@@ -2078,4 +2080,11 @@ abstract class BaseServerNode extends BaseObject  implements Persistent {
 	
 	/* ---------------------- CustomData functions ------------------------- */
 	
+	protected $last_hydrate_time;
+
+	public function getLastHydrateTime()
+	{
+		return $this->last_hydrate_time;
+	}
+
 } // BaseServerNode

--- a/alpha/lib/model/om/BaseStorageProfile.php
+++ b/alpha/lib/model/om/BaseStorageProfile.php
@@ -1061,6 +1061,8 @@ abstract class BaseStorageProfile extends BaseObject  implements Persistent {
 	 */
 	public function hydrate($row, $startcol = 0, $rehydrate = false)
 	{
+		$this->last_hydrate_time = time();
+
 		// Nullify cached objects
 		$this->m_custom_data = null;
 		
@@ -2244,4 +2246,11 @@ abstract class BaseStorageProfile extends BaseObject  implements Persistent {
 	
 	/* ---------------------- CustomData functions ------------------------- */
 	
+	protected $last_hydrate_time;
+
+	public function getLastHydrateTime()
+	{
+		return $this->last_hydrate_time;
+	}
+
 } // BaseStorageProfile

--- a/alpha/lib/model/om/BaseSystemUser.php
+++ b/alpha/lib/model/om/BaseSystemUser.php
@@ -896,6 +896,8 @@ abstract class BaseSystemUser extends BaseObject  implements Persistent {
 	 */
 	public function hydrate($row, $startcol = 0, $rehydrate = false)
 	{
+		$this->last_hydrate_time = time();
+
 		try {
 
 			$this->id = ($row[$startcol + 0] !== null) ? (int) $row[$startcol + 0] : null;
@@ -1750,6 +1752,13 @@ abstract class BaseSystemUser extends BaseObject  implements Persistent {
 		if ($deep) {
 		} // if ($deep)
 
+	}
+
+	protected $last_hydrate_time;
+
+	public function getLastHydrateTime()
+	{
+		return $this->last_hydrate_time;
 	}
 
 } // BaseSystemUser

--- a/alpha/lib/model/om/BaseTrackEntry.php
+++ b/alpha/lib/model/om/BaseTrackEntry.php
@@ -944,6 +944,8 @@ abstract class BaseTrackEntry extends BaseObject  implements Persistent {
 	 */
 	public function hydrate($row, $startcol = 0, $rehydrate = false)
 	{
+		$this->last_hydrate_time = time();
+
 		try {
 
 			$this->id = ($row[$startcol + 0] !== null) ? (int) $row[$startcol + 0] : null;
@@ -1917,4 +1919,11 @@ abstract class BaseTrackEntry extends BaseObject  implements Persistent {
 	
 	/* ---------------------- CustomData functions ------------------------- */
 	
+	protected $last_hydrate_time;
+
+	public function getLastHydrateTime()
+	{
+		return $this->last_hydrate_time;
+	}
+
 } // BaseTrackEntry

--- a/alpha/lib/model/om/BaseUploadToken.php
+++ b/alpha/lib/model/om/BaseUploadToken.php
@@ -826,6 +826,8 @@ abstract class BaseUploadToken extends BaseObject  implements Persistent {
 	 */
 	public function hydrate($row, $startcol = 0, $rehydrate = false)
 	{
+		$this->last_hydrate_time = time();
+
 		try {
 
 			$this->id = ($row[$startcol + 0] !== null) ? (string) $row[$startcol + 0] : null;
@@ -1780,6 +1782,13 @@ abstract class BaseUploadToken extends BaseObject  implements Persistent {
 		} // if ($deep)
 
 			$this->akuser = null;
+	}
+
+	protected $last_hydrate_time;
+
+	public function getLastHydrateTime()
+	{
+		return $this->last_hydrate_time;
 	}
 
 } // BaseUploadToken

--- a/alpha/lib/model/om/BaseUserEntry.php
+++ b/alpha/lib/model/om/BaseUserEntry.php
@@ -650,6 +650,8 @@ abstract class BaseUserEntry extends BaseObject  implements Persistent {
 	 */
 	public function hydrate($row, $startcol = 0, $rehydrate = false)
 	{
+		$this->last_hydrate_time = time();
+
 		// Nullify cached objects
 		$this->m_custom_data = null;
 		
@@ -1850,4 +1852,11 @@ abstract class BaseUserEntry extends BaseObject  implements Persistent {
 	
 	/* ---------------------- CustomData functions ------------------------- */
 	
+	protected $last_hydrate_time;
+
+	public function getLastHydrateTime()
+	{
+		return $this->last_hydrate_time;
+	}
+
 } // BaseUserEntry

--- a/alpha/lib/model/om/BaseUserLoginData.php
+++ b/alpha/lib/model/om/BaseUserLoginData.php
@@ -691,6 +691,8 @@ abstract class BaseUserLoginData extends BaseObject  implements Persistent {
 	 */
 	public function hydrate($row, $startcol = 0, $rehydrate = false)
 	{
+		$this->last_hydrate_time = time();
+
 		try {
 
 			$this->id = ($row[$startcol + 0] !== null) ? (int) $row[$startcol + 0] : null;
@@ -1632,4 +1634,11 @@ abstract class BaseUserLoginData extends BaseObject  implements Persistent {
 	
 	/* ---------------------- CustomData functions ------------------------- */
 	
+	protected $last_hydrate_time;
+
+	public function getLastHydrateTime()
+	{
+		return $this->last_hydrate_time;
+	}
+
 } // BaseUserLoginData

--- a/alpha/lib/model/om/BaseUserRole.php
+++ b/alpha/lib/model/om/BaseUserRole.php
@@ -707,6 +707,8 @@ abstract class BaseUserRole extends BaseObject  implements Persistent {
 	 */
 	public function hydrate($row, $startcol = 0, $rehydrate = false)
 	{
+		$this->last_hydrate_time = time();
+
 		try {
 
 			$this->id = ($row[$startcol + 0] !== null) ? (int) $row[$startcol + 0] : null;
@@ -1900,4 +1902,11 @@ abstract class BaseUserRole extends BaseObject  implements Persistent {
 	
 	/* ---------------------- CustomData functions ------------------------- */
 	
+	protected $last_hydrate_time;
+
+	public function getLastHydrateTime()
+	{
+		return $this->last_hydrate_time;
+	}
+
 } // BaseUserRole

--- a/alpha/lib/model/om/BaseWidgetLog.php
+++ b/alpha/lib/model/om/BaseWidgetLog.php
@@ -895,6 +895,8 @@ abstract class BaseWidgetLog extends BaseObject  implements Persistent {
 	 */
 	public function hydrate($row, $startcol = 0, $rehydrate = false)
 	{
+		$this->last_hydrate_time = time();
+
 		try {
 
 			$this->id = ($row[$startcol + 0] !== null) ? (int) $row[$startcol + 0] : null;
@@ -1851,6 +1853,13 @@ abstract class BaseWidgetLog extends BaseObject  implements Persistent {
 		} // if ($deep)
 
 			$this->aentry = null;
+	}
+
+	protected $last_hydrate_time;
+
+	public function getLastHydrateTime()
+	{
+		return $this->last_hydrate_time;
 	}
 
 } // BaseWidgetLog

--- a/alpha/lib/model/om/BaseaccessControl.php
+++ b/alpha/lib/model/om/BaseaccessControl.php
@@ -1002,6 +1002,8 @@ abstract class BaseaccessControl extends BaseObject  implements Persistent {
 	 */
 	public function hydrate($row, $startcol = 0, $rehydrate = false)
 	{
+		$this->last_hydrate_time = time();
+
 		// Nullify cached objects
 		$this->m_custom_data = null;
 		
@@ -2137,4 +2139,11 @@ abstract class BaseaccessControl extends BaseObject  implements Persistent {
 	
 	/* ---------------------- CustomData functions ------------------------- */
 	
+	protected $last_hydrate_time;
+
+	public function getLastHydrateTime()
+	{
+		return $this->last_hydrate_time;
+	}
+
 } // BaseaccessControl

--- a/alpha/lib/model/om/Baseasset.php
+++ b/alpha/lib/model/om/Baseasset.php
@@ -1241,6 +1241,8 @@ abstract class Baseasset extends BaseObject  implements Persistent {
 	 */
 	public function hydrate($row, $startcol = 0, $rehydrate = false)
 	{
+		$this->last_hydrate_time = time();
+
 		// Nullify cached objects
 		$this->m_custom_data = null;
 		
@@ -2908,4 +2910,11 @@ abstract class Baseasset extends BaseObject  implements Persistent {
 	
 	/* ---------------------- CustomData functions ------------------------- */
 	
+	protected $last_hydrate_time;
+
+	public function getLastHydrateTime()
+	{
+		return $this->last_hydrate_time;
+	}
+
 } // Baseasset

--- a/alpha/lib/model/om/BaseassetParams.php
+++ b/alpha/lib/model/om/BaseassetParams.php
@@ -1763,6 +1763,8 @@ abstract class BaseassetParams extends BaseObject  implements Persistent {
 	 */
 	public function hydrate($row, $startcol = 0, $rehydrate = false)
 	{
+		$this->last_hydrate_time = time();
+
 		// Nullify cached objects
 		$this->m_custom_data = null;
 		
@@ -3621,4 +3623,11 @@ abstract class BaseassetParams extends BaseObject  implements Persistent {
 	
 	/* ---------------------- CustomData functions ------------------------- */
 	
+	protected $last_hydrate_time;
+
+	public function getLastHydrateTime()
+	{
+		return $this->last_hydrate_time;
+	}
+
 } // BaseassetParams

--- a/alpha/lib/model/om/BaseassetParamsOutput.php
+++ b/alpha/lib/model/om/BaseassetParamsOutput.php
@@ -1845,6 +1845,8 @@ abstract class BaseassetParamsOutput extends BaseObject  implements Persistent {
 	 */
 	public function hydrate($row, $startcol = 0, $rehydrate = false)
 	{
+		$this->last_hydrate_time = time();
+
 		try {
 
 			$this->id = ($row[$startcol + 0] !== null) ? (int) $row[$startcol + 0] : null;
@@ -3324,4 +3326,11 @@ abstract class BaseassetParamsOutput extends BaseObject  implements Persistent {
 	
 	/* ---------------------- CustomData functions ------------------------- */
 	
+	protected $last_hydrate_time;
+
+	public function getLastHydrateTime()
+	{
+		return $this->last_hydrate_time;
+	}
+
 } // BaseassetParamsOutput

--- a/alpha/lib/model/om/BaseblockedEmail.php
+++ b/alpha/lib/model/om/BaseblockedEmail.php
@@ -133,6 +133,8 @@ abstract class BaseblockedEmail extends BaseObject  implements Persistent {
 	 */
 	public function hydrate($row, $startcol = 0, $rehydrate = false)
 	{
+		$this->last_hydrate_time = time();
+
 		try {
 
 			$this->email = ($row[$startcol + 0] !== null) ? (string) $row[$startcol + 0] : null;
@@ -808,6 +810,13 @@ abstract class BaseblockedEmail extends BaseObject  implements Persistent {
 		if ($deep) {
 		} // if ($deep)
 
+	}
+
+	protected $last_hydrate_time;
+
+	public function getLastHydrateTime()
+	{
+		return $this->last_hydrate_time;
 	}
 
 } // BaseblockedEmail

--- a/alpha/lib/model/om/Basecategory.php
+++ b/alpha/lib/model/om/Basecategory.php
@@ -1663,6 +1663,8 @@ abstract class Basecategory extends BaseObject  implements Persistent {
 	 */
 	public function hydrate($row, $startcol = 0, $rehydrate = false)
 	{
+		$this->last_hydrate_time = time();
+
 		try {
 
 			$this->id = ($row[$startcol + 0] !== null) ? (int) $row[$startcol + 0] : null;
@@ -3119,4 +3121,11 @@ abstract class Basecategory extends BaseObject  implements Persistent {
 	
 	/* ---------------------- CustomData functions ------------------------- */
 	
+	protected $last_hydrate_time;
+
+	public function getLastHydrateTime()
+	{
+		return $this->last_hydrate_time;
+	}
+
 } // Basecategory

--- a/alpha/lib/model/om/BasecategoryEntry.php
+++ b/alpha/lib/model/om/BasecategoryEntry.php
@@ -658,6 +658,8 @@ abstract class BasecategoryEntry extends BaseObject  implements Persistent {
 	 */
 	public function hydrate($row, $startcol = 0, $rehydrate = false)
 	{
+		$this->last_hydrate_time = time();
+
 		// Nullify cached objects
 		$this->m_custom_data = null;
 		
@@ -1720,4 +1722,11 @@ abstract class BasecategoryEntry extends BaseObject  implements Persistent {
 	
 	/* ---------------------- CustomData functions ------------------------- */
 	
+	protected $last_hydrate_time;
+
+	public function getLastHydrateTime()
+	{
+		return $this->last_hydrate_time;
+	}
+
 } // BasecategoryEntry

--- a/alpha/lib/model/om/BasecategoryKuser.php
+++ b/alpha/lib/model/om/BasecategoryKuser.php
@@ -806,6 +806,8 @@ abstract class BasecategoryKuser extends BaseObject  implements Persistent {
 	 */
 	public function hydrate($row, $startcol = 0, $rehydrate = false)
 	{
+		$this->last_hydrate_time = time();
+
 		try {
 
 			$this->id = ($row[$startcol + 0] !== null) ? (int) $row[$startcol + 0] : null;
@@ -1951,4 +1953,11 @@ abstract class BasecategoryKuser extends BaseObject  implements Persistent {
 	
 	/* ---------------------- CustomData functions ------------------------- */
 	
+	protected $last_hydrate_time;
+
+	public function getLastHydrateTime()
+	{
+		return $this->last_hydrate_time;
+	}
+
 } // BasecategoryKuser

--- a/alpha/lib/model/om/Basecomment.php
+++ b/alpha/lib/model/om/Basecomment.php
@@ -530,6 +530,8 @@ abstract class Basecomment extends BaseObject  implements Persistent {
 	 */
 	public function hydrate($row, $startcol = 0, $rehydrate = false)
 	{
+		$this->last_hydrate_time = time();
+
 		try {
 
 			$this->id = ($row[$startcol + 0] !== null) ? (int) $row[$startcol + 0] : null;
@@ -1374,6 +1376,13 @@ abstract class Basecomment extends BaseObject  implements Persistent {
 		} // if ($deep)
 
 			$this->akuser = null;
+	}
+
+	protected $last_hydrate_time;
+
+	public function getLastHydrateTime()
+	{
+		return $this->last_hydrate_time;
 	}
 
 } // Basecomment

--- a/alpha/lib/model/om/Baseconversion.php
+++ b/alpha/lib/model/om/Baseconversion.php
@@ -839,6 +839,8 @@ abstract class Baseconversion extends BaseObject  implements Persistent {
 	 */
 	public function hydrate($row, $startcol = 0, $rehydrate = false)
 	{
+		$this->last_hydrate_time = time();
+
 		try {
 
 			$this->id = ($row[$startcol + 0] !== null) ? (int) $row[$startcol + 0] : null;
@@ -1795,6 +1797,13 @@ abstract class Baseconversion extends BaseObject  implements Persistent {
 		} // if ($deep)
 
 			$this->aentry = null;
+	}
+
+	protected $last_hydrate_time;
+
+	public function getLastHydrateTime()
+	{
+		return $this->last_hydrate_time;
 	}
 
 } // Baseconversion

--- a/alpha/lib/model/om/BaseconversionProfile2.php
+++ b/alpha/lib/model/om/BaseconversionProfile2.php
@@ -1177,6 +1177,8 @@ abstract class BaseconversionProfile2 extends BaseObject  implements Persistent 
 	 */
 	public function hydrate($row, $startcol = 0, $rehydrate = false)
 	{
+		$this->last_hydrate_time = time();
+
 		// Nullify cached objects
 		$this->m_custom_data = null;
 		
@@ -2588,4 +2590,11 @@ abstract class BaseconversionProfile2 extends BaseObject  implements Persistent 
 	
 	/* ---------------------- CustomData functions ------------------------- */
 	
+	protected $last_hydrate_time;
+
+	public function getLastHydrateTime()
+	{
+		return $this->last_hydrate_time;
+	}
+
 } // BaseconversionProfile2

--- a/alpha/lib/model/om/Baseentry.php
+++ b/alpha/lib/model/om/Baseentry.php
@@ -2829,6 +2829,8 @@ abstract class Baseentry extends BaseObject  implements Persistent {
 	 */
 	public function hydrate($row, $startcol = 0, $rehydrate = false)
 	{
+		$this->last_hydrate_time = time();
+
 		// Nullify cached objects
 		$this->m_custom_data = null;
 		
@@ -7231,4 +7233,11 @@ abstract class Baseentry extends BaseObject  implements Persistent {
 	
 	/* ---------------------- CustomData functions ------------------------- */
 	
+	protected $last_hydrate_time;
+
+	public function getLastHydrateTime()
+	{
+		return $this->last_hydrate_time;
+	}
+
 } // Baseentry

--- a/alpha/lib/model/om/Basefavorite.php
+++ b/alpha/lib/model/om/Basefavorite.php
@@ -298,6 +298,8 @@ abstract class Basefavorite extends BaseObject  implements Persistent {
 	 */
 	public function hydrate($row, $startcol = 0, $rehydrate = false)
 	{
+		$this->last_hydrate_time = time();
+
 		try {
 
 			$this->kuser_id = ($row[$startcol + 0] !== null) ? (int) $row[$startcol + 0] : null;
@@ -1104,6 +1106,13 @@ abstract class Basefavorite extends BaseObject  implements Persistent {
 		} // if ($deep)
 
 			$this->akuser = null;
+	}
+
+	protected $last_hydrate_time;
+
+	public function getLastHydrateTime()
+	{
+		return $this->last_hydrate_time;
 	}
 
 } // Basefavorite

--- a/alpha/lib/model/om/Baseflag.php
+++ b/alpha/lib/model/om/Baseflag.php
@@ -471,6 +471,8 @@ abstract class Baseflag extends BaseObject  implements Persistent {
 	 */
 	public function hydrate($row, $startcol = 0, $rehydrate = false)
 	{
+		$this->last_hydrate_time = time();
+
 		try {
 
 			$this->id = ($row[$startcol + 0] !== null) ? (int) $row[$startcol + 0] : null;
@@ -1315,6 +1317,13 @@ abstract class Baseflag extends BaseObject  implements Persistent {
 		} // if ($deep)
 
 			$this->akuser = null;
+	}
+
+	protected $last_hydrate_time;
+
+	public function getLastHydrateTime()
+	{
+		return $this->last_hydrate_time;
 	}
 
 } // Baseflag

--- a/alpha/lib/model/om/BaseflavorParamsConversionProfile.php
+++ b/alpha/lib/model/om/BaseflavorParamsConversionProfile.php
@@ -689,6 +689,8 @@ abstract class BaseflavorParamsConversionProfile extends BaseObject  implements 
 	 */
 	public function hydrate($row, $startcol = 0, $rehydrate = false)
 	{
+		$this->last_hydrate_time = time();
+
 		try {
 
 			$this->id = ($row[$startcol + 0] !== null) ? (int) $row[$startcol + 0] : null;
@@ -1798,4 +1800,11 @@ abstract class BaseflavorParamsConversionProfile extends BaseObject  implements 
 	
 	/* ---------------------- CustomData functions ------------------------- */
 	
+	protected $last_hydrate_time;
+
+	public function getLastHydrateTime()
+	{
+		return $this->last_hydrate_time;
+	}
+
 } // BaseflavorParamsConversionProfile

--- a/alpha/lib/model/om/BaseflickrToken.php
+++ b/alpha/lib/model/om/BaseflickrToken.php
@@ -544,6 +544,8 @@ abstract class BaseflickrToken extends BaseObject  implements Persistent {
 	 */
 	public function hydrate($row, $startcol = 0, $rehydrate = false)
 	{
+		$this->last_hydrate_time = time();
+
 		try {
 
 			$this->kalt_token = ($row[$startcol + 0] !== null) ? (string) $row[$startcol + 0] : null;
@@ -1321,6 +1323,13 @@ abstract class BaseflickrToken extends BaseObject  implements Persistent {
 		if ($deep) {
 		} // if ($deep)
 
+	}
+
+	protected $last_hydrate_time;
+
+	public function getLastHydrateTime()
+	{
+		return $this->last_hydrate_time;
 	}
 
 } // BaseflickrToken

--- a/alpha/lib/model/om/BaseinvalidSession.php
+++ b/alpha/lib/model/om/BaseinvalidSession.php
@@ -443,6 +443,8 @@ abstract class BaseinvalidSession extends BaseObject  implements Persistent {
 	 */
 	public function hydrate($row, $startcol = 0, $rehydrate = false)
 	{
+		$this->last_hydrate_time = time();
+
 		try {
 
 			$this->id = ($row[$startcol + 0] !== null) ? (int) $row[$startcol + 0] : null;
@@ -1125,6 +1127,13 @@ abstract class BaseinvalidSession extends BaseObject  implements Persistent {
 		if ($deep) {
 		} // if ($deep)
 
+	}
+
+	protected $last_hydrate_time;
+
+	public function getLastHydrateTime()
+	{
+		return $this->last_hydrate_time;
 	}
 
 } // BaseinvalidSession

--- a/alpha/lib/model/om/Basekshow.php
+++ b/alpha/lib/model/om/Basekshow.php
@@ -2483,6 +2483,8 @@ abstract class Basekshow extends BaseObject  implements Persistent {
 	 */
 	public function hydrate($row, $startcol = 0, $rehydrate = false)
 	{
+		$this->last_hydrate_time = time();
+
 		// Nullify cached objects
 		$this->m_custom_data = null;
 		
@@ -5643,4 +5645,11 @@ abstract class Basekshow extends BaseObject  implements Persistent {
 	
 	/* ---------------------- CustomData functions ------------------------- */
 	
+	protected $last_hydrate_time;
+
+	public function getLastHydrateTime()
+	{
+		return $this->last_hydrate_time;
+	}
+
 } // Basekshow

--- a/alpha/lib/model/om/Basekuser.php
+++ b/alpha/lib/model/om/Basekuser.php
@@ -2327,6 +2327,8 @@ abstract class Basekuser extends BaseObject  implements Persistent {
 	 */
 	public function hydrate($row, $startcol = 0, $rehydrate = false)
 	{
+		$this->last_hydrate_time = time();
+
 		// Nullify cached objects
 		$this->m_custom_data = null;
 		
@@ -7245,4 +7247,11 @@ abstract class Basekuser extends BaseObject  implements Persistent {
 	
 	/* ---------------------- CustomData functions ------------------------- */
 	
+	protected $last_hydrate_time;
+
+	public function getLastHydrateTime()
+	{
+		return $this->last_hydrate_time;
+	}
+
 } // Basekuser

--- a/alpha/lib/model/om/Basekvote.php
+++ b/alpha/lib/model/om/Basekvote.php
@@ -629,6 +629,8 @@ abstract class Basekvote extends BaseObject  implements Persistent {
 	 */
 	public function hydrate($row, $startcol = 0, $rehydrate = false)
 	{
+		$this->last_hydrate_time = time();
+
 		// Nullify cached objects
 		$this->m_custom_data = null;
 		
@@ -1864,4 +1866,11 @@ abstract class Basekvote extends BaseObject  implements Persistent {
 	
 	/* ---------------------- CustomData functions ------------------------- */
 	
+	protected $last_hydrate_time;
+
+	public function getLastHydrateTime()
+	{
+		return $this->last_hydrate_time;
+	}
+
 } // Basekvote

--- a/alpha/lib/model/om/BasemediaInfo.php
+++ b/alpha/lib/model/om/BasemediaInfo.php
@@ -1577,6 +1577,8 @@ abstract class BasemediaInfo extends BaseObject  implements Persistent {
 	 */
 	public function hydrate($row, $startcol = 0, $rehydrate = false)
 	{
+		$this->last_hydrate_time = time();
+
 		try {
 
 			$this->id = ($row[$startcol + 0] !== null) ? (int) $row[$startcol + 0] : null;
@@ -2886,4 +2888,11 @@ abstract class BasemediaInfo extends BaseObject  implements Persistent {
 	
 	/* ---------------------- CustomData functions ------------------------- */
 	
+	protected $last_hydrate_time;
+
+	public function getLastHydrateTime()
+	{
+		return $this->last_hydrate_time;
+	}
+
 } // BasemediaInfo

--- a/alpha/lib/model/om/Basemoderation.php
+++ b/alpha/lib/model/om/Basemoderation.php
@@ -722,6 +722,8 @@ abstract class Basemoderation extends BaseObject  implements Persistent {
 	 */
 	public function hydrate($row, $startcol = 0, $rehydrate = false)
 	{
+		$this->last_hydrate_time = time();
+
 		try {
 
 			$this->id = ($row[$startcol + 0] !== null) ? (int) $row[$startcol + 0] : null;
@@ -1642,6 +1644,13 @@ abstract class Basemoderation extends BaseObject  implements Persistent {
 		} // if ($deep)
 
 			$this->akuser = null;
+	}
+
+	protected $last_hydrate_time;
+
+	public function getLastHydrateTime()
+	{
+		return $this->last_hydrate_time;
 	}
 
 } // Basemoderation

--- a/alpha/lib/model/om/BasemoderationFlag.php
+++ b/alpha/lib/model/om/BasemoderationFlag.php
@@ -662,6 +662,8 @@ abstract class BasemoderationFlag extends BaseObject  implements Persistent {
 	 */
 	public function hydrate($row, $startcol = 0, $rehydrate = false)
 	{
+		$this->last_hydrate_time = time();
+
 		try {
 
 			$this->id = ($row[$startcol + 0] !== null) ? (int) $row[$startcol + 0] : null;
@@ -1692,6 +1694,13 @@ abstract class BasemoderationFlag extends BaseObject  implements Persistent {
 			$this->akuserRelatedByKuserId = null;
 			$this->aentry = null;
 			$this->akuserRelatedByFlaggedKuserId = null;
+	}
+
+	protected $last_hydrate_time;
+
+	public function getLastHydrateTime()
+	{
+		return $this->last_hydrate_time;
 	}
 
 } // BasemoderationFlag

--- a/alpha/lib/model/om/BaseroughcutEntry.php
+++ b/alpha/lib/model/om/BaseroughcutEntry.php
@@ -584,6 +584,8 @@ abstract class BaseroughcutEntry extends BaseObject  implements Persistent {
 	 */
 	public function hydrate($row, $startcol = 0, $rehydrate = false)
 	{
+		$this->last_hydrate_time = time();
+
 		try {
 
 			$this->id = ($row[$startcol + 0] !== null) ? (int) $row[$startcol + 0] : null;
@@ -1590,6 +1592,13 @@ abstract class BaseroughcutEntry extends BaseObject  implements Persistent {
 			$this->aentryRelatedByRoughcutId = null;
 			$this->akshow = null;
 			$this->aentryRelatedByEntryId = null;
+	}
+
+	protected $last_hydrate_time;
+
+	public function getLastHydrateTime()
+	{
+		return $this->last_hydrate_time;
 	}
 
 } // BaseroughcutEntry

--- a/alpha/lib/model/om/BasesyndicationFeed.php
+++ b/alpha/lib/model/om/BasesyndicationFeed.php
@@ -1357,6 +1357,8 @@ abstract class BasesyndicationFeed extends BaseObject  implements Persistent {
 	 */
 	public function hydrate($row, $startcol = 0, $rehydrate = false)
 	{
+		$this->last_hydrate_time = time();
+
 		try {
 
 			$this->id = ($row[$startcol + 0] !== null) ? (string) $row[$startcol + 0] : null;
@@ -2512,4 +2514,11 @@ abstract class BasesyndicationFeed extends BaseObject  implements Persistent {
 	
 	/* ---------------------- CustomData functions ------------------------- */
 	
+	protected $last_hydrate_time;
+
+	public function getLastHydrateTime()
+	{
+		return $this->last_hydrate_time;
+	}
+
 } // BasesyndicationFeed

--- a/alpha/lib/model/om/BaseuiConf.php
+++ b/alpha/lib/model/om/BaseuiConf.php
@@ -1110,6 +1110,8 @@ abstract class BaseuiConf extends BaseObject  implements Persistent {
 	 */
 	public function hydrate($row, $startcol = 0, $rehydrate = false)
 	{
+		$this->last_hydrate_time = time();
+
 		// Nullify cached objects
 		$this->m_custom_data = null;
 		
@@ -2592,4 +2594,11 @@ abstract class BaseuiConf extends BaseObject  implements Persistent {
 	
 	/* ---------------------- CustomData functions ------------------------- */
 	
+	protected $last_hydrate_time;
+
+	public function getLastHydrateTime()
+	{
+		return $this->last_hydrate_time;
+	}
+
 } // BaseuiConf

--- a/alpha/lib/model/om/Basewidget.php
+++ b/alpha/lib/model/om/Basewidget.php
@@ -815,6 +815,8 @@ abstract class Basewidget extends BaseObject  implements Persistent {
 	 */
 	public function hydrate($row, $startcol = 0, $rehydrate = false)
 	{
+		$this->last_hydrate_time = time();
+
 		try {
 
 			$this->id = ($row[$startcol + 0] !== null) ? (string) $row[$startcol + 0] : null;
@@ -2026,4 +2028,11 @@ abstract class Basewidget extends BaseObject  implements Persistent {
 	
 	/* ---------------------- CustomData functions ------------------------- */
 	
+	protected $last_hydrate_time;
+
+	public function getLastHydrateTime()
+	{
+		return $this->last_hydrate_time;
+	}
+
 } // Basewidget

--- a/plugins/audit/lib/model/om/BaseAuditTrail.php
+++ b/plugins/audit/lib/model/om/BaseAuditTrail.php
@@ -1145,6 +1145,8 @@ abstract class BaseAuditTrail extends BaseObject  implements Persistent {
 	 */
 	public function hydrate($row, $startcol = 0, $rehydrate = false)
 	{
+		$this->last_hydrate_time = time();
+
 		try {
 
 			$this->id = ($row[$startcol + 0] !== null) ? (int) $row[$startcol + 0] : null;
@@ -1893,6 +1895,13 @@ abstract class BaseAuditTrail extends BaseObject  implements Persistent {
 		if ($deep) {
 		} // if ($deep)
 
+	}
+
+	protected $last_hydrate_time;
+
+	public function getLastHydrateTime()
+	{
+		return $this->last_hydrate_time;
 	}
 
 } // BaseAuditTrail

--- a/plugins/audit/lib/model/om/BaseAuditTrailConfig.php
+++ b/plugins/audit/lib/model/om/BaseAuditTrailConfig.php
@@ -289,6 +289,8 @@ abstract class BaseAuditTrailConfig extends BaseObject  implements Persistent {
 	 */
 	public function hydrate($row, $startcol = 0, $rehydrate = false)
 	{
+		$this->last_hydrate_time = time();
+
 		try {
 
 			$this->id = ($row[$startcol + 0] !== null) ? (int) $row[$startcol + 0] : null;
@@ -883,6 +885,13 @@ abstract class BaseAuditTrailConfig extends BaseObject  implements Persistent {
 		if ($deep) {
 		} // if ($deep)
 
+	}
+
+	protected $last_hydrate_time;
+
+	public function getLastHydrateTime()
+	{
+		return $this->last_hydrate_time;
 	}
 
 } // BaseAuditTrailConfig

--- a/plugins/audit/lib/model/om/BaseAuditTrailData.php
+++ b/plugins/audit/lib/model/om/BaseAuditTrailData.php
@@ -540,6 +540,8 @@ abstract class BaseAuditTrailData extends BaseObject  implements Persistent {
 	 */
 	public function hydrate($row, $startcol = 0, $rehydrate = false)
 	{
+		$this->last_hydrate_time = time();
+
 		try {
 
 			$this->id = ($row[$startcol + 0] !== null) ? (int) $row[$startcol + 0] : null;
@@ -1176,6 +1178,13 @@ abstract class BaseAuditTrailData extends BaseObject  implements Persistent {
 		if ($deep) {
 		} // if ($deep)
 
+	}
+
+	protected $last_hydrate_time;
+
+	public function getLastHydrateTime()
+	{
+		return $this->last_hydrate_time;
 	}
 
 } // BaseAuditTrailData

--- a/plugins/conf_maps/lib/model/om/BaseConfMaps.php
+++ b/plugins/conf_maps/lib/model/om/BaseConfMaps.php
@@ -462,6 +462,8 @@ abstract class BaseConfMaps extends BaseObject  implements Persistent {
 	 */
 	public function hydrate($row, $startcol = 0, $rehydrate = false)
 	{
+		$this->last_hydrate_time = time();
+
 		try {
 
 			$this->id = ($row[$startcol + 0] !== null) ? (int) $row[$startcol + 0] : null;
@@ -1245,6 +1247,13 @@ abstract class BaseConfMaps extends BaseObject  implements Persistent {
 		if ($deep) {
 		} // if ($deep)
 
+	}
+
+	protected $last_hydrate_time;
+
+	public function getLastHydrateTime()
+	{
+		return $this->last_hydrate_time;
 	}
 
 } // BaseConfMaps

--- a/plugins/content/caption/search/lib/model/om/BaseCaptionAssetItem.php
+++ b/plugins/content/caption/search/lib/model/om/BaseCaptionAssetItem.php
@@ -462,6 +462,8 @@ abstract class BaseCaptionAssetItem extends BaseObject  implements Persistent {
 	 */
 	public function hydrate($row, $startcol = 0, $rehydrate = false)
 	{
+		$this->last_hydrate_time = time();
+
 		try {
 
 			$this->id = ($row[$startcol + 0] !== null) ? (int) $row[$startcol + 0] : null;
@@ -1239,6 +1241,13 @@ abstract class BaseCaptionAssetItem extends BaseObject  implements Persistent {
 		if ($deep) {
 		} // if ($deep)
 
+	}
+
+	protected $last_hydrate_time;
+
+	public function getLastHydrateTime()
+	{
+		return $this->last_hydrate_time;
 	}
 
 } // BaseCaptionAssetItem

--- a/plugins/content_distribution/lib/model/om/BaseDistributionProfile.php
+++ b/plugins/content_distribution/lib/model/om/BaseDistributionProfile.php
@@ -983,6 +983,8 @@ abstract class BaseDistributionProfile extends BaseObject  implements Persistent
 	 */
 	public function hydrate($row, $startcol = 0, $rehydrate = false)
 	{
+		$this->last_hydrate_time = time();
+
 		try {
 
 			$this->id = ($row[$startcol + 0] !== null) ? (int) $row[$startcol + 0] : null;
@@ -2032,4 +2034,11 @@ abstract class BaseDistributionProfile extends BaseObject  implements Persistent
 	
 	/* ---------------------- CustomData functions ------------------------- */
 	
+	protected $last_hydrate_time;
+
+	public function getLastHydrateTime()
+	{
+		return $this->last_hydrate_time;
+	}
+
 } // BaseDistributionProfile

--- a/plugins/content_distribution/lib/model/om/BaseEntryDistribution.php
+++ b/plugins/content_distribution/lib/model/om/BaseEntryDistribution.php
@@ -1336,6 +1336,8 @@ abstract class BaseEntryDistribution extends BaseObject  implements Persistent {
 	 */
 	public function hydrate($row, $startcol = 0, $rehydrate = false)
 	{
+		$this->last_hydrate_time = time();
+
 		try {
 
 			$this->id = ($row[$startcol + 0] !== null) ? (int) $row[$startcol + 0] : null;
@@ -2421,4 +2423,11 @@ abstract class BaseEntryDistribution extends BaseObject  implements Persistent {
 	
 	/* ---------------------- CustomData functions ------------------------- */
 	
+	protected $last_hydrate_time;
+
+	public function getLastHydrateTime()
+	{
+		return $this->last_hydrate_time;
+	}
+
 } // BaseEntryDistribution

--- a/plugins/content_distribution/lib/model/om/BaseGenericDistributionProvider.php
+++ b/plugins/content_distribution/lib/model/om/BaseGenericDistributionProvider.php
@@ -749,6 +749,8 @@ abstract class BaseGenericDistributionProvider extends BaseObject  implements Pe
 	 */
 	public function hydrate($row, $startcol = 0, $rehydrate = false)
 	{
+		$this->last_hydrate_time = time();
+
 		try {
 
 			$this->id = ($row[$startcol + 0] !== null) ? (int) $row[$startcol + 0] : null;
@@ -1726,4 +1728,11 @@ abstract class BaseGenericDistributionProvider extends BaseObject  implements Pe
 	
 	/* ---------------------- CustomData functions ------------------------- */
 	
+	protected $last_hydrate_time;
+
+	public function getLastHydrateTime()
+	{
+		return $this->last_hydrate_time;
+	}
+
 } // BaseGenericDistributionProvider

--- a/plugins/content_distribution/lib/model/om/BaseGenericDistributionProviderAction.php
+++ b/plugins/content_distribution/lib/model/om/BaseGenericDistributionProviderAction.php
@@ -827,6 +827,8 @@ abstract class BaseGenericDistributionProviderAction extends BaseObject  impleme
 	 */
 	public function hydrate($row, $startcol = 0, $rehydrate = false)
 	{
+		$this->last_hydrate_time = time();
+
 		try {
 
 			$this->id = ($row[$startcol + 0] !== null) ? (int) $row[$startcol + 0] : null;
@@ -1828,4 +1830,11 @@ abstract class BaseGenericDistributionProviderAction extends BaseObject  impleme
 	
 	/* ---------------------- CustomData functions ------------------------- */
 	
+	protected $last_hydrate_time;
+
+	public function getLastHydrateTime()
+	{
+		return $this->last_hydrate_time;
+	}
+
 } // BaseGenericDistributionProviderAction

--- a/plugins/cue_points/base/lib/model/om/BaseCuePoint.php
+++ b/plugins/cue_points/base/lib/model/om/BaseCuePoint.php
@@ -1139,6 +1139,8 @@ abstract class BaseCuePoint extends BaseObject  implements Persistent {
 	 */
 	public function hydrate($row, $startcol = 0, $rehydrate = false)
 	{
+		$this->last_hydrate_time = time();
+
 		try {
 
 			$this->int_id = ($row[$startcol + 0] !== null) ? (int) $row[$startcol + 0] : null;
@@ -2107,4 +2109,11 @@ abstract class BaseCuePoint extends BaseObject  implements Persistent {
 	
 	/* ---------------------- CustomData functions ------------------------- */
 	
+	protected $last_hydrate_time;
+
+	public function getLastHydrateTime()
+	{
+		return $this->last_hydrate_time;
+	}
+
 } // BaseCuePoint

--- a/plugins/drm/lib/model/om/BaseDrmKey.php
+++ b/plugins/drm/lib/model/om/BaseDrmKey.php
@@ -557,6 +557,8 @@ abstract class BaseDrmKey extends BaseObject  implements Persistent {
 	 */
 	public function hydrate($row, $startcol = 0, $rehydrate = false)
 	{
+		$this->last_hydrate_time = time();
+
 		try {
 
 			$this->id = ($row[$startcol + 0] !== null) ? (int) $row[$startcol + 0] : null;
@@ -1355,6 +1357,13 @@ abstract class BaseDrmKey extends BaseObject  implements Persistent {
 		if ($deep) {
 		} // if ($deep)
 
+	}
+
+	protected $last_hydrate_time;
+
+	public function getLastHydrateTime()
+	{
+		return $this->last_hydrate_time;
 	}
 
 } // BaseDrmKey

--- a/plugins/drm/lib/model/om/BaseDrmPolicy.php
+++ b/plugins/drm/lib/model/om/BaseDrmPolicy.php
@@ -775,6 +775,8 @@ abstract class BaseDrmPolicy extends BaseObject  implements Persistent {
 	 */
 	public function hydrate($row, $startcol = 0, $rehydrate = false)
 	{
+		$this->last_hydrate_time = time();
+
 		try {
 
 			$this->id = ($row[$startcol + 0] !== null) ? (int) $row[$startcol + 0] : null;
@@ -1821,4 +1823,11 @@ abstract class BaseDrmPolicy extends BaseObject  implements Persistent {
 	
 	/* ---------------------- CustomData functions ------------------------- */
 	
+	protected $last_hydrate_time;
+
+	public function getLastHydrateTime()
+	{
+		return $this->last_hydrate_time;
+	}
+
 } // BaseDrmPolicy

--- a/plugins/drm/lib/model/om/BaseDrmProfile.php
+++ b/plugins/drm/lib/model/om/BaseDrmProfile.php
@@ -632,6 +632,8 @@ abstract class BaseDrmProfile extends BaseObject  implements Persistent {
 	 */
 	public function hydrate($row, $startcol = 0, $rehydrate = false)
 	{
+		$this->last_hydrate_time = time();
+
 		try {
 
 			$this->id = ($row[$startcol + 0] !== null) ? (int) $row[$startcol + 0] : null;
@@ -1642,4 +1644,11 @@ abstract class BaseDrmProfile extends BaseObject  implements Persistent {
 	
 	/* ---------------------- CustomData functions ------------------------- */
 	
+	protected $last_hydrate_time;
+
+	public function getLastHydrateTime()
+	{
+		return $this->last_hydrate_time;
+	}
+
 } // BaseDrmProfile

--- a/plugins/drop_folder/lib/model/om/BaseDropFolder.php
+++ b/plugins/drop_folder/lib/model/om/BaseDropFolder.php
@@ -944,6 +944,8 @@ abstract class BaseDropFolder extends BaseObject  implements Persistent {
 	 */
 	public function hydrate($row, $startcol = 0, $rehydrate = false)
 	{
+		$this->last_hydrate_time = time();
+
 		try {
 
 			$this->id = ($row[$startcol + 0] !== null) ? (int) $row[$startcol + 0] : null;
@@ -2049,4 +2051,11 @@ abstract class BaseDropFolder extends BaseObject  implements Persistent {
 	
 	/* ---------------------- CustomData functions ------------------------- */
 	
+	protected $last_hydrate_time;
+
+	public function getLastHydrateTime()
+	{
+		return $this->last_hydrate_time;
+	}
+
 } // BaseDropFolder

--- a/plugins/drop_folder/lib/model/om/BaseDropFolderFile.php
+++ b/plugins/drop_folder/lib/model/om/BaseDropFolderFile.php
@@ -1395,6 +1395,8 @@ abstract class BaseDropFolderFile extends BaseObject  implements Persistent {
 	 */
 	public function hydrate($row, $startcol = 0, $rehydrate = false)
 	{
+		$this->last_hydrate_time = time();
+
 		try {
 
 			$this->id = ($row[$startcol + 0] !== null) ? (int) $row[$startcol + 0] : null;
@@ -2548,4 +2550,11 @@ abstract class BaseDropFolderFile extends BaseObject  implements Persistent {
 	
 	/* ---------------------- CustomData functions ------------------------- */
 	
+	protected $last_hydrate_time;
+
+	public function getLastHydrateTime()
+	{
+		return $this->last_hydrate_time;
+	}
+
 } // BaseDropFolderFile

--- a/plugins/event_notification/lib/model/om/BaseEventNotificationTemplate.php
+++ b/plugins/event_notification/lib/model/om/BaseEventNotificationTemplate.php
@@ -671,6 +671,8 @@ abstract class BaseEventNotificationTemplate extends BaseObject  implements Pers
 	 */
 	public function hydrate($row, $startcol = 0, $rehydrate = false)
 	{
+		$this->last_hydrate_time = time();
+
 		try {
 
 			$this->id = ($row[$startcol + 0] !== null) ? (int) $row[$startcol + 0] : null;
@@ -1624,4 +1626,11 @@ abstract class BaseEventNotificationTemplate extends BaseObject  implements Pers
 	
 	/* ---------------------- CustomData functions ------------------------- */
 	
+	protected $last_hydrate_time;
+
+	public function getLastHydrateTime()
+	{
+		return $this->last_hydrate_time;
+	}
+
 } // BaseEventNotificationTemplate

--- a/plugins/event_notification/providers/bpm/lib/model/om/BaseBusinessProcessCase.php
+++ b/plugins/event_notification/providers/bpm/lib/model/om/BaseBusinessProcessCase.php
@@ -632,6 +632,8 @@ abstract class BaseBusinessProcessCase extends BaseObject  implements Persistent
 	 */
 	public function hydrate($row, $startcol = 0, $rehydrate = false)
 	{
+		$this->last_hydrate_time = time();
+
 		// Nullify cached objects
 		$this->m_custom_data = null;
 		
@@ -1687,4 +1689,11 @@ abstract class BaseBusinessProcessCase extends BaseObject  implements Persistent
 	
 	/* ---------------------- CustomData functions ------------------------- */
 	
+	protected $last_hydrate_time;
+
+	public function getLastHydrateTime()
+	{
+		return $this->last_hydrate_time;
+	}
+
 } // BaseBusinessProcessCase

--- a/plugins/event_notification/providers/bpm/lib/model/om/BaseBusinessProcessServer.php
+++ b/plugins/event_notification/providers/bpm/lib/model/om/BaseBusinessProcessServer.php
@@ -632,6 +632,8 @@ abstract class BaseBusinessProcessServer extends BaseObject  implements Persiste
 	 */
 	public function hydrate($row, $startcol = 0, $rehydrate = false)
 	{
+		$this->last_hydrate_time = time();
+
 		// Nullify cached objects
 		$this->m_custom_data = null;
 		
@@ -1683,4 +1685,11 @@ abstract class BaseBusinessProcessServer extends BaseObject  implements Persiste
 	
 	/* ---------------------- CustomData functions ------------------------- */
 	
+	protected $last_hydrate_time;
+
+	public function getLastHydrateTime()
+	{
+		return $this->last_hydrate_time;
+	}
+
 } // BaseBusinessProcessServer

--- a/plugins/metadata/lib/model/om/BaseMetadata.php
+++ b/plugins/metadata/lib/model/om/BaseMetadata.php
@@ -596,6 +596,8 @@ abstract class BaseMetadata extends BaseObject  implements Persistent {
 	 */
 	public function hydrate($row, $startcol = 0, $rehydrate = false)
 	{
+		$this->last_hydrate_time = time();
+
 		try {
 
 			$this->id = ($row[$startcol + 0] !== null) ? (int) $row[$startcol + 0] : null;
@@ -1406,6 +1408,13 @@ abstract class BaseMetadata extends BaseObject  implements Persistent {
 		if ($deep) {
 		} // if ($deep)
 
+	}
+
+	protected $last_hydrate_time;
+
+	public function getLastHydrateTime()
+	{
+		return $this->last_hydrate_time;
 	}
 
 } // BaseMetadata

--- a/plugins/metadata/lib/model/om/BaseMetadataProfile.php
+++ b/plugins/metadata/lib/model/om/BaseMetadataProfile.php
@@ -749,6 +749,8 @@ abstract class BaseMetadataProfile extends BaseObject  implements Persistent {
 	 */
 	public function hydrate($row, $startcol = 0, $rehydrate = false)
 	{
+		$this->last_hydrate_time = time();
+
 		try {
 
 			$this->id = ($row[$startcol + 0] !== null) ? (int) $row[$startcol + 0] : null;
@@ -1798,4 +1800,11 @@ abstract class BaseMetadataProfile extends BaseObject  implements Persistent {
 	
 	/* ---------------------- CustomData functions ------------------------- */
 	
+	protected $last_hydrate_time;
+
+	public function getLastHydrateTime()
+	{
+		return $this->last_hydrate_time;
+	}
+
 } // BaseMetadataProfile

--- a/plugins/metadata/lib/model/om/BaseMetadataProfileField.php
+++ b/plugins/metadata/lib/model/om/BaseMetadataProfileField.php
@@ -710,6 +710,8 @@ abstract class BaseMetadataProfileField extends BaseObject  implements Persisten
 	 */
 	public function hydrate($row, $startcol = 0, $rehydrate = false)
 	{
+		$this->last_hydrate_time = time();
+
 		try {
 
 			$this->id = ($row[$startcol + 0] !== null) ? (int) $row[$startcol + 0] : null;
@@ -1747,4 +1749,11 @@ abstract class BaseMetadataProfileField extends BaseObject  implements Persisten
 	
 	/* ---------------------- CustomData functions ------------------------- */
 	
+	protected $last_hydrate_time;
+
+	public function getLastHydrateTime()
+	{
+		return $this->last_hydrate_time;
+	}
+
 } // BaseMetadataProfileField

--- a/plugins/partner_aggregation/lib/model/om/BaseDwhHourlyPartner.php
+++ b/plugins/partner_aggregation/lib/model/om/BaseDwhHourlyPartner.php
@@ -2535,6 +2535,8 @@ abstract class BaseDwhHourlyPartner extends BaseObject  {
 	 */
 	public function hydrate($row, $startcol = 0, $rehydrate = false)
 	{
+		$this->last_hydrate_time = time();
+
 		try {
 
 			$this->partner_id = ($row[$startcol + 0] !== null) ? (int) $row[$startcol + 0] : null;
@@ -3337,6 +3339,13 @@ abstract class BaseDwhHourlyPartner extends BaseObject  {
 		if ($deep) {
 		} // if ($deep)
 
+	}
+
+	protected $last_hydrate_time;
+
+	public function getLastHydrateTime()
+	{
+		return $this->last_hydrate_time;
 	}
 
 } // BaseDwhHourlyPartner

--- a/plugins/reach/lib/model/om/BaseEntryVendorTask.php
+++ b/plugins/reach/lib/model/om/BaseEntryVendorTask.php
@@ -945,6 +945,8 @@ abstract class BaseEntryVendorTask extends BaseObject  implements Persistent {
 	 */
 	public function hydrate($row, $startcol = 0, $rehydrate = false)
 	{
+		$this->last_hydrate_time = time();
+
 		// Nullify cached objects
 		$this->m_custom_data = null;
 		
@@ -2060,4 +2062,11 @@ abstract class BaseEntryVendorTask extends BaseObject  implements Persistent {
 	
 	/* ---------------------- CustomData functions ------------------------- */
 	
+	protected $last_hydrate_time;
+
+	public function getLastHydrateTime()
+	{
+		return $this->last_hydrate_time;
+	}
+
 } // BaseEntryVendorTask

--- a/plugins/reach/lib/model/om/BasePartnerCatalogItem.php
+++ b/plugins/reach/lib/model/om/BasePartnerCatalogItem.php
@@ -476,6 +476,8 @@ abstract class BasePartnerCatalogItem extends BaseObject  implements Persistent 
 	 */
 	public function hydrate($row, $startcol = 0, $rehydrate = false)
 	{
+		$this->last_hydrate_time = time();
+
 		// Nullify cached objects
 		$this->m_custom_data = null;
 		
@@ -1483,4 +1485,11 @@ abstract class BasePartnerCatalogItem extends BaseObject  implements Persistent 
 	
 	/* ---------------------- CustomData functions ------------------------- */
 	
+	protected $last_hydrate_time;
+
+	public function getLastHydrateTime()
+	{
+		return $this->last_hydrate_time;
+	}
+
 } // BasePartnerCatalogItem

--- a/plugins/reach/lib/model/om/BaseReachProfile.php
+++ b/plugins/reach/lib/model/om/BaseReachProfile.php
@@ -658,6 +658,8 @@ abstract class BaseReachProfile extends BaseObject  implements Persistent {
 	 */
 	public function hydrate($row, $startcol = 0, $rehydrate = false)
 	{
+		$this->last_hydrate_time = time();
+
 		// Nullify cached objects
 		$this->m_custom_data = null;
 		
@@ -1713,4 +1715,11 @@ abstract class BaseReachProfile extends BaseObject  implements Persistent {
 	
 	/* ---------------------- CustomData functions ------------------------- */
 	
+	protected $last_hydrate_time;
+
+	public function getLastHydrateTime()
+	{
+		return $this->last_hydrate_time;
+	}
+
 } // BaseReachProfile

--- a/plugins/reach/lib/model/om/BaseVendorCatalogItem.php
+++ b/plugins/reach/lib/model/om/BaseVendorCatalogItem.php
@@ -749,6 +749,8 @@ abstract class BaseVendorCatalogItem extends BaseObject  implements Persistent {
 	 */
 	public function hydrate($row, $startcol = 0, $rehydrate = false)
 	{
+		$this->last_hydrate_time = time();
+
 		// Nullify cached objects
 		$this->m_custom_data = null;
 		
@@ -1840,4 +1842,11 @@ abstract class BaseVendorCatalogItem extends BaseObject  implements Persistent {
 	
 	/* ---------------------- CustomData functions ------------------------- */
 	
+	protected $last_hydrate_time;
+
+	public function getLastHydrateTime()
+	{
+		return $this->last_hydrate_time;
+	}
+
 } // BaseVendorCatalogItem

--- a/plugins/schedule/base/lib/model/om/BaseScheduleEvent.php
+++ b/plugins/schedule/base/lib/model/om/BaseScheduleEvent.php
@@ -1433,6 +1433,8 @@ abstract class BaseScheduleEvent extends BaseObject  implements Persistent {
 	 */
 	public function hydrate($row, $startcol = 0, $rehydrate = false)
 	{
+		$this->last_hydrate_time = time();
+
 		// Nullify cached objects
 		$this->m_custom_data = null;
 		
@@ -2676,4 +2678,11 @@ abstract class BaseScheduleEvent extends BaseObject  implements Persistent {
 	
 	/* ---------------------- CustomData functions ------------------------- */
 	
+	protected $last_hydrate_time;
+
+	public function getLastHydrateTime()
+	{
+		return $this->last_hydrate_time;
+	}
+
 } // BaseScheduleEvent

--- a/plugins/schedule/base/lib/model/om/BaseScheduleEventResource.php
+++ b/plugins/schedule/base/lib/model/om/BaseScheduleEventResource.php
@@ -476,6 +476,8 @@ abstract class BaseScheduleEventResource extends BaseObject  implements Persiste
 	 */
 	public function hydrate($row, $startcol = 0, $rehydrate = false)
 	{
+		$this->last_hydrate_time = time();
+
 		// Nullify cached objects
 		$this->m_custom_data = null;
 		
@@ -1479,4 +1481,11 @@ abstract class BaseScheduleEventResource extends BaseObject  implements Persiste
 	
 	/* ---------------------- CustomData functions ------------------------- */
 	
+	protected $last_hydrate_time;
+
+	public function getLastHydrateTime()
+	{
+		return $this->last_hydrate_time;
+	}
+
 } // BaseScheduleEventResource

--- a/plugins/schedule/base/lib/model/om/BaseScheduleResource.php
+++ b/plugins/schedule/base/lib/model/om/BaseScheduleResource.php
@@ -671,6 +671,8 @@ abstract class BaseScheduleResource extends BaseObject  implements Persistent {
 	 */
 	public function hydrate($row, $startcol = 0, $rehydrate = false)
 	{
+		$this->last_hydrate_time = time();
+
 		// Nullify cached objects
 		$this->m_custom_data = null;
 		
@@ -1734,4 +1736,11 @@ abstract class BaseScheduleResource extends BaseObject  implements Persistent {
 	
 	/* ---------------------- CustomData functions ------------------------- */
 	
+	protected $last_hydrate_time;
+
+	public function getLastHydrateTime()
+	{
+		return $this->last_hydrate_time;
+	}
+
 } // BaseScheduleResource

--- a/plugins/scheduled_task/lib/model/om/BaseScheduledTaskProfile.php
+++ b/plugins/scheduled_task/lib/model/om/BaseScheduledTaskProfile.php
@@ -811,6 +811,8 @@ abstract class BaseScheduledTaskProfile extends BaseObject  implements Persisten
 	 */
 	public function hydrate($row, $startcol = 0, $rehydrate = false)
 	{
+		$this->last_hydrate_time = time();
+
 		try {
 
 			$this->id = ($row[$startcol + 0] !== null) ? (int) $row[$startcol + 0] : null;
@@ -1669,6 +1671,13 @@ abstract class BaseScheduledTaskProfile extends BaseObject  implements Persisten
 		if ($deep) {
 		} // if ($deep)
 
+	}
+
+	protected $last_hydrate_time;
+
+	public function getLastHydrateTime()
+	{
+		return $this->last_hydrate_time;
 	}
 
 } // BaseScheduledTaskProfile

--- a/plugins/search/lib/model/om/BaseSphinxLog.php
+++ b/plugins/search/lib/model/om/BaseSphinxLog.php
@@ -651,6 +651,8 @@ abstract class BaseSphinxLog extends BaseObject  implements Persistent {
 	 */
 	public function hydrate($row, $startcol = 0, $rehydrate = false)
 	{
+		$this->last_hydrate_time = time();
+
 		// Nullify cached objects
 		$this->m_custom_data = null;
 		
@@ -1820,4 +1822,11 @@ abstract class BaseSphinxLog extends BaseObject  implements Persistent {
 	
 	/* ---------------------- CustomData functions ------------------------- */
 	
+	protected $last_hydrate_time;
+
+	public function getLastHydrateTime()
+	{
+		return $this->last_hydrate_time;
+	}
+
 } // BaseSphinxLog

--- a/plugins/search/lib/model/om/BaseSphinxLogServer.php
+++ b/plugins/search/lib/model/om/BaseSphinxLogServer.php
@@ -449,6 +449,8 @@ abstract class BaseSphinxLogServer extends BaseObject  implements Persistent {
 	 */
 	public function hydrate($row, $startcol = 0, $rehydrate = false)
 	{
+		$this->last_hydrate_time = time();
+
 		try {
 
 			$this->id = ($row[$startcol + 0] !== null) ? (int) $row[$startcol + 0] : null;
@@ -1225,6 +1227,13 @@ abstract class BaseSphinxLogServer extends BaseObject  implements Persistent {
 		} // if ($deep)
 
 			$this->aSphinxLog = null;
+	}
+
+	protected $last_hydrate_time;
+
+	public function getLastHydrateTime()
+	{
+		return $this->last_hydrate_time;
 	}
 
 } // BaseSphinxLogServer

--- a/plugins/short_link/lib/model/om/BaseShortLink.php
+++ b/plugins/short_link/lib/model/om/BaseShortLink.php
@@ -694,6 +694,8 @@ abstract class BaseShortLink extends BaseObject  implements Persistent {
 	 */
 	public function hydrate($row, $startcol = 0, $rehydrate = false)
 	{
+		$this->last_hydrate_time = time();
+
 		try {
 
 			$this->id = ($row[$startcol + 0] !== null) ? (string) $row[$startcol + 0] : null;
@@ -1522,6 +1524,13 @@ abstract class BaseShortLink extends BaseObject  implements Persistent {
 		if ($deep) {
 		} // if ($deep)
 
+	}
+
+	protected $last_hydrate_time;
+
+	public function getLastHydrateTime()
+	{
+		return $this->last_hydrate_time;
 	}
 
 } // BaseShortLink

--- a/plugins/sso/base/lib/model/om/BaseSso.php
+++ b/plugins/sso/base/lib/model/om/BaseSso.php
@@ -554,6 +554,8 @@ abstract class BaseSso extends BaseObject  implements Persistent {
 	 */
 	public function hydrate($row, $startcol = 0, $rehydrate = false)
 	{
+		$this->last_hydrate_time = time();
+
 		// Nullify cached objects
 		$this->m_custom_data = null;
 		
@@ -1593,4 +1595,11 @@ abstract class BaseSso extends BaseObject  implements Persistent {
 	
 	/* ---------------------- CustomData functions ------------------------- */
 	
+	protected $last_hydrate_time;
+
+	public function getLastHydrateTime()
+	{
+		return $this->last_hydrate_time;
+	}
+
 } // BaseSso

--- a/plugins/tag_search/lib/model/om/BaseTag.php
+++ b/plugins/tag_search/lib/model/om/BaseTag.php
@@ -580,6 +580,8 @@ abstract class BaseTag extends BaseObject  implements Persistent {
 	 */
 	public function hydrate($row, $startcol = 0, $rehydrate = false)
 	{
+		$this->last_hydrate_time = time();
+
 		try {
 
 			$this->id = ($row[$startcol + 0] !== null) ? (int) $row[$startcol + 0] : null;
@@ -1508,4 +1510,11 @@ abstract class BaseTag extends BaseObject  implements Persistent {
 	
 	/* ---------------------- CustomData functions ------------------------- */
 	
+	protected $last_hydrate_time;
+
+	public function getLastHydrateTime()
+	{
+		return $this->last_hydrate_time;
+	}
+
 } // BaseTag

--- a/plugins/vendor/lib/model/om/BaseVendorIntegration.php
+++ b/plugins/vendor/lib/model/om/BaseVendorIntegration.php
@@ -541,6 +541,8 @@ abstract class BaseVendorIntegration extends BaseObject  implements Persistent {
 	 */
 	public function hydrate($row, $startcol = 0, $rehydrate = false)
 	{
+		$this->last_hydrate_time = time();
+
 		// Nullify cached objects
 		$this->m_custom_data = null;
 		
@@ -1568,4 +1570,11 @@ abstract class BaseVendorIntegration extends BaseObject  implements Persistent {
 	
 	/* ---------------------- CustomData functions ------------------------- */
 	
+	protected $last_hydrate_time;
+
+	public function getLastHydrateTime()
+	{
+		return $this->last_hydrate_time;
+	}
+
 } // BaseVendorIntegration

--- a/plugins/virus_scan/lib/model/om/BaseVirusScanProfile.php
+++ b/plugins/virus_scan/lib/model/om/BaseVirusScanProfile.php
@@ -593,6 +593,8 @@ abstract class BaseVirusScanProfile extends BaseObject  implements Persistent {
 	 */
 	public function hydrate($row, $startcol = 0, $rehydrate = false)
 	{
+		$this->last_hydrate_time = time();
+
 		try {
 
 			$this->id = ($row[$startcol + 0] !== null) ? (int) $row[$startcol + 0] : null;
@@ -1522,4 +1524,11 @@ abstract class BaseVirusScanProfile extends BaseObject  implements Persistent {
 	
 	/* ---------------------- CustomData functions ------------------------- */
 	
+	protected $last_hydrate_time;
+
+	public function getLastHydrateTime()
+	{
+		return $this->last_hydrate_time;
+	}
+
 } // BaseVirusScanProfile


### PR DESCRIPTION
if there is a long api session (e.g. thumbnail stripe) and some object that it uses is updated during execution, an invalid query may be cached.
the reason is that the object is hydrated only once, due to propel instance pool. the api may not cache the query at first, since it's too close to the update time. after some time passes, the api may cache the query if the same object is pulled again, but the cached object will be old (hydrated long time ago).
since the query cache currently saves the current server time with the query, subsequent calls may use the cached query even though it's invalid.
the fix is to save the oldest hydration time as the 'query time', if such a scenario happens, subsequent api calls will know the cached query is invalid, and won't use it.