### PR TITLE
SUP-18687: fix SRT line index when clipping the beginning of the entry

### DIFF
--- a/plugins/content/caption/base/lib/kCaptionsContentManager.php
+++ b/plugins/content/caption/base/lib/kCaptionsContentManager.php
@@ -263,6 +263,7 @@ abstract class kCaptionsContentManager
 	public function createCaptionsFile($content, $clipStartTime, $clipEndTime, $timeCode, $globalOffset)
 	{
 		$newFileContent = '';
+		$newLineIndex = 1;
 		$originalFileContentArray = kCaptionsContentManager::getFileContentAsArray($content);
 		while (($line = kCaptionsContentManager::getNextValueFromArray($originalFileContentArray)) !== false)
 		{
@@ -285,7 +286,10 @@ abstract class kCaptionsContentManager
 				$line = kCaptionsContentManager::getNextValueFromArray($originalFileContentArray);
 			}
 			if($shouldAddBlockToNewFile)
-				$newFileContent .= $currentBlock . kCaptionsContentManager::UNIX_LINE_ENDING;;
+			{
+				$currentBlock[0] = $newLineIndex++;
+				$newFileContent .= $currentBlock . kCaptionsContentManager::UNIX_LINE_ENDING;
+			}
 		}
 		return $newFileContent;
 	}


### PR DESCRIPTION
@MosheMaorKaltura after reviewing, I believe this is OK
1. createNewCaptionFile is called
2. $unsupported_formats are being set (for scc and cap)
3. if caption is supported we call 'buildFile' at: plugins/content/caption/base/batch/CopyCaptions/KAsyncCopyCaptions.class.php:160
4. build file is abstract and implemented at the respective caption managers
5. **note** only srt and webVtt actually call "createCaptionsFile" which is where the fix for the line index is. Since dfxp does not have the same structure as srt and webvtt - I believe this is fine.

Happy to get your input
Thanks