### PR TITLE
fix: change log method for failed sphinx update

### DIFF
--- a/plugins/search/providers/sphinx_search/scripts/populateFromLog.php
+++ b/plugins/search/providers/sphinx_search/scripts/populateFromLog.php
@@ -179,7 +179,7 @@ while(true)
 					if(!$affected)
 					{
 						$errorInfo = $sphinxCon->errorInfo();
-						KalturaLog::log("Failed to run sphinx update query for sphinxLogId [$sphinxLogId] with error [" . $errorInfo . "]");
+						KalturaLog::err("Failed to run sphinx update query for sphinxLogId [$sphinxLogId] with error [" . $errorInfo . "]");
 					}
 					
 					unset($objectIdSphinxLog[$objectId]);


### PR DESCRIPTION
failed sphinx update queries should end up in error log