### PR TITLE
LIV-894: avoid setting condCacheExpiry of '-1'

### DIFF
--- a/alpha/apps/kaltura/lib/kSimuliveUtils.php
+++ b/alpha/apps/kaltura/lib/kSimuliveUtils.php
@@ -286,7 +286,7 @@ class kSimuliveUtils
 	/**
 	 * @param ILiveStreamScheduleEvent $event
 	 * @param int $time
-	 * @return int - the time of the future closest transition timestamp that comes after $time, if there isn't such transition time - return 0
+	 * @return int|null - the time of the future closest transition timestamp that comes after $time, if there isn't such transition time - return null
 	 */
 	public static function getClosestPlaybackTransitionTime($event, $time)
 	{
@@ -300,6 +300,6 @@ class kSimuliveUtils
 			}
 		}
 		// we shouldn't arrive this if $time is inside event
-		return 0;
+		return null;
 	}
 }

--- a/alpha/apps/kaltura/modules/extwidget/actions/playManifestAction.class.php
+++ b/alpha/apps/kaltura/modules/extwidget/actions/playManifestAction.class.php
@@ -1326,9 +1326,13 @@ class playManifestAction extends kalturaAction
 			// for simulive flow - we need to disable anonymous cache to avoid playback faults, and tune cond cache expiry to the closest transition time
 			kApiCache::disableAnonymousCache();
 			$now = time();
-			$timeToNextTransition = max(kSimuliveUtils::getClosestPlaybackTransitionTime($event, $now) - $now, -1);
-			KalturaLog::info('time to next transition for event ID [' . $event->getId() . "] : $timeToNextTransition");
-			kApiCache::setConditionalCacheExpiry(min($timeToNextTransition, kApiCache::CONDITIONAL_CACHE_EXPIRY));
+			$closestTransitionTime = kSimuliveUtils::getClosestPlaybackTransitionTime($event, $now);
+			if (!is_null($closestTransitionTime))
+			{
+				$timeToNextTransition = $closestTransitionTime - $now;
+				KalturaLog::info('time to next transition for event ID [' . $event->getId() . "] : $timeToNextTransition");
+				kApiCache::setConditionalCacheExpiry(min($timeToNextTransition, kApiCache::CONDITIONAL_CACHE_EXPIRY));
+			}
 		}
 
 		$renderer = null;


### PR DESCRIPTION
in case of request arrives exactly on the end of the event - "getClosestPlaybackTransitionTime" return 0 and the conCacheExpirty will be set to "-1". instead of that - in such case we don't want to touch the cond cache time.