### PR TITLE
LIV-894-B: simulive to live - another caching issue

### DIFF
--- a/alpha/apps/kaltura/lib/kSimuliveUtils.php
+++ b/alpha/apps/kaltura/lib/kSimuliveUtils.php
@@ -283,4 +283,24 @@ class kSimuliveUtils
 		return $event->isInterruptibleNow() && $entry->getEntryServerNodeStatusForPlayback() === EntryServerNodeStatus::PLAYABLE;
 	}
 
+	/**
+	 * @param ILiveStreamScheduleEvent $event
+	 * @param int $time
+	 * @return int - the time of the future closest transition timestamp that comes after $time, if there isn't such transition time - return 0
+	 */
+	public static function getClosestPlaybackTransitionTime($event, $time)
+	{
+		$eventTransitionTimes = $event->getEventTransitionTimes();
+		KalturaLog::info(print_r($eventTransitionTimes, true));
+		// find the first closest future transition time
+		foreach ($eventTransitionTimes as $transitionTime)
+		{
+			if ($time < $transitionTime)
+			{
+				return $transitionTime;
+			}
+		}
+		// we shouldn't arrive this if $time is inside event
+		return 0;
+	}
 }

--- a/alpha/apps/kaltura/lib/kSimuliveUtils.php
+++ b/alpha/apps/kaltura/lib/kSimuliveUtils.php
@@ -291,7 +291,6 @@ class kSimuliveUtils
 	public static function getClosestPlaybackTransitionTime($event, $time)
 	{
 		$eventTransitionTimes = $event->getEventTransitionTimes();
-		KalturaLog::info(print_r($eventTransitionTimes, true));
 		// find the first closest future transition time
 		foreach ($eventTransitionTimes as $transitionTime)
 		{

--- a/alpha/apps/kaltura/lib/scheduleEvent/ILiveStreamScheduleEvent.php
+++ b/alpha/apps/kaltura/lib/scheduleEvent/ILiveStreamScheduleEvent.php
@@ -6,4 +6,5 @@ interface ILiveStreamScheduleEvent extends IScheduleEvent
 	public function getPreStartEntryId();
 	public function getPostEndEntryId();
 	public function isInterruptibleNow();
+	public function getEventTransitionTimes();
 }

--- a/alpha/apps/kaltura/modules/extwidget/actions/playManifestAction.class.php
+++ b/alpha/apps/kaltura/modules/extwidget/actions/playManifestAction.class.php
@@ -1315,13 +1315,13 @@ class playManifestAction extends kalturaAction
 		$this->enforceEncryption();
 		
 		$this->servedEntryType = $this->entry->getType();
-		$playableEvent = kSimuliveUtils::getPlayableSimuliveEvent($this->entry,  $this->getScheduleTime());
-		if ($playableEvent)
+		$playableSimuliveEvent = kSimuliveUtils::getPlayableSimuliveEvent($this->entry,  $this->getScheduleTime());
+		if ($playableSimuliveEvent)
 		{
 			// serve as simulive only if shouldn't be interrupted by "real" live
-			if (!kSimuliveUtils::shouldLiveInterrupt($this->entry, $playableEvent))
+			if (!kSimuliveUtils::shouldLiveInterrupt($this->entry, $playableSimuliveEvent))
 			{
-				$this->initEventData($playableEvent);
+				$this->initEventData($playableSimuliveEvent);
 			}
 		}
 
@@ -1416,13 +1416,13 @@ class playManifestAction extends kalturaAction
 		}
 
 		// for simulive flow - we need to disable anonymous cache to avoid playback faults, and tune cond cache expiry to the closest transition time
-		if (!is_null($playableEvent))
+		if (!is_null($playableSimuliveEvent))
 		{
 			kApiCache::disableAnonymousCache();
 			$now = time();
-			$cacheExpiry = min(max(kSimuliveUtils::getClosestPlaybackTransitionTime($playableEvent, $now) - $now, 0), 600);
-			KalturaLog::info("setting simulive's playManifest conditional cache expiry of $cacheExpiry");
-			kApiCache::setConditionalCacheExpiry($cacheExpiry);
+			$timeToNextTransition = max(kSimuliveUtils::getClosestPlaybackTransitionTime($playableSimuliveEvent, $now) - $now, 0);
+			KalturaLog::info('time to next transition for event ID [' . $playableSimuliveEvent->getId() . "] : $timeToNextTransition");
+			kApiCache::setConditionalCacheExpiry(min($timeToNextTransition, 600));
 		}
 
 		if (!$this->secureEntryHelper || !$this->secureEntryHelper->shouldDisableCache())

--- a/plugins/schedule/base/lib/model/LiveStreamScheduleEvent.php
+++ b/plugins/schedule/base/lib/model/LiveStreamScheduleEvent.php
@@ -252,15 +252,16 @@ class LiveStreamScheduleEvent extends BaseLiveStreamScheduleEvent implements ILi
 	public function getEventTransitionTimes()
 	{
 		$transitionTimes = array();
+		$startScreenTime = $this->getStartScreenTime();
 		if ($this->getPreStartTime())
 		{
-			$transitionTimes[] = $this->getStartScreenTime() - $this->getPreStartTime(); // start of preStart
+			$transitionTimes[] = $startScreenTime - $this->getPreStartTime(); // start of preStart
 		}
-		$transitionTimes[] = $this->getStartScreenTime(); // start of main content / end of preStart
-		$transitionTimes[] = $this->getStartScreenTime() + $this->getDuration(); // end of main content / start of postEnd
+		$transitionTimes[] = $startScreenTime; // start of main content / end of preStart
+		$transitionTimes[] = $startScreenTime + $this->getDuration(); // end of main content / start of postEnd
 		if ($this->getPostEndTime())
 		{
-			$transitionTimes[] = $this->getStartScreenTime() + $this->getDuration() + $this->getPostEndTime(); // end of postEnd
+			$transitionTimes[] = $startScreenTime + $this->getDuration() + $this->getPostEndTime(); // end of postEnd
 		}
 		return $transitionTimes;
 	}

--- a/plugins/schedule/base/lib/model/LiveStreamScheduleEvent.php
+++ b/plugins/schedule/base/lib/model/LiveStreamScheduleEvent.php
@@ -249,4 +249,19 @@ class LiveStreamScheduleEvent extends BaseLiveStreamScheduleEvent implements ILi
 		return $this->getIsContentInterruptible() || !$this->isInsideContent();
 	}
 
+	public function getEventTransitionTimes()
+	{
+		$transitionTimes = array();
+		if ($this->getPreStartTime())
+		{
+			$transitionTimes[] = $this->getStartScreenTime() - $this->getPreStartTime(); // start of preStart
+		}
+		$transitionTimes[] = $this->getStartScreenTime(); // start of main content / end of preStart
+		$transitionTimes[] = $this->getStartScreenTime() + $this->getDuration(); // end of main content / start of postEnd
+		if ($this->getPostEndTime())
+		{
+			$transitionTimes[] = $this->getStartScreenTime() + $this->getDuration() + $this->getPostEndTime(); // end of postEnd
+		}
+		return $transitionTimes;
+	}
 }


### PR DESCRIPTION
Fixing the case of "real" live streaming while non-interruptible period. before this change - if PM request came after start streaming but before transition to interruptible period - it might stuck the playManifet response in cache with ttl finished after non-interruptible period finish - and cause playback transition failure:

![image](https://user-images.githubusercontent.com/24894820/151411589-4bbbea08-3719-481a-b964-638a95aed367.png)


The PR also contains simplification of https://github.com/kaltura/server/pull/11380

**The changes:**
added "getEventTransitionTimes" to LiveStreamScheduleEvent - which returning an array of transition times of playback (for example start of event playback / transition from main entry to post entry etc...)
added "getEventTransitionTimes" to ILiveStreamScheduleEvent interface
added "getClosestPlaybackTransitionTime" to kSiuliveUtils which getting an event and time and returning the closest transition of the event that comes after "$time"

in playManifest:
rename "event" to "playableEvent"
remove "liveInterruptedSimulive" boolean, as it can be calculated by checking if we have "playableEvent"
in case that we have "playableEvent" - calculate the conditional cache expiry according to the event's "closestPlaybackTransitionTime"