### PR TITLE
LIV-932: simulive - chop the main content according to event duration

### DIFF
--- a/alpha/apps/kaltura/lib/kSimuliveUtils.php
+++ b/alpha/apps/kaltura/lib/kSimuliveUtils.php
@@ -326,7 +326,7 @@ class kSimuliveUtils
 	public static function getSourceDurations($sourceEntries, $event)
 	{
 		$durations = array();
-		$postEndDurationMs = $event->getPostEndEntryId() ? myEntryUtils::getEntryDuration($event->getPostEndEntryId(), true) : 0;
+		$postEndDurationMs = $event->getPostEndEntryId() ? self::roundDuration(myEntryUtils::getEntryDuration($event->getPostEndEntryId(), true)) : 0;
 		$eventDuration = $event->getCalculatedEndTime() * self::SECOND_IN_MILLISECONDS - $event->getCalculatedStartTime() * self::SECOND_IN_MILLISECONDS - $postEndDurationMs;
 		$aggregatedDuration = 0;
 		foreach ($sourceEntries as $srcEntry)

--- a/alpha/apps/kaltura/lib/kSimuliveUtils.php
+++ b/alpha/apps/kaltura/lib/kSimuliveUtils.php
@@ -326,7 +326,8 @@ class kSimuliveUtils
 	public static function getSourceDurations($sourceEntries, $event)
 	{
 		$durations = array();
-		$eventDuration = $event->getCalculatedEndTime() * self::SECOND_IN_MILLISECONDS - $event->getCalculatedStartTime() * self::SECOND_IN_MILLISECONDS;
+		$postEndDurationMs = $event->getPostEndEntryId() ? myEntryUtils::getEntryDuration($event->getPostEndEntryId(), true) : 0;
+		$eventDuration = $event->getCalculatedEndTime() * self::SECOND_IN_MILLISECONDS - $event->getCalculatedStartTime() * self::SECOND_IN_MILLISECONDS - $postEndDurationMs;
 		$aggregatedDuration = 0;
 		foreach ($sourceEntries as $srcEntry)
 		{
@@ -339,6 +340,10 @@ class kSimuliveUtils
 			{
 				$durations[] = $entryRoundedDuration;
 			}
+		}
+		if ($postEndDurationMs)
+		{
+			$durations[count($durations) - 1] = $postEndDurationMs;
 		}
 		return $durations;
 	}

--- a/alpha/apps/kaltura/lib/myEntryUtils.class.php
+++ b/alpha/apps/kaltura/lib/myEntryUtils.class.php
@@ -2318,4 +2318,20 @@ PuserKuserPeer::getCriteriaFilter()->disable();
 		
 		return in_array($rootEntry->getSourceType(), $sourceType);
 	}
+
+	/**
+	 * Returning the duration of the entry received (if entry doesn't exists - return 0)
+	 * @param string $entryId
+	 * @param bool $inMilliseconds
+	 * @return int
+	 */
+	public static function getEntryDuration($entryId, $inMilliseconds = false)
+	{
+		$entry = entryPeer::retrieveByPk($entryId);
+		if (!$entry)
+		{
+			return 0;
+		}
+		return $inMilliseconds ? $entry->getLengthInMsecs() : $entry->getDuration();
+	}
 }


### PR DESCRIPTION
chop the main content of simulive according to event main duration (excluding pre&post times), while preStart & postEnd entries content will always play the whole content
for example - content duraitons [1,10,1] and event durations of [1,5,1] => playback will be [1,5,1] (main content chopped from 10min to 5 min while pre&post playing their whole content)