### PR TITLE
PSVAMB-37517: Change log message from notice to error level

### DIFF
--- a/plugins/search/providers/sphinx_search/scripts/populateFromLog.php
+++ b/plugins/search/providers/sphinx_search/scripts/populateFromLog.php
@@ -179,7 +179,7 @@ while(true)
 					if(!$affected)
 					{
 						$errorInfo = $sphinxCon->errorInfo();
-						KalturaLog::log("Failed to run sphinx update query for sphinxLogId [$sphinxLogId] with error [" . $errorInfo . "]");
+						KalturaLog::err("Failed to run sphinx update query for sphinxLogId [$sphinxLogId] with error [" . $errorInfo . "]");
 					}
 					
 					unset($objectIdSphinxLog[$objectId]);


### PR DESCRIPTION
In the situation sphinx is not able to update a record, a NOTICE message is throw, even though it is an error so depending on loglevel, the message is not displayed and the issue is missed.