### PR TITLE
LIV-529 : upload source when media info changed

### DIFF
--- a/api_v3/lib/KalturaLiveEntryService.php
+++ b/api_v3/lib/KalturaLiveEntryService.php
@@ -470,7 +470,7 @@ class KalturaLiveEntryService extends KalturaEntryService
 	{
 		if (!$flavorParamsId)
 		{
-			if (!$this->getPartner()->getDefaultRecordingConversionProfile())
+			if ($recordedEntry->getconversionProfile2()->getType() == ConversionProfileType::LIVE_STREAM)
 			{
 				$recordedEntry->setConversionProfileId($this->getPartner()->getDefaultConversionProfileId());
 			}

--- a/api_v3/lib/KalturaLiveEntryService.php
+++ b/api_v3/lib/KalturaLiveEntryService.php
@@ -468,8 +468,10 @@ class KalturaLiveEntryService extends KalturaEntryService
 
 	private function handleRecording(LiveEntry $dbLiveEntry, entry $recordedEntry, KalturaDataCenterContentResource $resource, $flavorParamsId = null)
 	{
+		// in case we get null in the $flavorParamsId it mean that live will upload the source and let the BE convert it.
 		if (!$flavorParamsId)
 		{
+			// check if the conversion profile is already VOD if not set it to default.
 			if ($recordedEntry->getconversionProfile2()->getType() == ConversionProfileType::LIVE_STREAM)
 			{
 				$recordedEntry->setConversionProfileId($this->getPartner()->getDefaultConversionProfileId());

--- a/api_v3/lib/KalturaLiveEntryService.php
+++ b/api_v3/lib/KalturaLiveEntryService.php
@@ -470,6 +470,10 @@ class KalturaLiveEntryService extends KalturaEntryService
 	{
 		if (!$flavorParamsId)
 		{
+			if (!$this->getPartner()->getDefaultRecordingConversionProfile())
+			{
+				$recordedEntry->setConversionProfileId($this->getPartner()->getDefaultConversionProfileId());
+			}
 			$service = new MediaService();
 			$service->initService('media', 'media', 'updateContent');
 			$service->updateContentAction($recordedEntry->getId(), $resource);


### PR DESCRIPTION
In case we send null value as the flavor param upload with the default conversion profile (unless we have default recording conversion profile)