### PR TITLE
fix: remove password from stack trace

### DIFF
--- a/alpha/lib/model/UserLoginData.php
+++ b/alpha/lib/model/UserLoginData.php
@@ -48,9 +48,9 @@ class UserLoginData extends BaseUserLoginData{
 	} 
 	
 	
-	public function isPasswordValid($password_to_match)
+	public function isPasswordValid(array $password_to_match)
 	{
-		return sha1( $this->getSalt().$password_to_match ) === $this->getSha1Password() ;
+		return sha1( $this->getSalt().$password_to_match[0] ) === $this->getSha1Password() ;
 	}
 	
 	

--- a/alpha/lib/model/UserLoginDataPeer.php
+++ b/alpha/lib/model/UserLoginDataPeer.php
@@ -468,7 +468,7 @@ class UserLoginDataPeer extends BaseUserLoginDataPeer implements IRelatedObjectP
 	}
 	
 	// user login by user_login_data record id
-	public static function userLoginByDataId($loginDataId, $password, $partnerId = null)
+	public static function userLoginByDataId($loginDataId, array $password, $partnerId = null)
 	{
 		$loginData = self::retrieveByPK($loginDataId);
 		if (!$loginData) {
@@ -479,7 +479,7 @@ class UserLoginDataPeer extends BaseUserLoginDataPeer implements IRelatedObjectP
 	}
 	
 	// user login by login_email
-	public static function userLoginByEmail($email, $password, $partnerId = null, $otp = null)
+	public static function userLoginByEmail($email, array $password, $partnerId = null, $otp = null)
 	{
 		$loginData = self::getByEmail($email);
 		if (!$loginData) {
@@ -528,7 +528,7 @@ class UserLoginDataPeer extends BaseUserLoginDataPeer implements IRelatedObjectP
 	}
 
 	// user login by user_login_data object
-	private static function userLogin(UserLoginData $loginData = null, $password, $partnerId = null, $validatePassword = true, $otp = null, $validateOtp = true)
+	private static function userLogin(UserLoginData $loginData = null, array $password, $partnerId = null, $validatePassword = true, $otp = null, $validateOtp = true)
 	{
 		$requestedPartner = $partnerId;
 		$kuser = null;

--- a/alpha/lib/model/kuserPeer.php
+++ b/alpha/lib/model/kuserPeer.php
@@ -402,11 +402,11 @@ class kuserPeer extends BasekuserPeer implements IRelatedObjectPeer
 
 	/**
 	 * @param string $email
-	 * @param string $password
+	 * @param array $password
 	 * @param int $partnerId
 	 * @return kuser
 	 */
-	public static function userLogin($puserId, $password, $partnerId)
+	public static function userLogin($puserId, array $password, $partnerId)
 	{
 		$kuser = self::getKuserByPartnerAndUid($partnerId , $puserId);
 		if (!$kuser) {

--- a/api_v3/lib/KalturaBaseUserService.php
+++ b/api_v3/lib/KalturaBaseUserService.php
@@ -182,7 +182,7 @@ class KalturaBaseUserService extends KalturaBaseService
 	 * 
 	 * @param string $puserId
 	 * @param string $loginEmail
-	 * @param string $password
+	 * @param array $password
 	 * @param int $partnerId
 	 * @param int $expiry
 	 * @param string $privileges
@@ -199,7 +199,7 @@ class KalturaBaseUserService extends KalturaBaseService
 	 * @throws KalturaErrors::USER_IS_BLOCKED
 	 * @throws KalturaErrors::DIRECT_LOGIN_BLOCKED
 	 */		
-	protected function loginImpl($puserId, $loginEmail, $password, $partnerId = null, $expiry = 86400, $privileges = '*', $otp = null)
+	protected function loginImpl($puserId, $loginEmail, array $password, $partnerId = null, $expiry = 86400, $privileges = '*', $otp = null)
 	{
 		KalturaResponseCacher::disableCache();
 		myPartnerUtils::resetPartnerFilter('kuser');

--- a/api_v3/services/AdminUserService.php
+++ b/api_v3/services/AdminUserService.php
@@ -143,7 +143,7 @@ class AdminUserService extends KalturaBaseUserService
 	{
 		try
 		{
-			$ks = parent::loginImpl(null, $email, $password, $partnerId);
+			$ks = parent::loginImpl(null, $email, [$password], $partnerId);
 			$tempKs = kSessionUtils::crackKs($ks);
 			if (!$tempKs->isAdmin()) {
 				throw new KalturaAPIException(KalturaErrors::USER_DATA_ERROR);

--- a/api_v3/services/UserService.php
+++ b/api_v3/services/UserService.php
@@ -286,7 +286,7 @@ class UserService extends KalturaBaseUserService
 	public function loginAction($partnerId, $userId, $password, $expiry = 86400, $privileges = '*')
 	{
 		// exceptions might be thrown
-		return parent::loginImpl($userId, null, $password, $partnerId, $expiry, $privileges);
+		return parent::loginImpl($userId, null, [$password], $partnerId, $expiry, $privileges);
 	}
 	
 	/**
@@ -315,7 +315,7 @@ class UserService extends KalturaBaseUserService
 	public function loginByLoginIdAction($loginId, $password, $partnerId = null, $expiry = 86400, $privileges = '*', $otp = null)
 	{
 		// exceptions might be thrown
-		return parent::loginImpl(null, $loginId, $password, $partnerId, $expiry, $privileges, $otp);
+		return parent::loginImpl(null, $loginId, [$password], $partnerId, $expiry, $privileges, $otp);
 	}
 
 	protected static function validateLoginDataParams($paramsArray)


### PR DESCRIPTION
Password param used during login can be read in clear text in stack trace.
Put the password argument in an array, that way removing it from stack
trace.