### PR TITLE
LIV-932: simulive - consider the postEnd duration while chopping main playback

### DIFF
--- a/alpha/apps/kaltura/lib/kSimuliveUtils.php
+++ b/alpha/apps/kaltura/lib/kSimuliveUtils.php
@@ -326,8 +326,7 @@ class kSimuliveUtils
 	public static function getSourceDurations($sourceEntries, $event)
 	{
 		$durations = array();
-		$postEndDurationMs = $event->getPostEndEntryId() ? self::roundDuration(myEntryUtils::getEntryDuration($event->getPostEndEntryId(), true)) : 0;
-		$eventDuration = $event->getCalculatedEndTime() * self::SECOND_IN_MILLISECONDS - $event->getCalculatedStartTime() * self::SECOND_IN_MILLISECONDS - $postEndDurationMs;
+		$eventDuration = $event->getCalculatedEndTime() * self::SECOND_IN_MILLISECONDS - $event->getCalculatedStartTime() * self::SECOND_IN_MILLISECONDS;
 		$aggregatedDuration = 0;
 		foreach ($sourceEntries as $srcEntry)
 		{
@@ -340,10 +339,6 @@ class kSimuliveUtils
 			{
 				$durations[] = $entryRoundedDuration;
 			}
-		}
-		if ($postEndDurationMs)
-		{
-			$durations[count($durations) - 1] = $postEndDurationMs;
 		}
 		return $durations;
 	}


### PR DESCRIPTION
partially revert of https://github.com/kaltura/server/pull/11525/files
for example - content durations [10,25,15] and event durations of [10,**20**,15] => playback will be [10,**25**,**10**] (main content won't be chopped, but only the post for this case)