### PR TITLE
LIV-1087: remove underscore from host in broadcast url

### DIFF
--- a/alpha/apps/kaltura/lib/live/kBroadcastUrlManager.php
+++ b/alpha/apps/kaltura/lib/live/kBroadcastUrlManager.php
@@ -93,7 +93,7 @@ class kBroadcastUrlManager
 		return $partner->getLiveStreamBroadcastUrlConfigurations($dc);
 	}
 
-	private static function getLiveIdForHost(BaseEntry $entry)
+	protected static function getLiveIdForHost($entry)
 	{
 		$entryId = str_replace('1_', '', $entry->getId());
 		return str_replace('_', '-', $entryId); // dns resolve don't handle well underscore in host

--- a/alpha/apps/kaltura/lib/live/kBroadcastUrlManager.php
+++ b/alpha/apps/kaltura/lib/live/kBroadcastUrlManager.php
@@ -92,13 +92,19 @@ class kBroadcastUrlManager
 		$partner = PartnerPeer::retrieveByPK($this->partnerId);
 		return $partner->getLiveStreamBroadcastUrlConfigurations($dc);
 	}
+
+	private static function getEntryIdForHost(BaseEntry $entry)
+	{
+		$entryId = str_replace('1_', '', $entry->getId());
+		return str_replace('_', '-', $entryId); // dns resolve don't handle well underscore in host
+	}
 	
 	protected function getHostname ($dc, $primary, $entry, $protocol)
 	{
 		$broadcastConfig = $this->getConfiguration($dc);
 		list($domainParam, $portParam) = self::getUrlParamsByProtocol($protocol);
 		$url = $broadcastConfig[$domainParam];
-		$url = str_replace(array('{entryId}', '{primary}'), array($entry->getId(), $primary ? 'p' : 'b'), $url);
+		$url = str_replace(array('{entryId}', '{primary}'), array(self::getEntryIdForHost($entry), $primary ? 'p' : 'b'), $url);
 		$url .= ':' . $this->getPort($dc, $portParam, $protocol);
 
 		if ($protocol === kBroadcastUrlManager::PROTOCOL_SRT )

--- a/alpha/apps/kaltura/lib/live/kBroadcastUrlManager.php
+++ b/alpha/apps/kaltura/lib/live/kBroadcastUrlManager.php
@@ -93,7 +93,7 @@ class kBroadcastUrlManager
 		return $partner->getLiveStreamBroadcastUrlConfigurations($dc);
 	}
 
-	private static function getEntryIdForHost(BaseEntry $entry)
+	private static function getLiveIdForHost(BaseEntry $entry)
 	{
 		$entryId = str_replace('1_', '', $entry->getId());
 		return str_replace('_', '-', $entryId); // dns resolve don't handle well underscore in host
@@ -104,7 +104,7 @@ class kBroadcastUrlManager
 		$broadcastConfig = $this->getConfiguration($dc);
 		list($domainParam, $portParam) = self::getUrlParamsByProtocol($protocol);
 		$url = $broadcastConfig[$domainParam];
-		$url = str_replace(array('{entryId}', '{primary}'), array(self::getEntryIdForHost($entry), $primary ? 'p' : 'b'), $url);
+		$url = str_replace(array('{entryId}', '{liveId}', '{primary}'), array($entry->getId(), self::getLiveIdForHost($entry), $primary ? 'p' : 'b'), $url);
 		$url .= ':' . $this->getPort($dc, $portParam, $protocol);
 
 		if ($protocol === kBroadcastUrlManager::PROTOCOL_SRT )


### PR DESCRIPTION
Underscore in host can cause problem in dns-resolve.
For entry starting with '1_' - we just remove the prefix
For all other entries we just replace the underscore with '-' 