### PR TITLE
PLAT-22670: revert isPlayableUser default to true

### DIFF
--- a/alpha/lib/model/LiveEntryServerNode.php
+++ b/alpha/lib/model/LiveEntryServerNode.php
@@ -270,7 +270,7 @@ class LiveEntryServerNode extends EntryServerNode
 
 	public function getIsPlayableUser()
 	{
-		return $this->getFromCustomData(self::CUSTOM_DATA_IS_PLAYABLE_USER, null, false);
+		return $this->getFromCustomData(self::CUSTOM_DATA_IS_PLAYABLE_USER, null, true);
 	}
 
 	public function setIsPlayableUser($v)


### PR DESCRIPTION
revert the EntryServerNode->isPlayableUser default value to false because of issues occurred on old live system