### PR TITLE
SUP-28434-Clipping-Not-Ready-Audio-Flavor: Check if the audio flavor is ready for retrieve flavor for clipping

### DIFF
--- a/alpha/lib/model/assetPeer.php
+++ b/alpha/lib/model/assetPeer.php
@@ -825,6 +825,7 @@ class assetPeer extends BaseassetPeer implements IRelatedObjectPeer
 		$c = new Criteria();
 		$c->add(assetPeer::ENTRY_ID, $entryId);
 		$c->add(assetPeer::IS_ORIGINAL, 0);
+		$c->add(assetPeer::STATUS, asset::ASSET_STATUS_READY);
 		$idCriterion = $c->getNewCriterion(assetPeer::TAGS, '%' . assetParams::TAG_ALT_AUDIO . '%', Criteria::LIKE);
 		$idCriterion->addOr($c->getNewCriterion(assetPeer::TAGS, '%' . assetParams::TAG_AUDIO_ONLY. '%',Criteria::LIKE));
 		$c->addAnd($idCriterion);


### PR DESCRIPTION
Checking flavor status for audio flavor in source entry when clipping the entry.
Is the audio flavor do not ready we cannot clip the new audio flavors for the temp entry. 