### PR TITLE
LIV-1104: take env var from name

### DIFF
--- a/plugins/media/live_cluster/lib/model/LiveClusterMediaServerNode.php
+++ b/plugins/media/live_cluster/lib/model/LiveClusterMediaServerNode.php
@@ -47,7 +47,7 @@ class LiveClusterMediaServerNode extends MediaServerNode
 
     public function getEnvDc()
     {
-        return self::ENVIRONMENT . '/' . $this->getEnvironment();
+        return self::ENVIRONMENT . '/' . $this->getName();
     }
 
     public static function getSessionType($entryServerNode)


### PR DESCRIPTION
Currently for all liveCluster server nodes the name, host-name and environment is the same.  We want to start use the environment as optional region - so moving the url to be build with the name field