### PR TITLE
Use __CLASS__ rather than `self::class`

### DIFF
--- a/alpha/apps/kaltura/lib/cache/myObjectCache.class.php
+++ b/alpha/apps/kaltura/lib/cache/myObjectCache.class.php
@@ -53,7 +53,7 @@ class myObjectCache
 
 		$key = $parnet_clazz . "_" . $id . "_arr_$field_name";
 		
-		KalturaLog::info (  self::class . ":putArray: $key" );
+		KalturaLog::info (  __CLASS__ . ":putArray: $key" );
 //		echo "putArray:" . $key . "(" . count ( $arr ) . ")\n" ;
 		
 		self::$s_memory_cache->put ( $key , $id_list , $this->m_expiry_in_seconds );

--- a/alpha/apps/kaltura/lib/fastdb/fastdb.class.php
+++ b/alpha/apps/kaltura/lib/fastdb/fastdb.class.php
@@ -19,12 +19,12 @@ class fdb
     {
         $obj = self::select($class_name, "id={$old_id}");
         if (!$obj) {
-            throw new Exception (self::class . ": error! did not find [{$class_name}] with {$old_id} to duplicate");
+            throw new Exception (__CLASS__ . ": error! did not find [{$class_name}] with {$old_id} to duplicate");
         }
 
         $temp_obj = self::select($class_name, "id={$new_id}");
         if ($temp_obj) {
-            throw new Exception (self::class . ": error! [{$class_name}] with {$new_id} already exists in db. cannot duplicate");
+            throw new Exception (__CLASS__ . ": error! [{$class_name}] with {$new_id} already exists in db. cannot duplicate");
         }
 
         $new_obj = $obj->copy();
@@ -59,7 +59,7 @@ class fdb
 
         if (empty ($class_name)) //|| empty ( $criteria_str ) )
         {
-            throw new Exception (self::class . ": error! cannot execute query for empty class [{$class_name}] or empty criteria [{$criteria_str}]");
+            throw new Exception (__CLASS__ . ": error! cannot execute query for empty class [{$class_name}] or empty criteria [{$criteria_str}]");
         } else {
             self::$last_class_name = $class_name;
             self::$last_criteria_str = $criteria_str;

--- a/alpha/apps/kaltura/lib/myFileConverter.class.php
+++ b/alpha/apps/kaltura/lib/myFileConverter.class.php
@@ -274,20 +274,20 @@ class myFileConverter
 	{
 		if (!kFile::checkFileExists($source_file))
 		{
-			KalturaLog::log ( self::class . " File not found [$source_file]" );
+			KalturaLog::log ( __CLASS__ . " File not found [$source_file]" );
 			return;
 		}
 
 		if (kFile::isDir($source_file))
 		{
-			KalturaLog::log ( self::class . " Cannot create image from directory [$source_file]" );
+			KalturaLog::log ( __CLASS__ . " Cannot create image from directory [$source_file]" );
 			return;
 		}
 
 		list($sourcewidth, $sourceheight, $type, $attr, $srcIm) = self::createImageByFile($source_file);
 		if (!$srcIm || !$sourcewidth || !$sourceheight)
 		{
-			KalturaLog::log ( self::class . " bad image / dimensions [$source_file]" );
+			KalturaLog::log ( __CLASS__ . " bad image / dimensions [$source_file]" );
 			return;
 		}
 


### PR DESCRIPTION
`__CLASS__` is supported across all PHP versions from as back as I can remember (and I've a very good memory), whereas `self::class`, with older PHP versions, would yield:

> PHP Parse error:  syntax error, unexpected T_CLASS, expecting T_STRING or T_VARIABLE or '$'

Both output the name of the class so.. 