### PR TITLE
FOUN-320: fix static content flow not being applied for clipped entries

### DIFF
--- a/alpha/apps/kaltura/lib/batch2/bcdl/kBusinessPreConvertDL.php
+++ b/alpha/apps/kaltura/lib/batch2/bcdl/kBusinessPreConvertDL.php
@@ -2324,7 +2324,8 @@ KalturaLog::log("Forcing (create anyway) target $matchSourceHeightIdx");
 	public static function getConversionProfileKey(Entry $entry)
 	{
 		$adminTags = $entry->getAdminTagsArr();
-		if ($entry->getSourceType() == EntrySourceType::LECTURE_CAPTURE)
+		if ($entry->getSourceType() == EntrySourceType::LECTURE_CAPTURE
+			|| $entry->getSourceEntry()->getSourceType() == EntrySourceType::LECTURE_CAPTURE)
 		{
 			if (in_array('kalturaclassroom', $adminTags))
 			{

--- a/alpha/lib/model/entry.php
+++ b/alpha/lib/model/entry.php
@@ -1880,8 +1880,19 @@ class entry extends Baseentry implements ISyncableFile, IIndexable, IOwnable, IR
 		}
 		
 		$parentEntry = entryPeer::retrieveByPK($this->getParentEntryId());
-		
 		return $parentEntry;
+	}
+	
+	public function getSourceEntry()
+	{
+		if (!$this->getSourceEntryId())
+		{
+			KalturaLog::info("Attempting to get source entry of entry " . $this->getId() . " but source does not exist, returning original entry");
+			return $this;
+		}
+		
+		$sourceEntry = entryPeer::retrieveByPK($this->getSourceEntryId());
+		return $sourceEntry;
 	}
 	
 	public function getSecurityParentId()


### PR DESCRIPTION
@yossipapi @gotlieb - currently I made the 'minimum' but think we can save DB hit (to fetch source entry) if we check if entry sourceType == clip --> if yes --> fetch sourceEntry

Also - do we need to apply it to all other cases? (so in which case best to take if out of if statement)

Let me know if you have any feedback
Thanks