### PR TITLE
LIV-846: simulive to live transition (and vice versa)

### DIFF
--- a/alpha/apps/kaltura/lib/kSimuliveUtils.php
+++ b/alpha/apps/kaltura/lib/kSimuliveUtils.php
@@ -62,10 +62,7 @@ class kSimuliveUtils
 
 		if (self::shouldLiveInterrupt($entry, $currentEvent))
 		{
-			// we need to add margin to broadcastStartTime as it's in the past and the player may already requested segments after this time
-			$broadcastPlayableStartTimeMs = $entry->getCurrentBroadcastStartTime() * self::SECOND_IN_MILLISECONDS + self::MINIMUM_TIME_TO_PLAYABLE_SEC * self::SECOND_IN_MILLISECONDS;
-			$durations = self::recalculateDurations($durations, $startTime, $broadcastPlayableStartTimeMs);
-			// endTime null will cause staled manifest and trigger "playManifest" by the player
+			// endTime null will cause the vod packager to return 404 (expired) and trigger "playManifest" by the player
 			$endTime = null;
 		}
 
@@ -286,32 +283,4 @@ class kSimuliveUtils
 		return $event->isInterruptibleNow() && $entry->getEntryServerNodeStatusForPlayback() === EntryServerNodeStatus::PLAYABLE;
 	}
 
-	/**
-	 * getting the durations array, event start time and the "real" live playable start time (epoch sec).
-	 * creating and returning new durations array s.t the duration element that overlaps with "playableStartLive" time will be shorten
-	 * to duration that ending at "playableStartLive", and all the other durations after will get duration of "1" (as 0 isn't valid value for packager)
-	 *
-	 * @param array $durations
-	 * @param int $startDate
-	 * @param int $playableStartLive
-	 * @return array
-	 */
-	public static function recalculateDurations($durations, $startDate, $playableStartLive)
-	{
-		$newDurations = [];
-		$accumulated = 0;
-		for ($i = 0; $i < count($durations); $i++)
-		{
-			$accumulated += $durations[$i];
-			if ($startDate + $accumulated >= $playableStartLive)
-			{
-				$newDurations[] = max($durations[$i] - ($startDate + $accumulated - $playableStartLive), 1); // 1 as 0 is not valid for the packager
-			}
-			else
-			{
-				$newDurations[] = $durations[$i];
-			}
-		}
-		return $newDurations;
-	}
 }

--- a/alpha/apps/kaltura/lib/kSimuliveUtils.php
+++ b/alpha/apps/kaltura/lib/kSimuliveUtils.php
@@ -62,7 +62,7 @@ class kSimuliveUtils
 
 		if (self::shouldLiveInterrupt($entry, $currentEvent))
 		{
-			// endTime null will cause the vod packager to return 404 (expired) and trigger "playManifest" by the player
+			// endTime null will cause "expirationTime" to be added to the json
 			$endTime = null;
 		}
 

--- a/alpha/apps/kaltura/lib/kSimuliveUtils.php
+++ b/alpha/apps/kaltura/lib/kSimuliveUtils.php
@@ -63,8 +63,8 @@ class kSimuliveUtils
 		if (self::shouldLiveInterrupt($entry, $currentEvent))
 		{
 			// we need to add margin to broadcastStartTime as it's in the past and the player may already requested segments after this time
-			$broadcastStartTimeMs = $entry->getCurrentBroadcastStartTime() * self::SECOND_IN_MILLISECONDS + self::MINIMUM_TIME_TO_PLAYABLE_SEC * self::SECOND_IN_MILLISECONDS;
-			$durations = self::recalculateDurations($durations, $startTime, $broadcastStartTimeMs);
+			$broadcastPlayableStartTimeMs = $entry->getCurrentBroadcastStartTime() * self::SECOND_IN_MILLISECONDS + self::MINIMUM_TIME_TO_PLAYABLE_SEC * self::SECOND_IN_MILLISECONDS;
+			$durations = self::recalculateDurations($durations, $startTime, $broadcastPlayableStartTimeMs);
 			// endTime null will cause staled manifest and trigger "playManifest" by the player
 			$endTime = null;
 		}
@@ -283,33 +283,29 @@ class kSimuliveUtils
 	 */
 	public static function shouldLiveInterrupt (LiveEntry $entry, ILiveStreamScheduleEvent $event)
 	{
-		if ($event->isInterruptibleNow())
-		{
-			return $entry->getInternalLiveStatus() === EntryServerNodeStatus::PLAYABLE;
-		}
-		return false;
+		return $event->isInterruptibleNow() && $entry->getEntryServerNodeStatusForPlayback() === EntryServerNodeStatus::PLAYABLE;
 	}
 
 	/**
-	 * getting the durations array, event start time and the "real" live start time (epoch sec).
-	 * creating and returning new durations array s.t the duration element that overlaps with "startLive" time will be shorten
-	 * to duration that ending at "startLive", and all the other durations after will get duration of "1" (as 0 isn't valid value for packager)
+	 * getting the durations array, event start time and the "real" live playable start time (epoch sec).
+	 * creating and returning new durations array s.t the duration element that overlaps with "playableStartLive" time will be shorten
+	 * to duration that ending at "playableStartLive", and all the other durations after will get duration of "1" (as 0 isn't valid value for packager)
 	 *
 	 * @param array $durations
 	 * @param int $startDate
-	 * @param int $startLive
+	 * @param int $playableStartLive
 	 * @return array
 	 */
-	public static function recalculateDurations($durations, $startDate, $startLive)
+	public static function recalculateDurations($durations, $startDate, $playableStartLive)
 	{
 		$newDurations = [];
 		$accumulated = 0;
 		for ($i = 0; $i < count($durations); $i++)
 		{
 			$accumulated += $durations[$i];
-			if ($startDate + $accumulated >= $startLive)
+			if ($startDate + $accumulated >= $playableStartLive)
 			{
-				$newDurations[] = max($durations[$i] - ($startDate + $accumulated - $startLive), 1); // 1 as 0 is not valid for the packager
+				$newDurations[] = max($durations[$i] - ($startDate + $accumulated - $playableStartLive), 1); // 1 as 0 is not valid for the packager
 			}
 			else
 			{

--- a/alpha/apps/kaltura/lib/scheduleEvent/ILiveStreamScheduleEvent.php
+++ b/alpha/apps/kaltura/lib/scheduleEvent/ILiveStreamScheduleEvent.php
@@ -5,4 +5,5 @@ interface ILiveStreamScheduleEvent extends IScheduleEvent
 	public function getSourceEntryId();
 	public function getPreStartEntryId();
 	public function getPostEndEntryId();
+	public function isInterruptibleNow();
 }

--- a/alpha/apps/kaltura/modules/extwidget/actions/playManifestAction.class.php
+++ b/alpha/apps/kaltura/modules/extwidget/actions/playManifestAction.class.php
@@ -1318,7 +1318,11 @@ class playManifestAction extends kalturaAction
 		$event = kSimuliveUtils::getPlayableSimuliveEvent($this->entry,  $this->getScheduleTime());
 		if ($event)
 		{
-			$this->initEventData($event);
+			// serve as simulive only if shouldn't be interrupted by "real" live
+			if (!kSimuliveUtils::shouldLiveInterrupt($this->entry, $event))
+			{
+				$this->initEventData($event);
+			}
 		}
 
 		$renderer = null;

--- a/alpha/apps/kaltura/modules/extwidget/actions/serveFlavorAction.class.php
+++ b/alpha/apps/kaltura/modules/extwidget/actions/serveFlavorAction.class.php
@@ -133,8 +133,9 @@ class serveFlavorAction extends kalturaAction
 		{
 			$mediaSet['presentationEndTime'] = $endTime + $offset;
 		}
-		else if (!is_null($dvrWindow)) // the case of simulive flow that should be expired now (switch to "real" live)
+		else if (!is_null($dvrWindow)) // the case of simulive flow that should be expired now
 		{
+			// expirationTime will cause the hls playlist to be expired from now (as we need to switch from simulive to live)
 			$mediaSet['expirationTime'] = time() * self::SECOND_IN_MILLISECONDS - self::TIME_MARGIN;
 		}
 

--- a/alpha/apps/kaltura/modules/extwidget/actions/serveFlavorAction.class.php
+++ b/alpha/apps/kaltura/modules/extwidget/actions/serveFlavorAction.class.php
@@ -133,6 +133,10 @@ class serveFlavorAction extends kalturaAction
 		{
 			$mediaSet['presentationEndTime'] = $endTime + $offset;
 		}
+		else if (!is_null($dvrWindow)) // the case of simulive flow that should be expired now (switch to "real" live)
+		{
+			$mediaSet['expirationTime'] = time() * self::SECOND_IN_MILLISECONDS - self::TIME_MARGIN;
+		}
 
 		if($repeat)
 		{

--- a/alpha/apps/kaltura/modules/extwidget/actions/serveFlavorAction.class.php
+++ b/alpha/apps/kaltura/modules/extwidget/actions/serveFlavorAction.class.php
@@ -136,7 +136,7 @@ class serveFlavorAction extends kalturaAction
 		else if (!is_null($dvrWindow)) // the case of simulive flow that should be expired now
 		{
 			// expirationTime will cause the hls playlist to be expired from now (as we need to switch from simulive to live)
-			$mediaSet['expirationTime'] = time() * self::SECOND_IN_MILLISECONDS - self::TIME_MARGIN;
+			$mediaSet['expirationTime'] = time() * self::SECOND_IN_MILLISECONDS + $offset - self::TIME_MARGIN;
 		}
 
 		if($repeat)

--- a/alpha/lib/model/LiveEntry.php
+++ b/alpha/lib/model/LiveEntry.php
@@ -653,7 +653,7 @@ abstract class LiveEntry extends entry
 	}
 	
 	
-	protected function getInternalLiveStatus($checkExplicitLive = false)
+	public function getInternalLiveStatus($checkExplicitLive = false)
 	{
 		$statusOrder = array(EntryServerNodeStatus::STOPPED, EntryServerNodeStatus::AUTHENTICATED, EntryServerNodeStatus::BROADCASTING, EntryServerNodeStatus::PLAYABLE);
 		$status = EntryServerNodeStatus::STOPPED;

--- a/alpha/lib/model/LiveEntry.php
+++ b/alpha/lib/model/LiveEntry.php
@@ -555,7 +555,7 @@ abstract class LiveEntry extends entry
 		
 		if (in_array($this->getSource(), LiveEntry::$kalturaLiveSourceTypes))
 		{
-			return $this->getInternalLiveStatus($checkExplicitLive);
+			return $this->getEntryServerNodeStatusForPlayback($checkExplicitLive);
 		}
 		else
 		{
@@ -653,7 +653,7 @@ abstract class LiveEntry extends entry
 	}
 	
 	
-	public function getInternalLiveStatus($checkExplicitLive = false)
+	public function getEntryServerNodeStatusForPlayback($checkExplicitLive = false)
 	{
 		$statusOrder = array(EntryServerNodeStatus::STOPPED, EntryServerNodeStatus::AUTHENTICATED, EntryServerNodeStatus::BROADCASTING, EntryServerNodeStatus::PLAYABLE);
 		$status = EntryServerNodeStatus::STOPPED;

--- a/plugins/schedule/base/lib/api/KalturaLiveStreamScheduleEvent.php
+++ b/plugins/schedule/base/lib/api/KalturaLiveStreamScheduleEvent.php
@@ -41,6 +41,12 @@ class KalturaLiveStreamScheduleEvent extends KalturaBaseLiveScheduleEvent
 	 * @var string
 	 */
 	public $postEndEntryId;
+
+	/**
+	 * Detect whether "real" live can interrupt to the "main" content
+	 * @var bool
+	 */
+	public $isContentInterruptible;
 	
 	
 	/* (non-PHPdoc)
@@ -69,6 +75,7 @@ class KalturaLiveStreamScheduleEvent extends KalturaBaseLiveScheduleEvent
 		'endDate' => 'endScreenTime',
 		'preStartEntryId',
 		'postEndEntryId',
+		'isContentInterruptible',
 	);
 
 	/* (non-PHPdoc)

--- a/plugins/schedule/base/lib/model/LiveStreamScheduleEvent.php
+++ b/plugins/schedule/base/lib/model/LiveStreamScheduleEvent.php
@@ -3,7 +3,7 @@
  * @package plugins.schedule
  * @subpackage model
  */
-class LiveStreamScheduleEvent extends BaseLiveStreamScheduleEvent
+class LiveStreamScheduleEvent extends BaseLiveStreamScheduleEvent implements ILiveStreamScheduleEvent
 {
 	const PROJECTED_AUDIENCE = 'projected_audience';
 	const PRE_START_TIME = 'pre_start_time';
@@ -13,6 +13,7 @@ class LiveStreamScheduleEvent extends BaseLiveStreamScheduleEvent
 	const SOURCE_ENTRY_ID = 'source_entry_id';
 	const PRE_START_ENTRY_ID = 'pre_start_entry_id';
 	const POST_END_ENTRY_ID = 'post_end_entry_id';
+	const IS_CONTENT_INTERRUPTIBLE = 'is_content_interruptible';
 	
 	/**
 	 * @param string $v
@@ -223,4 +224,29 @@ class LiveStreamScheduleEvent extends BaseLiveStreamScheduleEvent
 		$this->setCustomDataObj();
 		return true;
 	}
+
+	/**
+	 * @param bool $v
+	 */
+	public function setIsContentInterruptible($v)
+	{
+		$this->putInCustomData(self::IS_CONTENT_INTERRUPTIBLE, $v);
+	}
+
+	public function getIsContentInterruptible()
+	{
+		return $this->getFromCustomData(self::IS_CONTENT_INTERRUPTIBLE);
+	}
+
+	protected function isInsideContent()
+	{
+		$now = time();
+		return $now > $this->getStartScreenTime() && $now < $this->getEndScreenTime();
+	}
+
+	public function isInterruptibleNow()
+	{
+		return $this->getIsContentInterruptible() || !$this->isInsideContent();
+	}
+
 }


### PR DESCRIPTION
add "isContentInterruptible" field to LiveStreamScheduleEvent's custom data which define whether the "main" content (sourceEntry) of the simulive can be interrupted by a "real" live stream. by definition - preStart/postEnd content always interruptible.
in playManifest action - for simulive flow - if "real" live streaming right now and the event is interruptible now - serve as regular live and not as simulive.
change "getInternalLiveStatus" to public - as we need to call it from "kSimuliveUtils"
**from the serveFlavor perspective:**
-  if live interrupted - set endTime as null, which will cause addition of "expirationTime" to the json, will cause the requests to packager to get 404  and trigger new playManifest request by the player