### PR TITLE
SUP-31486: get shorter expiry than 24 hours in session.impersonate

### DIFF
--- a/alpha/lib/model/Partner.php
+++ b/alpha/lib/model/Partner.php
@@ -129,7 +129,16 @@ class Partner extends BasePartner
 			in_array($partner_secret, $additionalSecrets, true) ||
 			(!$admin && $partner_secret === $this->getSecret()))
 		{
-			$ks_max_expiry_in_seconds = $this->getKsMaxExpiryInSeconds();
+			$ks_max_expiry_in_seconds_from_partner = $this->getKsMaxExpiryInSeconds();
+			if (!$ks_max_expiry_in_seconds_from_partner|| $ks_max_expiry_in_seconds_from_partner < 0){
+				$ks_max_expiry_in_seconds_from_partner = 86400;
+			}
+			if ($ks_max_expiry_in_seconds && $ks_max_expiry_in_seconds > 0) {
+				$ks_max_expiry_in_seconds = min($ks_max_expiry_in_seconds_from_partner, $ks_max_expiry_in_seconds);
+			}
+			else{
+				$ks_max_expiry_in_seconds = $ks_max_expiry_in_seconds_from_partner;
+			}
 			return true;
 		}
 		else


### PR DESCRIPTION
Cover the cases : 

1. Parter has expiry null or non positive and expiry from user is null or non positive - return 24 hours as expiry.
2. Parter has expiry null or non positive and expiry from user is less than 24 hours but positive - return expiry from user.
3. Parter has expiry null or non positive and expiry from user is more than 24 hours - return 24 hours as expiry.
4. Partner has positive value for expiry and expiry from user is null or non positive - return partner's expiry.
5. Partner has positive value for expiry and expiry from user is positive - return the minimum between them.

Not handled for now - case 5 when both of expiries are bigger than 24 hours.