### PR TITLE
SUP-31042: set executionScope of INDEXING before indexing (LIV-900)

### DIFF
--- a/alpha/apps/kaltura/lib/events/events/kObjectReadyForIndexEvent.php
+++ b/alpha/apps/kaltura/lib/events/events/kObjectReadyForIndexEvent.php
@@ -25,7 +25,10 @@ class kObjectReadyForIndexEvent extends kApplicativeEvent
 			$additionalLog .= 'id [' . $this->object->getId() . ']';
 			
 		KalturaLog::debug('consumer [' . get_class($consumer) . '] started handling [' . get_class($this) . '] object type [' . get_class($this->object) . '] ' . $additionalLog);
+		$origExecutionScope = kCurrentContext::$executionScope;
+		kCurrentContext::$executionScope = executionScope::INDEXING;
 		$result = $consumer->objectReadyForIndex($this->object, $this->raisedJob);
+		kCurrentContext::$executionScope = $origExecutionScope;
 		KalturaLog::debug('consumer [' . get_class($consumer) . '] finished handling [' . get_class($this) . '] object type [' . get_class($this->object) . '] ' . $additionalLog);
 		return $result;
 	}


### PR DESCRIPTION
set executionScope of INDEXING before indexing so simulive scheduleEvent's "getter" will return false and won't affect liveStatus of list action