### PR TITLE
PLAT-22662: change EntryServerNode's 'isPlayableUser' default to false

### DIFF
--- a/alpha/lib/model/LiveEntryServerNode.php
+++ b/alpha/lib/model/LiveEntryServerNode.php
@@ -269,7 +269,7 @@ class LiveEntryServerNode extends EntryServerNode
 
 	public function getIsPlayableUser()
 	{
-		return $this->getFromCustomData(self::CUSTOM_DATA_IS_PLAYABLE_USER, null, true);
+		return $this->getFromCustomData(self::CUSTOM_DATA_IS_PLAYABLE_USER, null, false);
 	}
 
 	public function setIsPlayableUser($v)


### PR DESCRIPTION
change the default value of EntryServerNode:isPlayableUser to false to solve bug in "Explicit Live" feature