### PR TITLE
VCP-15400: Remove ImageMagic memory limits

### DIFF
--- a/plugins/content/document/lib/kdl_transcoders/KDLTranscoderImageMagick.php
+++ b/plugins/content/document/lib/kdl_transcoders/KDLTranscoderImageMagick.php
@@ -19,7 +19,7 @@ class KDLTranscoderImageMagick extends KDLOperatorBase{
 			$cmdStr.= $this->getTwoDimensionsParams('density', $target->_image->_densityWidth, $target->_image->_densityHeight);
 			$cmdStr.= $this->getTwoDimensionsParams('geometry', $target->_image->_sizeWidth , $target->_image->_sizeHeight);
 			$cmdStr.= $this->getSimpleParam('depth', $target->_image->_depth);
-			$cmdStr.= '-colorspace RGB -limit memory 1000MB -limit map 200 ';
+			$cmdStr.= '-colorspace RGB ';
 		}
 		$cmdStr .= $extra . KDLCmdlinePlaceholders::InFileName.' '.KDLCmdlinePlaceholders::OutFileName;
 		return $cmdStr;


### PR DESCRIPTION
Without the specific limitation the default should be use as define in https://imagemagick.org/script/command-line-options.php