### PR TITLE
SUP-40499: Protect against duplicate recording VOD

### DIFF
--- a/api_v3/lib/KalturaLiveEntryService.php
+++ b/api_v3/lib/KalturaLiveEntryService.php
@@ -260,7 +260,7 @@ class KalturaLiveEntryService extends KalturaEntryService
 
 		// If while we were waiting for the lock, someone has updated the recorded entry id - we should use it.
 		$dbEntry->reload();
-		if (($dbEntry->getRecordStatus() != RecordStatus::PER_SESSION) && ($dbEntry->getRecordedEntryId()))
+		if ($dbEntry->getRecordedEntryId())
 		{
 			$recordedEntry = entryPeer::retrieveByPK($dbEntry->getRecordedEntryId());
 			if ($recordedEntry)


### PR DESCRIPTION
When APPEND recording is used and we get 2 request in the same time (race) - the first should create the recording and the second need to use it. Note that the wrapper reset the recording entry ID after the should create func before the actual create.

We still have rare case if the 2 request will pass the should function, one will create the recording and only then the second will reset it - solving it will be by moving the lock but that has lot more affect so we rather avoid it