### PR TITLE
LIV-780: fix False recording blocking

### DIFF
--- a/api_v3/lib/KalturaLiveEntryService.php
+++ b/api_v3/lib/KalturaLiveEntryService.php
@@ -543,7 +543,7 @@ class KalturaLiveEntryService extends KalturaEntryService
 		{
 			return false;
 		}
-		if ($forcePrimaryValidation && $mediaServerIndex !== EntryServerNodeType::LIVE_PRIMARY)
+		if ($forcePrimaryValidation && $mediaServerIndex != EntryServerNodeType::LIVE_PRIMARY)
 		{
 			return false;
 		}


### PR DESCRIPTION
"old" live system sending the "mediaServerIndex" as string (https://github.com/kaltura/liveDVR/blob/3.0/lib/kaltura-client-lib/KalturaTypes.js#L2427). in the past, before refactor of LIV-780 (https://github.com/kaltura/server/pull/10948) we didn't compared the type.