### PR TITLE
fix: update flavorparams live source naming

### DIFF
--- a/deployment/base/scripts/init_data/04.liveParams.ini
+++ b/deployment/base/scripts/init_data/04.liveParams.ini
@@ -3,8 +3,8 @@
 id=32
 version=0
 partnerId=0
-name="Source"
-systemName="Source"
+name="Source Livestream"
+systemName="Source Livestream"
 tags="source,ingest,web,mobile,ipad,ipadnew"
 description="Maintains the original format and settings of the input stream"
 readyBehavior=0


### PR DESCRIPTION
It's confusing to use the same name and systemName for livestream source and non-livestream source.

For instance, when doing KMC bulk-action download.
Let's say we download a mixed bag of entries, livestream VODs and non-livestream media entries.

If we want the source, usually source with flavorParams id = 0 will be selected, since being at the top of the list.
Downloading source from livestream vods will fail since it has flavorParams id = 32.

From a user perspective, you don't really know the sources have different flavorParams ids.
Changing the name will make this obvious when reviewing flavors in KMC.