### PR TITLE
LIV-472: remove "type" from delivery profile url when serveVodFromLive

### DIFF
--- a/alpha/lib/model/DeliveryProfileLive.php
+++ b/alpha/lib/model/DeliveryProfileLive.php
@@ -358,10 +358,7 @@ abstract class DeliveryProfileLive extends DeliveryProfile {
 		$livePackagerUrl .= $serverNode->getSessionType($entryServerNode);
 
 		$entry = $this->getDynamicAttributes()->getEntry();
-		if ($entry->getExplicitLive())
-		{
-			$livePackagerUrl .= $serverNode->getExplicitLiveUrl($this->getDynamicAttributes());
-		}
+		$livePackagerUrl .= $serverNode->getExplicitLiveUrl($livePackagerUrl, $this->getDynamicAttributes(), $entry);
 		$secureToken = $this->generateLiveSecuredPackagerToken($livePackagerUrl);
 		$livePackagerUrl .= "t/$secureToken/";
 

--- a/alpha/lib/model/DeliveryProfileLive.php
+++ b/alpha/lib/model/DeliveryProfileLive.php
@@ -1,8 +1,6 @@
 <?php
 
 abstract class DeliveryProfileLive extends DeliveryProfile {
-	const USER_TYPE_ADMIN = 'admin';
-	const USER_TYPE_USER = 'user';
 	const DEFAULT_MAINTENANCE_DC = -1;
 
 	/**
@@ -362,10 +360,7 @@ abstract class DeliveryProfileLive extends DeliveryProfile {
 		$entry = $this->getDynamicAttributes()->getEntry();
 		if ($entry->getExplicitLive())
 		{
-			$userType = self::USER_TYPE_ADMIN;
-		 	if (!$entry->canViewExplicitLive())
-				$userType = self::USER_TYPE_USER;
-			$livePackagerUrl .= "type/$userType/";
+			$livePackagerUrl .= $serverNode->getExplicitLiveUrl($this->getDynamicAttributes());
 		}
 		$secureToken = $this->generateLiveSecuredPackagerToken($livePackagerUrl);
 		$livePackagerUrl .= "t/$secureToken/";

--- a/alpha/lib/model/DeliveryProfileLive.php
+++ b/alpha/lib/model/DeliveryProfileLive.php
@@ -358,7 +358,7 @@ abstract class DeliveryProfileLive extends DeliveryProfile {
 		$livePackagerUrl .= $serverNode->getSessionType($entryServerNode);
 
 		$entry = $this->getDynamicAttributes()->getEntry();
-		$livePackagerUrl .= $serverNode->getExplicitLiveUrl($livePackagerUrl, $this->getDynamicAttributes(), $entry);
+		$livePackagerUrl .= $serverNode->getExplicitLiveUrl($livePackagerUrl, $entry);
 		$secureToken = $this->generateLiveSecuredPackagerToken($livePackagerUrl);
 		$livePackagerUrl .= "t/$secureToken/";
 

--- a/alpha/lib/model/MediaServerNode.php
+++ b/alpha/lib/model/MediaServerNode.php
@@ -112,9 +112,8 @@ abstract class MediaServerNode extends DeliveryServerNode {
 		return $liveUrl;
 	}
 
-	public static function getExplicitLiveUrl(DeliveryProfileDynamicAttributes $da)
+	public static function getExplicitLiveUrl($liveUrl, DeliveryProfileDynamicAttributes $da, LiveStreamEntry $entry)
 	{
-		$entry = $da->getEntry();
 		$userType = static::USER_TYPE_ADMIN;
 		if (!$entry->canViewExplicitLive())
 		{

--- a/alpha/lib/model/MediaServerNode.php
+++ b/alpha/lib/model/MediaServerNode.php
@@ -95,13 +95,13 @@ abstract class MediaServerNode extends DeliveryServerNode {
 		return '';
 	}
 
-	public static function getPartnerIdUrl(DeliveryProfileDynamicAttributes $da)
+	public function getPartnerIdUrl(DeliveryProfileDynamicAttributes $da)
 	{
 		$partnerId = $da->getEntry()->getPartnerId();
 		return '/' . self::PARTNER_ID_URL_PARAM . '/' . $partnerId;
 	}
 
-	public static function getEntryIdUrl(DeliveryProfileDynamicAttributes $da)
+	public function getEntryIdUrl(DeliveryProfileDynamicAttributes $da)
 	{
 		$entryId = $da->getEntryId();
 		return '/' . self::ENTRY_ID_URL_PARAM . "/$entryId/";
@@ -112,14 +112,24 @@ abstract class MediaServerNode extends DeliveryServerNode {
 		return $liveUrl;
 	}
 
-	public static function getExplicitLiveUrl($liveUrl, LiveStreamEntry $entry)
+	protected function getUserType($isAdmin)
 	{
-		$userType = static::USER_TYPE_ADMIN;
+		return $isAdmin ? self::USER_TYPE_ADMIN : self::USER_TYPE_USER;
+	}
+
+	protected function getUrlType()
+	{
+		return self::EXPLICIT_LIVE_VIEWER_TYPE_URL;
+	}
+
+	public function getExplicitLiveUrl($liveUrl, LiveStreamEntry $entry)
+	{
+		$userType = $this->getUserType(true);
 		if ($entry->getExplicitLive() && !$entry->canViewExplicitLive())
 		{
-			$userType = static::USER_TYPE_USER;
+			$userType = $this->getUserType(false);
 		}
-		return static::EXPLICIT_LIVE_VIEWER_TYPE_URL . "/$userType/";
+		return $this->getUrlType() . "/$userType/";
 	}
 
 } // MediaServerNode

--- a/alpha/lib/model/MediaServerNode.php
+++ b/alpha/lib/model/MediaServerNode.php
@@ -11,6 +11,9 @@ abstract class MediaServerNode extends DeliveryServerNode {
 	const DEFAULT_APPLICATION = 'kLive';
 	const ENTRY_ID_URL_PARAM = 'e';
 	const PARTNER_ID_URL_PARAM = 'p';
+	const EXPLICIT_LIVE_VIEWER_TYPE_URL = 'type';
+	const USER_TYPE_ADMIN = 'admin';
+	const USER_TYPE_USER = 'user';
 	
 	abstract public function getWebService($serviceName);
 	abstract public function getLiveWebServiceName();
@@ -107,6 +110,17 @@ abstract class MediaServerNode extends DeliveryServerNode {
 	public static function modifyUrlForVodFromLive($liveUrl, DeliveryProfileDynamicAttributes $da)
 	{
 		return $liveUrl;
+	}
+
+	public static function getExplicitLiveUrl(DeliveryProfileDynamicAttributes $da)
+	{
+		$entry = $da->getEntry();
+		$userType = self::USER_TYPE_ADMIN;
+		if (!$entry->canViewExplicitLive())
+		{
+			$userType = self::USER_TYPE_USER;
+		}
+		return self::EXPLICIT_LIVE_VIEWER_TYPE_URL . "/$userType/";
 	}
 
 } // MediaServerNode

--- a/alpha/lib/model/MediaServerNode.php
+++ b/alpha/lib/model/MediaServerNode.php
@@ -115,12 +115,12 @@ abstract class MediaServerNode extends DeliveryServerNode {
 	public static function getExplicitLiveUrl(DeliveryProfileDynamicAttributes $da)
 	{
 		$entry = $da->getEntry();
-		$userType = self::USER_TYPE_ADMIN;
+		$userType = static::USER_TYPE_ADMIN;
 		if (!$entry->canViewExplicitLive())
 		{
-			$userType = self::USER_TYPE_USER;
+			$userType = static::USER_TYPE_USER;
 		}
-		return self::EXPLICIT_LIVE_VIEWER_TYPE_URL . "/$userType/";
+		return static::EXPLICIT_LIVE_VIEWER_TYPE_URL . "/$userType/";
 	}
 
 } // MediaServerNode

--- a/alpha/lib/model/MediaServerNode.php
+++ b/alpha/lib/model/MediaServerNode.php
@@ -112,10 +112,10 @@ abstract class MediaServerNode extends DeliveryServerNode {
 		return $liveUrl;
 	}
 
-	public static function getExplicitLiveUrl($liveUrl, DeliveryProfileDynamicAttributes $da, LiveStreamEntry $entry)
+	public static function getExplicitLiveUrl($liveUrl, LiveStreamEntry $entry)
 	{
 		$userType = static::USER_TYPE_ADMIN;
-		if (!$entry->canViewExplicitLive())
+		if ($entry->getExplicitLive() && !$entry->canViewExplicitLive())
 		{
 			$userType = static::USER_TYPE_USER;
 		}

--- a/plugins/media/live_cluster/lib/model/LiveClusterMediaServerNode.php
+++ b/plugins/media/live_cluster/lib/model/LiveClusterMediaServerNode.php
@@ -67,12 +67,17 @@ class LiveClusterMediaServerNode extends MediaServerNode
 		return parent::getEntryIdUrl($da);
 	}
 
-	public static function getExplicitLiveUrl(DeliveryProfileDynamicAttributes $da)
+	public static function getExplicitLiveUrl($liveUrl, DeliveryProfileDynamicAttributes $da, LiveStreamEntry $entry)
 	{
-		if ($da->getServeVodFromLive())
+		if (strpos($liveUrl, self::TIMELINE_URL_PARAM) !== false)
 		{
 			return '';
 		}
-		return parent::getExplicitLiveUrl($da);
+		if ($entry->getExplicitLive())
+		{
+			return parent::getExplicitLiveUrl($liveUrl, $da, $entry);
+		}
+		// when not explicitLive and no timeline inserted before - we want to request for the main timeline
+		return static::EXPLICIT_LIVE_VIEWER_TYPE_URL . '/' . self::USER_TYPE_ADMIN . '/';
 	}
 }

--- a/plugins/media/live_cluster/lib/model/LiveClusterMediaServerNode.php
+++ b/plugins/media/live_cluster/lib/model/LiveClusterMediaServerNode.php
@@ -6,6 +6,9 @@ class LiveClusterMediaServerNode extends MediaServerNode
     const ENVIRONMENT = 'env';
     const SESSION_TYPE = 'st';
     const TIMELINE_URL_PARAM = 'tl';
+	const EXPLICIT_LIVE_VIEWER_TYPE_URL = 'tl';
+	const USER_TYPE_ADMIN = 'main';
+	const USER_TYPE_USER = 'viewer';
 
     /**
      * Applies default values to this object.

--- a/plugins/media/live_cluster/lib/model/LiveClusterMediaServerNode.php
+++ b/plugins/media/live_cluster/lib/model/LiveClusterMediaServerNode.php
@@ -6,9 +6,9 @@ class LiveClusterMediaServerNode extends MediaServerNode
     const ENVIRONMENT = 'env';
     const SESSION_TYPE = 'st';
     const TIMELINE_URL_PARAM = 'tl';
-	const EXPLICIT_LIVE_VIEWER_TYPE_URL = 'tl';
-	const USER_TYPE_ADMIN = 'main';
-	const USER_TYPE_USER = 'viewer';
+    const EXPLICIT_LIVE_VIEWER_TYPE_URL = 'tl';
+    const USER_TYPE_ADMIN = 'main';
+    const USER_TYPE_USER = 'viewer';
 
     /**
      * Applies default values to this object.

--- a/plugins/media/live_cluster/lib/model/LiveClusterMediaServerNode.php
+++ b/plugins/media/live_cluster/lib/model/LiveClusterMediaServerNode.php
@@ -54,7 +54,7 @@ class LiveClusterMediaServerNode extends MediaServerNode
         return self::SESSION_TYPE . '/' . $entryServerNode->getServerType() . '/';
     }
 
-	public static function getEntryIdUrl(DeliveryProfileDynamicAttributes $da)
+	public function getEntryIdUrl(DeliveryProfileDynamicAttributes $da)
 	{
 		if ($da->getServeVodFromLive())
 		{
@@ -67,7 +67,18 @@ class LiveClusterMediaServerNode extends MediaServerNode
 		return parent::getEntryIdUrl($da);
 	}
 
-	public static function getExplicitLiveUrl($liveUrl, LiveStreamEntry $entry)
+	protected function getUserType($isAdmin)
+	{
+		return $isAdmin ? self::USER_TYPE_ADMIN : self::USER_TYPE_USER;
+	}
+
+	protected function getUrlType()
+	{
+		return self::EXPLICIT_LIVE_VIEWER_TYPE_URL;
+	}
+
+
+	public function getExplicitLiveUrl($liveUrl, LiveStreamEntry $entry)
 	{
 		if (strpos($liveUrl, self::TIMELINE_URL_PARAM) !== false)
 		{

--- a/plugins/media/live_cluster/lib/model/LiveClusterMediaServerNode.php
+++ b/plugins/media/live_cluster/lib/model/LiveClusterMediaServerNode.php
@@ -67,17 +67,12 @@ class LiveClusterMediaServerNode extends MediaServerNode
 		return parent::getEntryIdUrl($da);
 	}
 
-	public static function getExplicitLiveUrl($liveUrl, DeliveryProfileDynamicAttributes $da, LiveStreamEntry $entry)
+	public static function getExplicitLiveUrl($liveUrl, LiveStreamEntry $entry)
 	{
 		if (strpos($liveUrl, self::TIMELINE_URL_PARAM) !== false)
 		{
 			return '';
 		}
-		if ($entry->getExplicitLive())
-		{
-			return parent::getExplicitLiveUrl($liveUrl, $da, $entry);
-		}
-		// when not explicitLive and no timeline inserted before - we want to request for the main timeline
-		return static::EXPLICIT_LIVE_VIEWER_TYPE_URL . '/' . self::USER_TYPE_ADMIN . '/';
+		return parent::getExplicitLiveUrl($liveUrl, $entry);
 	}
 }

--- a/plugins/media/live_cluster/lib/model/LiveClusterMediaServerNode.php
+++ b/plugins/media/live_cluster/lib/model/LiveClusterMediaServerNode.php
@@ -63,4 +63,13 @@ class LiveClusterMediaServerNode extends MediaServerNode
 
 		return parent::getEntryIdUrl($da);
 	}
+
+	public static function getExplicitLiveUrl(DeliveryProfileDynamicAttributes $da)
+	{
+		if ($da->getServeVodFromLive())
+		{
+			return '';
+		}
+		return parent::getExplicitLiveUrl($da);
+	}
 }

--- a/plugins/media/wowza/lib/model/WowzaMediaServerNode.php
+++ b/plugins/media/wowza/lib/model/WowzaMediaServerNode.php
@@ -235,7 +235,7 @@ class WowzaMediaServerNode extends MediaServerNode {
 		return $this->getFromCustomData(self::CUSTOM_DATA_LIVE_SERVICE_INTERNAL_DOMAIN, null, null);
 	}
 
-	public static function getEntryIdUrl(DeliveryProfileDynamicAttributes $da)
+	public function getEntryIdUrl(DeliveryProfileDynamicAttributes $da)
 	{
 		if ($da->getServeVodFromLive())
 		{
@@ -259,7 +259,7 @@ class WowzaMediaServerNode extends MediaServerNode {
 		return $liveUrl;
 	}
 
-	public static function getExplicitLiveUrl($liveUrl, LiveStreamEntry $entry)
+	public function getExplicitLiveUrl($liveUrl, LiveStreamEntry $entry)
 	{
 		if ($entry->getExplicitLive())
 		{

--- a/plugins/media/wowza/lib/model/WowzaMediaServerNode.php
+++ b/plugins/media/wowza/lib/model/WowzaMediaServerNode.php
@@ -259,11 +259,11 @@ class WowzaMediaServerNode extends MediaServerNode {
 		return $liveUrl;
 	}
 
-	public static function getExplicitLiveUrl($liveUrl, DeliveryProfileDynamicAttributes $da, LiveStreamEntry $entry)
+	public static function getExplicitLiveUrl($liveUrl, LiveStreamEntry $entry)
 	{
 		if ($entry->getExplicitLive())
 		{
-			return parent::getExplicitLiveUrl($liveUrl, $da, $entry);
+			return parent::getExplicitLiveUrl($liveUrl, $entry);
 		}
 		return '';
 	}

--- a/plugins/media/wowza/lib/model/WowzaMediaServerNode.php
+++ b/plugins/media/wowza/lib/model/WowzaMediaServerNode.php
@@ -259,4 +259,13 @@ class WowzaMediaServerNode extends MediaServerNode {
 		return $liveUrl;
 	}
 
+	public static function getExplicitLiveUrl($liveUrl, DeliveryProfileDynamicAttributes $da, LiveStreamEntry $entry)
+	{
+		if ($entry->getExplicitLive())
+		{
+			return parent::getExplicitLiveUrl($liveUrl, $da, $entry);
+		}
+		return '';
+	}
+
 } // WowzaMediaServer


### PR DESCRIPTION
- in case of server node of "LiveClusterMediaServerNode" type (LiveNG) and explicitLive is on and "getServeVodFromLive" is true - we don't want the "type" to exist in url as it contradict with the new recording implementation
- in case of LiveNG - add '/tl/' to the url anyway - regardless of explicitLive (with '/tl/main' by default)