### PR TITLE
export script: cross pid link bug fix

### DIFF
--- a/alpha/scripts/utils/ExportToDifferentStorage.php
+++ b/alpha/scripts/utils/ExportToDifferentStorage.php
@@ -304,7 +304,6 @@ function handleSyncKey($assetId, $syncKey, $depth = 0)
 	$linkFileSync->setStatus($sourceFileSync->getStatus());
 	$linkFileSync->setOriginal($sourceFileSync->getOriginal());
 	$linkFileSync->setLinkedId($sourceFileSync->getId());
-	$linkFileSync->setPartnerID($sourceFileSync->getPartnerID());
 	$linkFileSync->setFileSize(-1);
 
 	if($sourceFileSync->getFileType() == FileSync::FILE_SYNC_FILE_TYPE_URL)


### PR DESCRIPTION
remove the call to setPartnerId, leave the partner that was set from the file sync key.