### PR TITLE
apimon: improve ps2 tracking

### DIFF
--- a/infra/monitor/KalturaMonitorClient.php
+++ b/infra/monitor/KalturaMonitorClient.php
@@ -291,17 +291,29 @@ class KalturaMonitorClient
 	{
 		$context = sfContext::getInstance();
 		$request = $context->getRequest();
-		$action = $request->getParameter('module') . '.' . $request->getParameter('action');
-		if (strtolower($action) == 'extwidget.playmanifest')
+
+		$module = $request->getParameter('module');
+		$action = $module . '.' . $request->getParameter('action');
+		switch (strtolower($action))
 		{
+		case 'extwidget.playmanifest':
 			return;		// handled by kApiCache
+
+		case 'partnerservices2.defpartnerservices2base':
+			$realAction = $request->getParameter('myaction');
+			if ($realAction)
+			{
+				$action = $module . '.' . $realAction;
+			}
+			break;
 		}
 
 		$params = infraRequestUtils::getRequestParams();
 		$sessionType = isset($params['ks']) ? kSessionBase::SESSION_TYPE_USER : kSessionBase::SESSION_TYPE_NONE;	// assume user ks
 		$clientTag = isset($params['clientTag']) ? $params['clientTag'] : null;
+		$partnerId = isset($params['partner_id']) ? $params['partner_id'] : null;
 
-		self::monitorApiStart(false, $action, null, $sessionType, $clientTag);
+		self::monitorApiStart(false, $action, $partnerId, $sessionType, $clientTag);
 	}
 
 	public static function monitorApiEnd($errorCode)

--- a/infra/monitor/KalturaMonitorClient.php
+++ b/infra/monitor/KalturaMonitorClient.php
@@ -311,7 +311,7 @@ class KalturaMonitorClient
 		$params = infraRequestUtils::getRequestParams();
 		$sessionType = isset($params['ks']) ? kSessionBase::SESSION_TYPE_USER : kSessionBase::SESSION_TYPE_NONE;	// assume user ks
 		$clientTag = isset($params['clientTag']) ? $params['clientTag'] : null;
-		$partnerId = isset($params['partner_id']) ? $params['partner_id'] : null;
+		$partnerId = isset($params['partner_id']) && ctype_digit($params['partner_id']) ? $params['partner_id'] : null;
 
 		self::monitorApiStart(false, $action, $partnerId, $sessionType, $clientTag);
 	}


### PR DESCRIPTION
- report the real action name when using defpartnerservices2base
- use the partner_id query param, if exists