### PR TITLE
PLAT-22950: simulive - isLive true only when event is playable

### DIFF
--- a/plugins/schedule/base/lib/model/LiveStreamScheduleEvent.php
+++ b/plugins/schedule/base/lib/model/LiveStreamScheduleEvent.php
@@ -134,8 +134,9 @@ class LiveStreamScheduleEvent extends BaseLiveStreamScheduleEvent
 		switch ($context)
 		{
 			case 'getLiveStatus':
-				if($this->getSourceEntryId())
+				if ($this->getSourceEntryId() && ($this->getCalculatedStartTime() + kSimuliveUtils::MINIMUM_TIME_TO_PLAYABLE_SEC < time()))
 				{
+					// Simulive flow (and event is playable)
 					$output = EntryServerNodeStatus::PLAYABLE;
 					return true;
 				}


### PR DESCRIPTION
change the dynamicGetter in case of simuliveFlow (LiveStreamScheduleEvent) to return playable only if we're at least 18 seconds inside the event (and not immediately from the event start as today)