### PR TITLE
SUP-27743-Java-Long-Integers-FlavorAsset-SizeInBytes:Change type of sizeInBytes from int to long

### DIFF
--- a/api_v3/lib/types/conversionProfile/KalturaAsset.php
+++ b/api_v3/lib/types/conversionProfile/KalturaAsset.php
@@ -120,7 +120,7 @@ class KalturaAsset extends KalturaObject implements IRelatedFilterable, IApiObje
 	/**
 	 * The size (in Bytes) of the asset
 	 *
-	 * @var int
+	 * @var long
 	 * @readonly
 	 */
 	public $sizeInBytes;


### PR DESCRIPTION
Preventing extended the limitation of int variable in Java, when receiving big sizeInBytes variable in Json response for flavorAsset request in Java client.


