### PR TITLE
kPlayManifestCacher: ignore missing files

### DIFF
--- a/alpha/apps/kaltura/lib/cache/kPlayManifestCacher.php
+++ b/alpha/apps/kaltura/lib/cache/kPlayManifestCacher.php
@@ -86,7 +86,10 @@ class kPlayManifestCacher extends kApiCache
 		$requiredFiles = explode(',', $this->_responseMetadata);
 		foreach ($requiredFiles as $requiredFile)
 		{
-			require_once($requiredFile);
+			if (!include_once($requiredFile))
+			{
+				return;
+			}
 		}
 		$renderer = unserialize($serializedRenderer);
 		


### PR DESCRIPTION
this can happen when switching versions, just ignore the error and avoid
using the cache