### PR TITLE
apiV3/playManifest referrer cache fix

### DIFF
--- a/alpha/apps/kaltura/lib/cache/kPlayManifestCacher.php
+++ b/alpha/apps/kaltura/lib/cache/kPlayManifestCacher.php
@@ -41,7 +41,7 @@ class kPlayManifestCacher extends kApiCache
 		$this->_deliveryCode = isset($this->_params['deliveryCode']) ? $this->_params['deliveryCode'] : null;
 		unset($this->_params['deliveryCode']);
 		
-		// take only the hostname part of the referrer parameter of baseEntry.getContextData
+		$referrer = null;
 		if (isset($this->_params['referrer']))
 		{
 			$referrer = base64_decode(str_replace(" ", "+", $this->_params['referrer']));
@@ -49,8 +49,12 @@ class kPlayManifestCacher extends kApiCache
 				$referrer = "";				
 			unset($this->_params['referrer']);
 		}
-		else
+
+		if (!$referrer)
+		{
 			$referrer = self::getHttpReferrer();
+		}
+
 		$this->_referrers[] = $referrer;
 		
 		$this->finalizeCacheKey();

--- a/api_v3/lib/KalturaResponseCacher.php
+++ b/api_v3/lib/KalturaResponseCacher.php
@@ -73,7 +73,8 @@ class KalturaResponseCacher extends kApiCache
 			{
 				continue;
 			}
-			
+
+			$referrer = null;
 			$referrerKey = "{$prefix}contextDataParams:referrer";
 			if (isset($this->_params[$referrerKey]))
 			{
@@ -85,7 +86,8 @@ class KalturaResponseCacher extends kApiCache
 				$referrer = $this->_params[$i]['contextDataParams']['referrer'];
 				unset($this->_params[$i]['contextDataParams']['referrer']);
 			}
-			else
+
+			if (!$referrer)
 			{
 				$referrer = self::getHttpReferrer();
 			}


### PR DESCRIPTION
in case an empty/invalid referrer param is sent, kScope will contain the HTTP referrer value, but the cache layer will use the empty param.
this PR aligns the cache layer with the impl of kScope.