### PR TITLE
No-Plat: cancel sim2live flow in case of playManifest request with time/offset

### DIFF
--- a/alpha/apps/kaltura/modules/extwidget/actions/playManifestAction.class.php
+++ b/alpha/apps/kaltura/modules/extwidget/actions/playManifestAction.class.php
@@ -1315,12 +1315,13 @@ class playManifestAction extends kalturaAction
 		$this->enforceEncryption();
 		
 		$this->servedEntryType = $this->entry->getType();
-		$event = kSimuliveUtils::getPlayableSimuliveEvent($this->entry,  $this->getScheduleTime());
+		$scheduleTime = $this->getScheduleTime();
+		$event = kSimuliveUtils::getPlayableSimuliveEvent($this->entry, $scheduleTime);
 		if ($event)
 		{
 			KalturaLog::info('Found event id: [' . $event->getId() . '] ');
-			// serve as simulive only if shouldn't be interrupted by "real" live
-			if (!kSimuliveUtils::shouldLiveInterrupt($this->entry, $event))
+			// serve as simulive only if shouldn't be interrupted by "real" live (or specific time/offset requested)
+			if ($scheduleTime || !kSimuliveUtils::shouldLiveInterrupt($this->entry, $event))
 			{
 				$this->initEventData($event);
 			}
@@ -1547,9 +1548,10 @@ class playManifestAction extends kalturaAction
 
     protected function getScheduleTime()
     {
-		$time = intval($this->getRequestParameter(kSimuliveUtils::SCHEDULE_TIME_URL_PARAM, time()));
-		$time += intval($this->getRequestParameter(kSimuliveUtils::SCHEDULE_TIME_OFFSET_URL_PARAM, 0));
-		return $time;
+		$time = intval($this->getRequestParameter(kSimuliveUtils::SCHEDULE_TIME_URL_PARAM, 0));
+		$offset = intval($this->getRequestParameter(kSimuliveUtils::SCHEDULE_TIME_OFFSET_URL_PARAM, 0));
+		$time = (!$time && $offset) ? time() : $time;
+		return $time + $offset;
     }
 
     protected function isSimuliveFlow()

--- a/alpha/apps/kaltura/modules/extwidget/actions/playManifestAction.class.php
+++ b/alpha/apps/kaltura/modules/extwidget/actions/playManifestAction.class.php
@@ -1315,13 +1315,13 @@ class playManifestAction extends kalturaAction
 		$this->enforceEncryption();
 		
 		$this->servedEntryType = $this->entry->getType();
-		$scheduleTime = $this->getScheduleTime();
-		$event = kSimuliveUtils::getPlayableSimuliveEvent($this->entry, $scheduleTime);
+		$requestedScheduleTime = $this->getRequestedScheduleTime();
+		$event = kSimuliveUtils::getPlayableSimuliveEvent($this->entry, $requestedScheduleTime);
 		if ($event)
 		{
 			KalturaLog::info('Found event id: [' . $event->getId() . '] ');
 			// serve as simulive only if shouldn't be interrupted by "real" live (or specific time/offset requested)
-			if ($scheduleTime || !kSimuliveUtils::shouldLiveInterrupt($this->entry, $event))
+			if ($requestedScheduleTime || !kSimuliveUtils::shouldLiveInterrupt($this->entry, $event))
 			{
 				$this->initEventData($event);
 			}
@@ -1546,7 +1546,7 @@ class playManifestAction extends kalturaAction
 		return array($maxDc, $remoteFlavors);
 	}
 
-    protected function getScheduleTime()
+    protected function getRequestedScheduleTime()
     {
 		$time = intval($this->getRequestParameter(kSimuliveUtils::SCHEDULE_TIME_URL_PARAM, 0));
 		$offset = intval($this->getRequestParameter(kSimuliveUtils::SCHEDULE_TIME_OFFSET_URL_PARAM, 0));


### PR DESCRIPTION
in case of playManifest request came with time / offset - we don't want to return a "real" live response even in case that "real" live interrupt (if got time / offset it doesn't make sense that interrupt occur as we can't predict)