### PR TITLE
Allow media server to get default conversion profile.

### DIFF
--- a/deployment/permissions/service.conversionprofile.ini
+++ b/deployment/permissions/service.conversionprofile.ini
@@ -42,7 +42,7 @@ permissionItem5.param3 =
 permissionItem5.param4 = 
 permissionItem5.param5 = 
 permissionItem5.tags = 
-permissionItem5.permissions = TRANSCODING_BASE, -2>PARTNER_-2_GROUP_*_PERMISSION, -1>BATCH_BASE, -1>PARTNER_-1_GROUP_*_PERMISSION
+permissionItem5.permissions = TRANSCODING_BASE, -2>PARTNER_-2_GROUP_*_PERMISSION, -1>BATCH_BASE, -1>PARTNER_-1_GROUP_*_PERMISSION, -5>PARTNER_-5_GROUP_*_PERMISSION
 
 permissionItem6.service = conversionprofile
 permissionItem6.action = list

--- a/deployment/updates/scripts/add_permissions/2021_07_06_allow_media_server_to_get_default_conversionprofile.php
+++ b/deployment/updates/scripts/add_permissions/2021_07_06_allow_media_server_to_get_default_conversionprofile.php
@@ -1,0 +1,11 @@
+<?php
+/**
+ * @package deployment
+ * @subpackage falcon.roles_and_permissions
+ * 
+ * Add permissions to LiveNG
+ */
+
+$script = realpath(dirname(__FILE__) . '/../../../../') . '/alpha/scripts/utils/permissions/addPermissionsAndItems.php';
+$config = realpath(dirname(__FILE__)) . '/../../../permissions/service.conversionprofile.ini';
+passthru("php $script $config");


### PR DESCRIPTION
For some scenario we need to get the default conversion profile in the liveNG.