### PR TITLE
SUP-20297: support REACH automatic rules when updating External-Media type (KMS current flow)

### DIFF
--- a/plugins/reach/lib/kReachManager.php
+++ b/plugins/reach/lib/kReachManager.php
@@ -390,6 +390,7 @@ class kReachManager implements kObjectChangedEventConsumer, kObjectCreatedEventC
 			{
 				$this->handleEntryDurationChanged($object);
 			}
+			// Checking if entry duration was modified to handle YouTube entries duration set
 			if (in_array(entryPeer::STATUS, $modifiedColumns)
 				|| (in_array(entryPeer::LENGTH_IN_MSECS, $modifiedColumns)
 					&& $object->getColumnsOldValue(entryPeer::LENGTH_IN_MSECS) === 0))

--- a/plugins/reach/lib/kReachManager.php
+++ b/plugins/reach/lib/kReachManager.php
@@ -390,7 +390,9 @@ class kReachManager implements kObjectChangedEventConsumer, kObjectCreatedEventC
 			{
 				$this->handleEntryDurationChanged($object);
 			}
-			if (in_array(entryPeer::STATUS, $modifiedColumns))
+			if (in_array(entryPeer::STATUS, $modifiedColumns)
+				|| (in_array(entryPeer::LENGTH_IN_MSECS, $modifiedColumns)
+					&& $object->getColumnsOldValue(entryPeer::LENGTH_IN_MSECS) === 0))
 			{
 				if ($object->getStatus() == entryStatus::READY && !$object->getBlockAutoTranscript())
 				{


### PR DESCRIPTION
 support REACH automatic rules for External-Media type when updating duration after entry was added (KMS current flow)

* When KMS add External Media (YouTube) they first do externalMedia-->add and only then update with 'msDuration'