### PR TITLE
VIRTC-18530: avoid consider linked events as overlap when updating

### DIFF
--- a/plugins/schedule/base/lib/api/KalturaEntryScheduleEvent.php
+++ b/plugins/schedule/base/lib/api/KalturaEntryScheduleEvent.php
@@ -59,8 +59,8 @@ abstract class KalturaEntryScheduleEvent extends KalturaScheduleEvent
 
 		if ($this->templateEntryId && $this->recurrenceType === KalturaScheduleEventRecurrenceType::NONE)
 		{
-			$events = ScheduleEventPeer::retrieveOtherEvents($this->templateEntryId, $startDate, $endDate, array($this->id));
-
+			$eventIdsToIgnore = array_merge(array($this->id) , array_filter(explode(',', $this->linkedBy)));
+			$events = ScheduleEventPeer::retrieveOtherEvents($this->templateEntryId, $startDate, $endDate, $eventIdsToIgnore);
 			if ($events)
 			{
 				throw new KalturaAPIException(KalturaScheduleErrors::SCHEDULE_TIME_IN_USE);

--- a/plugins/schedule/base/lib/api/KalturaScheduleEvent.php
+++ b/plugins/schedule/base/lib/api/KalturaScheduleEvent.php
@@ -446,6 +446,11 @@ abstract class KalturaScheduleEvent extends KalturaObject implements IRelatedFil
 		{
 			$this->recurrenceType = $sourceObject->getRecurrenceType();
 		}
+
+		if (is_null($this->linkedBy) && !is_null($sourceObject->getLinkedBy()))
+		{
+			$this->linkedBy = $sourceObject->getLinkedBy();
+		}
 		
 		$this->validate($startDate, $endDate);
 


### PR DESCRIPTION
currently updating scheduleEvent to a time that overlap with it's linked events will fail due to "Another event is already scheduled during this time".
we need to filter out the linked events when checking for overlapping events to avoid this problem