### PR TITLE
SUP-27954-Add-SizeInBytes-To-Flavor-Asset:Add sizeInBytes to flavors when using share and remote storage

### DIFF
--- a/alpha/apps/kaltura/lib/storage/kFileSyncUtils.class.php
+++ b/alpha/apps/kaltura/lib/storage/kFileSyncUtils.class.php
@@ -1189,7 +1189,8 @@ class kFileSyncUtils implements kObjectChangedEventConsumer, kObjectAddedEventCo
         }
 
 		kEventsManager::raiseEvent(new kObjectAddedEvent($fileSync));
-		return $fileSync;
+
+        return $fileSync;
 	}
 
 	/**

--- a/alpha/apps/kaltura/lib/storage/kFileSyncUtils.class.php
+++ b/alpha/apps/kaltura/lib/storage/kFileSyncUtils.class.php
@@ -1180,7 +1180,14 @@ class kFileSyncUtils implements kObjectChangedEventConsumer, kObjectAddedEventCo
 		$fileSync->setFileType ( FileSync::FILE_SYNC_FILE_TYPE_FILE );
 		$fileSync->setIsDir($isDir);
 		$fileSync->save();
-		
+
+		if ($fileSync->getObjectType() == FileSyncObjectType::ASSET &&
+            $fileSync->getObjectSubType() == asset::FILE_SYNC_ASSET_SUB_TYPE_ASSET &&
+            $fileSync->getFileSize())
+        {
+            self::setSizeInBytesOnAsset($fileSync);
+        }
+
 		kEventsManager::raiseEvent(new kObjectAddedEvent($fileSync));
 		return $fileSync;
 	}
@@ -1438,6 +1445,12 @@ class kFileSyncUtils implements kObjectChangedEventConsumer, kObjectAddedEventCo
 		$fileSync->setOriginal	( false );
 		$fileSync->setFileType	( FileSync::FILE_SYNC_FILE_TYPE_URL );
 		$fileSync->save();
+
+        if ($fileSync->getObjectType() == FileSyncObjectType::ASSET &&
+            $fileSync->getObjectSubType() == asset::FILE_SYNC_ASSET_SUB_TYPE_ASSET)
+        {
+            self::setSizeInBytesOnAsset($fileSync);
+        }
 
 		kEventsManager::raiseEvent(new kObjectAddedEvent($fileSync));
 

--- a/alpha/apps/kaltura/lib/storage/kFileSyncUtils.class.php
+++ b/alpha/apps/kaltura/lib/storage/kFileSyncUtils.class.php
@@ -1181,7 +1181,7 @@ class kFileSyncUtils implements kObjectChangedEventConsumer, kObjectAddedEventCo
 		$fileSync->setIsDir($isDir);
 		$fileSync->save();
 
-        if ($fileSync->getObjectType() == FileSyncObjectType::ASSET &&
+		if ($fileSync->getObjectType() == FileSyncObjectType::ASSET &&
             $fileSync->getObjectSubType() == asset::FILE_SYNC_ASSET_SUB_TYPE_ASSET &&
             $fileSync->getFileSize())
         {

--- a/alpha/apps/kaltura/lib/storage/kFileSyncUtils.class.php
+++ b/alpha/apps/kaltura/lib/storage/kFileSyncUtils.class.php
@@ -1182,10 +1182,10 @@ class kFileSyncUtils implements kObjectChangedEventConsumer, kObjectAddedEventCo
 		$fileSync->save();
 
 		if ($fileSync->getObjectType() == FileSyncObjectType::ASSET &&
-            $fileSync->getObjectSubType() == asset::FILE_SYNC_ASSET_SUB_TYPE_ASSET &&
-            $fileSync->getFileSize())
+			$fileSync->getObjectSubType() == asset::FILE_SYNC_ASSET_SUB_TYPE_ASSET &&
+			$fileSync->getFileSize())
 		{
-		    self::setSizeInBytesOnAsset($fileSync);
+			self::setSizeInBytesOnAsset($fileSync);
 		}
 
 		kEventsManager::raiseEvent(new kObjectAddedEvent($fileSync));

--- a/alpha/apps/kaltura/lib/storage/kFileSyncUtils.class.php
+++ b/alpha/apps/kaltura/lib/storage/kFileSyncUtils.class.php
@@ -1182,8 +1182,8 @@ class kFileSyncUtils implements kObjectChangedEventConsumer, kObjectAddedEventCo
 		$fileSync->save();
 
 		if ($fileSync->getObjectType() == FileSyncObjectType::ASSET &&
-                $fileSync->getObjectSubType() == asset::FILE_SYNC_ASSET_SUB_TYPE_ASSET &&
-                $fileSync->getFileSize())
+             $fileSync->getObjectSubType() == asset::FILE_SYNC_ASSET_SUB_TYPE_ASSET &&
+             $fileSync->getFileSize())
 		{
 		    self::setSizeInBytesOnAsset($fileSync);
 		}

--- a/alpha/apps/kaltura/lib/storage/kFileSyncUtils.class.php
+++ b/alpha/apps/kaltura/lib/storage/kFileSyncUtils.class.php
@@ -1190,7 +1190,7 @@ class kFileSyncUtils implements kObjectChangedEventConsumer, kObjectAddedEventCo
 
 		kEventsManager::raiseEvent(new kObjectAddedEvent($fileSync));
 
-        return $fileSync;
+		return $fileSync;
 	}
 
 	/**

--- a/alpha/apps/kaltura/lib/storage/kFileSyncUtils.class.php
+++ b/alpha/apps/kaltura/lib/storage/kFileSyncUtils.class.php
@@ -1182,8 +1182,8 @@ class kFileSyncUtils implements kObjectChangedEventConsumer, kObjectAddedEventCo
 		$fileSync->save();
 
 		if ($fileSync->getObjectType() == FileSyncObjectType::ASSET &&
-            $fileSync->getObjectSubType() == asset::FILE_SYNC_ASSET_SUB_TYPE_ASSET &&
-            $fileSync->getFileSize())
+                $fileSync->getObjectSubType() == asset::FILE_SYNC_ASSET_SUB_TYPE_ASSET &&
+                $fileSync->getFileSize())
 		{
 		    self::setSizeInBytesOnAsset($fileSync);
 		}

--- a/alpha/apps/kaltura/lib/storage/kFileSyncUtils.class.php
+++ b/alpha/apps/kaltura/lib/storage/kFileSyncUtils.class.php
@@ -1182,8 +1182,8 @@ class kFileSyncUtils implements kObjectChangedEventConsumer, kObjectAddedEventCo
 		$fileSync->save();
 
 		if ($fileSync->getObjectType() == FileSyncObjectType::ASSET &&
-             $fileSync->getObjectSubType() == asset::FILE_SYNC_ASSET_SUB_TYPE_ASSET &&
-             $fileSync->getFileSize())
+                $fileSync->getObjectSubType() == asset::FILE_SYNC_ASSET_SUB_TYPE_ASSET &&
+                $fileSync->getFileSize())
 		{
 		    self::setSizeInBytesOnAsset($fileSync);
 		}

--- a/alpha/apps/kaltura/lib/storage/kFileSyncUtils.class.php
+++ b/alpha/apps/kaltura/lib/storage/kFileSyncUtils.class.php
@@ -1181,12 +1181,12 @@ class kFileSyncUtils implements kObjectChangedEventConsumer, kObjectAddedEventCo
 		$fileSync->setIsDir($isDir);
 		$fileSync->save();
 
-		if ($fileSync->getObjectType() == FileSyncObjectType::ASSET &&
-                $fileSync->getObjectSubType() == asset::FILE_SYNC_ASSET_SUB_TYPE_ASSET &&
-                $fileSync->getFileSize())
-		{
-		    self::setSizeInBytesOnAsset($fileSync);
-		}
+        if ($fileSync->getObjectType() == FileSyncObjectType::ASSET &&
+            $fileSync->getObjectSubType() == asset::FILE_SYNC_ASSET_SUB_TYPE_ASSET &&
+            $fileSync->getFileSize())
+        {
+            self::setSizeInBytesOnAsset($fileSync);
+        }
 
 		kEventsManager::raiseEvent(new kObjectAddedEvent($fileSync));
 		return $fileSync;

--- a/alpha/apps/kaltura/lib/storage/kFileSyncUtils.class.php
+++ b/alpha/apps/kaltura/lib/storage/kFileSyncUtils.class.php
@@ -1184,9 +1184,9 @@ class kFileSyncUtils implements kObjectChangedEventConsumer, kObjectAddedEventCo
 		if ($fileSync->getObjectType() == FileSyncObjectType::ASSET &&
             $fileSync->getObjectSubType() == asset::FILE_SYNC_ASSET_SUB_TYPE_ASSET &&
             $fileSync->getFileSize())
-        {
-            self::setSizeInBytesOnAsset($fileSync);
-        }
+		{
+		    self::setSizeInBytesOnAsset($fileSync);
+		}
 
 		kEventsManager::raiseEvent(new kObjectAddedEvent($fileSync));
 

--- a/alpha/apps/kaltura/lib/storage/kFileSyncUtils.class.php
+++ b/alpha/apps/kaltura/lib/storage/kFileSyncUtils.class.php
@@ -1176,7 +1176,7 @@ class kFileSyncUtils implements kObjectChangedEventConsumer, kObjectAddedEventCo
 			else
 				$fileSync->setStatus( FileSync::FILE_SYNC_STATUS_PENDING );
 		}
-		
+
 		$fileSync->setFileType ( FileSync::FILE_SYNC_FILE_TYPE_FILE );
 		$fileSync->setIsDir($isDir);
 		$fileSync->save();
@@ -1184,9 +1184,9 @@ class kFileSyncUtils implements kObjectChangedEventConsumer, kObjectAddedEventCo
 		if ($fileSync->getObjectType() == FileSyncObjectType::ASSET &&
             $fileSync->getObjectSubType() == asset::FILE_SYNC_ASSET_SUB_TYPE_ASSET &&
             $fileSync->getFileSize())
-        {
-            self::setSizeInBytesOnAsset($fileSync);
-        }
+		{
+		    self::setSizeInBytesOnAsset($fileSync);
+		}
 
 		kEventsManager::raiseEvent(new kObjectAddedEvent($fileSync));
 		return $fileSync;
@@ -1445,12 +1445,6 @@ class kFileSyncUtils implements kObjectChangedEventConsumer, kObjectAddedEventCo
 		$fileSync->setOriginal	( false );
 		$fileSync->setFileType	( FileSync::FILE_SYNC_FILE_TYPE_URL );
 		$fileSync->save();
-
-        if ($fileSync->getObjectType() == FileSyncObjectType::ASSET &&
-            $fileSync->getObjectSubType() == asset::FILE_SYNC_ASSET_SUB_TYPE_ASSET)
-        {
-            self::setSizeInBytesOnAsset($fileSync);
-        }
 
 		kEventsManager::raiseEvent(new kObjectAddedEvent($fileSync));
 


### PR DESCRIPTION
Add sizeInBytes data to flavor asset when using shared and remote storage