### PR TITLE
PLAT-23257: fix incorrect getDetails response

### DIFF
--- a/api_v3/services/LiveStreamService.php
+++ b/api_v3/services/LiveStreamService.php
@@ -595,6 +595,7 @@ class LiveStreamService extends KalturaLiveEntryService
 			$liveStreamDetails->broadcastStatus = KalturaLiveStreamBroadcastStatus::LIVE;
 		}
 
+		KalturaLog::info("broadcastStatus of entry [$id] is [$liveStreamDetails->broadcastStatus] and isLive is [$isLive]");
 		$this->responseHandlingIsLive($isLive);
 		return $liveStreamDetails;
 	}

--- a/plugins/schedule/base/lib/model/LiveStreamScheduleEvent.php
+++ b/plugins/schedule/base/lib/model/LiveStreamScheduleEvent.php
@@ -170,7 +170,7 @@ class LiveStreamScheduleEvent extends BaseLiveStreamScheduleEvent
 		switch ($context)
 		{
 			case 'getLiveStatus':
-				if ($this->getSourceEntryId() && ($this->getCalculatedStartTime() + kSimuliveUtils::MINIMUM_TIME_TO_PLAYABLE_SEC < time()))
+				if ($this->getSourceEntryId() && ($this->getCalculatedStartTime() + kSimuliveUtils::MINIMUM_TIME_TO_PLAYABLE_SEC <= time()))
 				{
 					// Simulive flow (and event is playable)
 					$output = EntryServerNodeStatus::PLAYABLE;


### PR DESCRIPTION
**This PR is to the main branch. The hot-fix already merged https://github.com/kaltura/server/pull/11183**
on "dynamicGetter" of LiveStreamScheduleEvent - where we check if the simulive event is currently playable - check the case that the current time is actually equal to the "startTime" + 18 (change "<" to "<="). otherwise the response will be considered as "not live" and will be saved on cache until the end of the event with this incorrect response.
add log print to "getDetails" of the calculated broadcast status