### PR TITLE
SUP-27690-Duplicate-Add-To-Channel-Notification:Prevent sending email notification for live entry

### DIFF
--- a/deployment/updates/scripts/2021_06_13_deploy_update_entry_was_added_to_channel_email_notification.php
+++ b/deployment/updates/scripts/2021_06_13_deploy_update_entry_was_added_to_channel_email_notification.php
@@ -1,0 +1,17 @@
+<?php
+/**
+ * @package deployment
+ */
+require_once (__DIR__ . '/../../bootstrap.php');
+
+$script = realpath(dirname(__FILE__) . "/../../../tests/standAloneClient/exec.php");
+
+$newTemplateUpdate = realpath(dirname(__FILE__) . "/../../updates/scripts/xml/2021_06_13_updateEntryWasAddedToChannelEmailNotification.xml");
+
+if(!file_exists($newTemplateUpdate) || !file_exists($script))
+{
+    KalturaLog::err("Missing update script file");
+    return;
+}
+
+passthru("php $script $newTemplateUpdate");

--- a/deployment/updates/scripts/xml/2021_06_13_updateEntryWasAddedToChannelEmailNotification.template.xml
+++ b/deployment/updates/scripts/xml/2021_06_13_updateEntryWasAddedToChannelEmailNotification.template.xml
@@ -1,0 +1,84 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xml>
+    <config>
+        <serviceUrl>@SERVICE_URL@</serviceUrl>
+        <partnerId>-2</partnerId>
+        <clientTag>Stand alone php 1.0.0</clientTag>
+        <curlTimeout>30</curlTimeout>
+        <userAgent>Stand alone php 1.0.0</userAgent>
+    </config>
+    <session>
+        <partnerId>-2</partnerId>
+        <secret>@ADMIN_CONSOLE_PARTNER_ADMIN_SECRET@</secret>
+        <sessionType>2</sessionType>
+    </session>
+    <multirequest>
+        <!-- Entry was added to channel -->
+        <request service="eventNotificationTemplate" action="add" plugin="eventNotification" partnerId="0">
+            <template objectType="KalturaEmailNotificationTemplate">
+                <name>Entry was added to channel</name>
+                <systemName>Entry_Was_Added_To_Channel</systemName>
+                <description>Email notification template to be sent when entry is added to channel.</description>
+                <automaticDispatchEnabled>1</automaticDispatchEnabled>
+                <eventType>5</eventType> <!-- EventNotificationEventType::OBJECT_CREATED -->
+                <eventObjectType>37</eventObjectType> <!-- EventNotificationEventObjectType::CATEGORYENTRY -->
+                <eventConditions objectType="array">
+                    <item objectType="KalturaEventFieldCondition">
+                        <field objectType="KalturaEvalBooleanField">
+                            <code>$scope->getEvent()->getObject() instanceof categoryEntry &amp;&amp; $scope->getEvent()->getObject()->getStatus() == CategoryEntryStatus::ACTIVE &amp;&amp; entryPeer::retrieveByPK($scope->getEvent()->getObject()->getEntryId())->getSourceType()!= EntrySourceType::LIVE_STREAM</code>
+                        </field>
+                    </item>
+                </eventConditions>
+                <format>1</format>
+                <subject>[AppTitle] - A new media was added to {category_name}</subject>
+                <body>Media {entry_name} was added to {category_name}. You can see the media here: [AppEntryUrl]{entry_id}</body>
+                <fromEmail>{from_email}</fromEmail>
+                <fromName>{from_name}</fromName>
+                <bcc objectType="KalturaEmailNotificationCategoryRecipientProvider">
+                    <categoryId objectType="KalturaEvalStringField">
+                        <code>$scope->getObject()->getCategoryId()</code>
+                    </categoryId>
+                    <categoryUserFilter objectType="KalturaCategoryUserProviderFilter">
+                        <permissionNamesMatchOr>CATEGORY_SUBSCRIBE</permissionNamesMatchOr>
+                    </categoryUserFilter>
+                </bcc>
+                <contentParameters objectType="array">
+                    <item objectType="KalturaEventNotificationParameter">
+                        <key>from_email</key>
+                        <value objectType="KalturaEvalStringField">
+                            <code>kConf::get("partner_notification_email")</code>
+                        </value>
+                    </item>
+                    <item objectType="KalturaEventNotificationParameter">
+                        <key>from_name</key>
+                        <value objectType="KalturaEvalStringField">
+                            <code>kConf::get("partner_notification_name")</code>
+                        </value>
+                    </item>
+                    <item objectType="KalturaEventNotificationParameter">
+                        <key>category_name</key>
+                        <value objectType="KalturaEvalStringField">
+                            <code>!is_null(categoryPeer::retrieveByPk($scope->getObject()->getCategoryId())) ? categoryPeer::retrieveByPk($scope->getObject()->getCategoryId())->getName() : ''</code>
+                        </value>
+                    </item>
+                    <item objectType="KalturaEventNotificationParameter">
+                        <key>entry_id</key>
+                        <value objectType="KalturaEvalStringField">
+                            <code>$scope->getObject()->getEntryId()</code>
+                        </value>
+                    </item>
+                    <item objectType="KalturaEventNotificationParameter">
+                        <key>entry_name</key>
+                        <value objectType="KalturaEvalStringField">
+                            <code>!is_null(entryPeer::retrieveByPk($scope->getObject()->getEntryId())) ? entryPeer::retrieveByPk($scope->getObject()->getEntryId())->getName() : ''</code>
+                        </value>
+                    </item>
+                </contentParameters>
+            </template>
+        </request>
+        <request service="eventNotificationTemplate" action="updateStatus" plugin="eventNotification" partnerId="0">
+            <id>{1:result:id}</id>
+            <status>1</status><!-- EventNotificationTemplateStatus::DISABLED -->
+        </request>
+    </multirequest>
+</xml>


### PR DESCRIPTION
"Entry Was Added To Category" template is triggered by live entry and VOD entry. 
This update will prevent sending live entry notification and, therefore, prevent duplicate notification.
