### PR TITLE
PLAT-22661: add the entry viewMode to the EntryServerNode object

### DIFF
--- a/alpha/lib/model/EntryServerNodePeer.php
+++ b/alpha/lib/model/EntryServerNodePeer.php
@@ -66,6 +66,24 @@ class EntryServerNodePeer extends BaseEntryServerNodePeer {
 
 		return EntryServerNodePeer::doSelectOne($criteria, $con);
 	}
+
+	/**
+	 * Retrieve an array of EntryServerNodes with the matching entryId of the requested server types
+	 *
+	 * @param      string $entryId .
+	 * @param      array $serverTypes .
+	 * @param      PropelPDO $con the connection to use
+	 * @return 	   array<EntryServerNode> of matching EntryServerNodes
+	 * @throws     kCoreException
+	 */
+	public static function retrieveByEntryIdAndServerTypes($entryId, $serverTypes, PropelPDO $con = null)
+	{
+		$criteria = new Criteria();
+		$criteria->add(EntryServerNodePeer::ENTRY_ID, $entryId);
+		$criteria->add(EntryServerNodePeer::SERVER_TYPE, $serverTypes, Criteria::IN);
+
+		return EntryServerNodePeer::doSelect($criteria, $con);
+	}
 	
 	/**
 	 * Retrieve a count of all EntryServerNodeType associated with a partner.

--- a/alpha/lib/model/LiveEntry.php
+++ b/alpha/lib/model/LiveEntry.php
@@ -777,6 +777,7 @@ abstract class LiveEntry extends entry
 			$dbLiveEntryServerNode->setPartnerId($this->getPartnerId());
 			$dbLiveEntryServerNode->setStatus($liveEntryStatus);
 			$dbLiveEntryServerNode->setDc($serverNode->getDc());
+			$dbLiveEntryServerNode->setViewMode($this->getViewMode());
 			
 			if($applicationName)
 				$dbLiveEntryServerNode->setApplicationName($applicationName);
@@ -1117,6 +1118,13 @@ abstract class LiveEntry extends entry
 	public function setViewMode($v)
 	{
 		$this->putInCustomData(self::CUSTOM_DATA_VIEW_MODE, $v);
+		$entryServerNodes = EntryServerNodePeer::retrieveByEntryIdAndServerTypes($this->getId(), array(EntryServerNodeType::LIVE_PRIMARY, EntryServerNodeType::LIVE_BACKUP));
+		foreach ($entryServerNodes as $entryServerNode)
+		{
+			/* @var $entryServerNode LiveEntryServerNode */
+			$entryServerNode->setViewMode($v);
+			$entryServerNode->save();
+		}
 	}
 
 	public function getRecordingStatus()

--- a/alpha/lib/model/LiveEntryServerNode.php
+++ b/alpha/lib/model/LiveEntryServerNode.php
@@ -282,4 +282,9 @@ class LiveEntryServerNode extends EntryServerNode
 		$disableDcCheck = kConf::get('disable_dc_check_for_entryServerNode', 'runtime_config', 0);
 		return $disableDcCheck || $this->getDc() == kDataCenterMgr::getCurrentDcId();
 	}
+
+	public function getViewMode()
+	{
+		return $this->getLiveEntry()->getViewMode();
+	}
 }

--- a/alpha/lib/model/LiveEntryServerNode.php
+++ b/alpha/lib/model/LiveEntryServerNode.php
@@ -13,6 +13,7 @@ class LiveEntryServerNode extends EntryServerNode
 	const CUSTOM_DATA_RECORDING_INFO = "recording_info";
 	const MAX_DURATIONS_TO_KEEP = 20;
 	const CUSTOM_DATA_IS_PLAYABLE_USER = "is_playable_user";
+	const CUSTOM_DATA_VIEW_MODE = "view_mode";
 
 	/* (non-PHPdoc)
 	 * @see BaseEntryServerNode::postInsert()
@@ -283,8 +284,13 @@ class LiveEntryServerNode extends EntryServerNode
 		return $disableDcCheck || $this->getDc() == kDataCenterMgr::getCurrentDcId();
 	}
 
+	public function setViewMode($v)
+	{
+		$this->putInCustomData(self::CUSTOM_DATA_VIEW_MODE, $v);
+	}
+
 	public function getViewMode()
 	{
-		return $this->getLiveEntry()->getViewMode();
+		return $this->getFromCustomData(self::CUSTOM_DATA_VIEW_MODE, null, ViewMode::ALLOW_ALL);
 	}
 }

--- a/api_v3/lib/types/EntryServerNode/live/KalturaLiveEntryServerNode.php
+++ b/api_v3/lib/types/EntryServerNode/live/KalturaLiveEntryServerNode.php
@@ -25,11 +25,18 @@ class KalturaLiveEntryServerNode extends KalturaEntryServerNode
 	 */
 	public $isPlayableUser;
 
+	/**
+	 * @var KalturaViewMode
+	 * @readonly
+	 */
+	public $viewMode;
+
 	private static $map_between_objects = array
 	(
 		"streams",
 		"recordingInfo",
 		"isPlayableUser",
+		"viewMode",
 	);
 
 	/* (non-PHPdoc)

--- a/api_v3/lib/types/EntryServerNode/live/KalturaLiveEntryServerNode.php
+++ b/api_v3/lib/types/EntryServerNode/live/KalturaLiveEntryServerNode.php
@@ -27,7 +27,6 @@ class KalturaLiveEntryServerNode extends KalturaEntryServerNode
 
 	/**
 	 * @var KalturaViewMode
-	 * @readonly
 	 */
 	public $viewMode;
 


### PR DESCRIPTION
add the entry viewMode to the EntryServerNode object, needed for the "Explicit Live" feature implementation in LiveNG