### PR TITLE
apimon: add exec errors

### DIFF
--- a/infra/general/kExecWrapper.php
+++ b/infra/general/kExecWrapper.php
@@ -52,7 +52,7 @@ class kExecWrapper
 		
 		$startTime = microtime(true);
 		list($return_value, $output, $errorDescription)  = self::runWrappedCommand($command, $filePath);
-		KalturaMonitorClient::monitorExec($command . " " . $filePath, $startTime, $return_value ? 'ERROR_' . $return_value : '');
+		KalturaMonitorClient::monitorExec($command . " " . $filePath, $startTime, $return_value ? 'EXEC_' . $return_value : '');
 		return array($return_value, $output, $errorDescription);
 	}
 	

--- a/infra/general/kExecWrapper.php
+++ b/infra/general/kExecWrapper.php
@@ -12,7 +12,7 @@ class kExecWrapper
 
 		$startTime = microtime(true);
 		$res = exec($command, $output, $return_var);
-		KalturaMonitorClient::monitorExec($command, $startTime);
+		KalturaMonitorClient::monitorExec($command, $startTime, $res === false ? 'ERROR' : '');
 		return $res;
 	}
 
@@ -22,7 +22,7 @@ class kExecWrapper
 
 		$startTime = microtime(true);
 		$res = system($command, $return_var);
-		KalturaMonitorClient::monitorExec($command, $startTime);
+		KalturaMonitorClient::monitorExec($command, $startTime, $res === false ? 'ERROR' : '');
 		return $res;
 	}
 
@@ -52,7 +52,7 @@ class kExecWrapper
 		
 		$startTime = microtime(true);
 		list($return_value, $output, $errorDescription)  = self::runWrappedCommand($command, $filePath);
-		KalturaMonitorClient::monitorExec($command . " " . $filePath, $startTime);
+		KalturaMonitorClient::monitorExec($command . " " . $filePath, $startTime, $return_value ? 'ERROR_' . $return_value : '');
 		return array($return_value, $output, $errorDescription);
 	}
 	

--- a/infra/monitor/KalturaMonitorClient.php
+++ b/infra/monitor/KalturaMonitorClient.php
@@ -651,7 +651,7 @@ class KalturaMonitorClient
 		self::$sleepCount++;
 	}
 
-	public static function monitorExec($command, $startTime)
+	public static function monitorExec($command, $startTime, $errorCode='')
 	{
 		if (!self::$stream)
 			return;
@@ -669,6 +669,7 @@ class KalturaMonitorClient
 			self::FIELD_EVENT_TYPE 		=> self::EVENT_EXEC,
 			self::FIELD_COMMAND			=> $command,
 			self::FIELD_EXECUTION_TIME	=> microtime(true) - $startTime,
+			self::FIELD_ERROR_CODE		=> $errorCode,
 		));
 
 		self::writeDeferredEvent($data);


### PR DESCRIPTION
shell_exec / passthru do not return error, and are therefore not
monitored