### PR TITLE
LIV-917: simulive - add support for playlist source

### DIFF
--- a/alpha/apps/kaltura/lib/kSimuliveUtils.php
+++ b/alpha/apps/kaltura/lib/kSimuliveUtils.php
@@ -313,7 +313,6 @@ class kSimuliveUtils
 			$entriesFlavorAssets = array_merge($entriesFlavorAssets, array($mainFlavorAssets));
 			$entriesCaptionAssets = array_merge($entriesCaptionAssets, array($mainCaptionAssets));
 			$entriesAudioAssets = array_merge($entriesAudioAssets, array($mainAudioAssets));
-			$durations[] = self::roundDuration($srcEntry->getLengthInMsecs());
 		}
 		return array($entriesFlavorAssets, $entriesCaptionAssets, $entriesAudioAssets);
 	}

--- a/alpha/apps/kaltura/lib/kSimuliveUtils.php
+++ b/alpha/apps/kaltura/lib/kSimuliveUtils.php
@@ -232,13 +232,11 @@ class kSimuliveUtils
 	protected static function createPaddedAssetsArray ($assets)
 	{
 		$paddedAssets = array();
-		$assetsExists = count(array_filter($assets));
+		// null padding should be according to the largest assets array
+		$assetsCount = count(max($assets));
 		// we need to handle caption / audio assets only if there is an asset for at least one of the entries
-		if ($assetsExists)
+		if ($assetsCount)
 		{
-			// null padding should be according to the largest assets array
-			$assetsCount = count(max($assets));
-
 			foreach ($assets as &$asset)
 			{
 				$asset = array_pad($asset, $assetsCount, null);
@@ -310,9 +308,9 @@ class kSimuliveUtils
 		foreach ($sourceEntries as $srcEntry)
 		{
 			list($mainFlavorAssets, $mainCaptionAssets, $mainAudioAssets) = myEntryUtils::getEntryAssets($srcEntry);
-			$entriesFlavorAssets = array_merge($entriesFlavorAssets, array($mainFlavorAssets));
-			$entriesCaptionAssets = array_merge($entriesCaptionAssets, array($mainCaptionAssets));
-			$entriesAudioAssets = array_merge($entriesAudioAssets, array($mainAudioAssets));
+			$entriesFlavorAssets[] = $mainFlavorAssets;
+			$entriesCaptionAssets[] = $mainCaptionAssets;
+			$entriesAudioAssets[] = $mainAudioAssets;
 		}
 		return array($entriesFlavorAssets, $entriesCaptionAssets, $entriesAudioAssets);
 	}

--- a/alpha/apps/kaltura/modules/extwidget/actions/playManifestAction.class.php
+++ b/alpha/apps/kaltura/modules/extwidget/actions/playManifestAction.class.php
@@ -1568,6 +1568,8 @@ class playManifestAction extends kalturaAction
 		{
 			KExternalErrors::dieError(KExternalErrors::ENTRY_NOT_FOUND);
 		}
-		$this->servedEntryType = $sourceEntry->getType();
+		$srcEntryType = $sourceEntry->getType();
+		// for simulive case with playlist source - servedEntryType should be MEDIA_CLIP
+		$this->servedEntryType = $srcEntryType == entryType::PLAYLIST ? entryType::MEDIA_CLIP : $srcEntryType;
 	}
 }


### PR DESCRIPTION
### playManifest changes:
in case of simulive with playlist source - override the servedType with MEDIA_CLIP to continue to the regular flow of simulive
### kSimuliveUtils:
in case of source of playlist type - create the json in accordance with all the playlist entries assets
**IMPORTANT:**
this PR will cause behavioral change for simulive. until now - if event total time was configured to be shorter than the sourceEntry - the source entry duration (only) in json was shorten to the event's total time. this PR changing it so if the event duration is shorter than the total time of all sources - the durations array will be transformed s.t the duration that causing the exceeding will be shorten to the remainder, and all the durations after will get the value of '1'.