### PR TITLE
docs: update api apptoken sessionprivileges

### DIFF
--- a/api_v3/lib/types/KalturaAppToken.php
+++ b/api_v3/lib/types/KalturaAppToken.php
@@ -85,7 +85,8 @@ class KalturaAppToken extends KalturaObject implements IFilterable
 	public $sessionDuration;
 
 	/**
-	 * Comma separated privileges to be applied on KS (Kaltura Session) that created using the current token
+	 * Privileges for KS created by this token. User role and privacy like so: setrole:<role id>,privacycontext:<privacy context label>
+	 *
 	 * @var string
 	 */
 	public $sessionPrivileges;

--- a/api_v3/lib/types/KalturaAppToken.php
+++ b/api_v3/lib/types/KalturaAppToken.php
@@ -85,7 +85,7 @@ class KalturaAppToken extends KalturaObject implements IFilterable
 	public $sessionDuration;
 
 	/**
-	 * Privileges for KS created by this token. User role and privacy like so: setrole:<role id>,privacycontext:<privacy context label>
+	 * Comma separated privileges to be applied on KS (Kaltura Session) that created using the current token. https://developer.kaltura.com/api-docs/VPaaS-API-Getting-Started/Kaltura_API_Authentication_and_Security.html#ks-privileges
 	 *
 	 * @var string
 	 */


### PR DESCRIPTION
Update description in API to be more aligned with
https://developer.kaltura.com/api-docs/VPaaS-API-Getting-Started/application-tokens.html

I've seen user try adding session privileges like so:
BASE_USER_SESSION_PERMISSION,WIDGET_SESSION_PERMISSION etc.

From the current API description I can see why they do that.