### PR TITLE
PSVAMB-28297: Fix False recording blocking

### DIFF
--- a/api_v3/lib/KalturaLiveEntryService.php
+++ b/api_v3/lib/KalturaLiveEntryService.php
@@ -543,7 +543,7 @@ class KalturaLiveEntryService extends KalturaEntryService
 		{
 			return false;
 		}
-		if ($forcePrimaryValidation && $mediaServerIndex !== EntryServerNodeType::LIVE_PRIMARY)
+		if ($forcePrimaryValidation && $mediaServerIndex != EntryServerNodeType::LIVE_PRIMARY)
 		{
 			return false;
 		}


### PR DESCRIPTION
When comparing $mediaServerIndex and EntryServerNodeType::LIVE_PRIMARY should not be strongly typed.