### PR TITLE
PLAT-23206: block liveStream:authenticate of blocked partner

### DIFF
--- a/api_v3/services/LiveStreamService.php
+++ b/api_v3/services/LiveStreamService.php
@@ -165,6 +165,11 @@ class LiveStreamService extends KalturaLiveEntryService
 		$dbEntry = entryPeer::retrieveByPK($entryId);
 		if (!$dbEntry || $dbEntry->getType() != entryType::LIVE_STREAM)
 			throw new KalturaAPIException(KalturaErrors::ENTRY_ID_NOT_FOUND, $entryId);
+
+		if (in_array($dbEntry->getPartner()->getStatus(), array(Partner::PARTNER_STATUS_CONTENT_BLOCK, Partner::PARTNER_STATUS_FULL_BLOCK)))
+		{
+			throw new KalturaAPIException(KalturaErrors::SERVICE_FORBIDDEN_CONTENT_BLOCKED);
+		}
 		
 		/* @var $dbEntry LiveStreamEntry */
 		if ($dbEntry->getStreamPassword() != $token)


### PR DESCRIPTION
block liveStream:authenticate request of entry id of blocked partner (currently the partner validation is performed on the request partner - which is the live partner - and not on the entry's partner)