### PR TITLE
LIV-558: fix tl missing in case of entryId with 'tl'

### DIFF
--- a/plugins/media/live_cluster/lib/model/LiveClusterMediaServerNode.php
+++ b/plugins/media/live_cluster/lib/model/LiveClusterMediaServerNode.php
@@ -80,7 +80,8 @@ class LiveClusterMediaServerNode extends MediaServerNode
 
 	public function getExplicitLiveUrl($liveUrl, LiveStreamEntry $entry)
 	{
-		if (strpos($liveUrl, self::TIMELINE_URL_PARAM) !== false)
+		$tlUrlParam = '/' . self::TIMELINE_URL_PARAM . '/';
+		if (strpos($liveUrl, $tlUrlParam) !== false)
 		{
 			return '';
 		}


### PR DESCRIPTION
In case of entryId with 'tl' inside - the playManifest response mistakenly won't include the '/tl/' param
fix it by checking the 'tl' strpos **with slashes**