### PR TITLE
replaced condition that could cause issues if shouldServeVodFromLive …

### DIFF
--- a/plugins/media/live_cluster/lib/model/LiveClusterMediaServerNode.php
+++ b/plugins/media/live_cluster/lib/model/LiveClusterMediaServerNode.php
@@ -69,7 +69,7 @@ class LiveClusterMediaServerNode extends MediaServerNode
 
 	protected function getThumbTimeline($entry)
 	{
-		if (myEntryUtils::shouldServeVodFromLive($entry))
+		if ($entry->getType() != entryType::LIVE_STREAM)
 		{
 			return $entry->getId();
 		}


### PR DESCRIPTION
changed to prevent the error seen here
[FW- PHP Fatal error in LiveClusterMediaServerNode.php line 77.eml.zip](https://github.com/kaltura/server/files/7581704/FW-.PHP.Fatal.error.in.LiveClusterMediaServerNode.php.line.77.eml.zip)
:
