### PR TITLE
LIV-894: fix simulive to live playManifest cache issue

### DIFF
--- a/alpha/apps/kaltura/lib/cache/kApiCacheBase.php
+++ b/alpha/apps/kaltura/lib/cache/kApiCacheBase.php
@@ -137,7 +137,12 @@ class kApiCacheBase
 			$curInstance->disableConditionalCacheInternal();
 		}
 	}
-	
+
+	public static function disableAnonymousCache()
+	{
+		self::setExpiry(-1);
+	}
+
 	protected function disableConditionalCacheInternal()
 	{
 		if (self::$_debugMode && $this->_cacheStatus != self::CACHE_STATUS_ANONYMOUS_ONLY)

--- a/alpha/apps/kaltura/modules/extwidget/actions/playManifestAction.class.php
+++ b/alpha/apps/kaltura/modules/extwidget/actions/playManifestAction.class.php
@@ -1571,5 +1571,4 @@ class playManifestAction extends kalturaAction
 		}
 		$this->servedEntryType = $sourceEntry->getType();
 	}
-
 }

--- a/alpha/apps/kaltura/modules/extwidget/actions/playManifestAction.class.php
+++ b/alpha/apps/kaltura/modules/extwidget/actions/playManifestAction.class.php
@@ -1420,7 +1420,6 @@ class playManifestAction extends kalturaAction
 			$cache = kPlayManifestCacher::getInstance();
 			$cache->storeRendererToCache($renderer);
 		}
-
 		
 		// Output the response
 		KExternalErrors::terminateDispatch();

--- a/alpha/apps/kaltura/modules/extwidget/actions/playManifestAction.class.php
+++ b/alpha/apps/kaltura/modules/extwidget/actions/playManifestAction.class.php
@@ -1415,11 +1415,12 @@ class playManifestAction extends kalturaAction
 			$renderer->setRestrictAccessControlAllowOriginDomains(true);
 		}
 		
-		if (!$this->secureEntryHelper || !$this->secureEntryHelper->shouldDisableCache())
+		if (!$this->shouldDisableCache())
 		{
 			$cache = kPlayManifestCacher::getInstance();
 			$cache->storeRendererToCache($renderer);
 		}
+
 		
 		// Output the response
 		KExternalErrors::terminateDispatch();
@@ -1559,5 +1560,18 @@ class playManifestAction extends kalturaAction
 			KExternalErrors::dieError(KExternalErrors::ENTRY_NOT_FOUND);
 		}
 		$this->servedEntryType = $sourceEntry->getType();
+	}
+
+	protected function shouldDisableCache()
+	{
+		if ($this->secureEntryHelper && $this->secureEntryHelper->shouldDisableCache())
+		{
+			return true;
+		}
+		if ($this->isSimuliveFlow() && (!kCurrentContext::$ks_object || kCurrentContext::$ks_object->isAnonymousSession()))
+		{
+			return true;
+		}
+		return false;
 	}
 }


### PR DESCRIPTION
in case of anonymous request - the playManifest response might be stuck in cache for up to 10 min (default cache time for playManifest responses)
this cache might break the simulive to live feature, as the player might get playManifest response that redirect it to vod packager instead of live (or the opposite), and break the playback transition.
The solution is that in case of anonymous playManifest request of **simulive flow only (!)**, we disabling the cache