### PR TITLE
[PHP 8.4] Fix: Curl `CURLOPT_BINARYTRANSFER` deprecated

### DIFF
--- a/alpha/apps/kaltura/lib/reports/kDruidBase.php
+++ b/alpha/apps/kaltura/lib/reports/kDruidBase.php
@@ -372,7 +372,6 @@ class kDruidBase
 			curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
 			curl_setopt($ch, CURLOPT_POST, true);
 			curl_setopt($ch, CURLOPT_HTTPHEADER, array('Content-Type: application/json'));
-			curl_setopt($ch, CURLOPT_BINARYTRANSFER, true);
 			curl_setopt($ch, CURLOPT_ENCODING, 'gzip,deflate');
 			self::$curl_handle = $ch;
 		}

--- a/infra/general/KCurlWrapper.class.php
+++ b/infra/general/KCurlWrapper.class.php
@@ -453,7 +453,6 @@ class KCurlWrapper
 	public function getHeader($sourceUrl, $noBody = false, $allowInternalUrl = false)
 	{
 		curl_setopt($this->ch, CURLOPT_HEADER, true);
-		curl_setopt($this->ch, CURLOPT_BINARYTRANSFER, true);
 		curl_setopt($this->ch, CURLOPT_WRITEFUNCTION, 'KCurlWrapper::read_body');
 
 		if (!self::setSourceUrl($this->ch, $sourceUrl, $this->protocol, $this->host, $allowInternalUrl, true))

--- a/infra/storage/shared_file_system_managers/kS3SharedFileSystemMgr.php
+++ b/infra/storage/shared_file_system_managers/kS3SharedFileSystemMgr.php
@@ -705,7 +705,6 @@ class kS3SharedFileSystemMgr extends kSharedFileSystemMgr
 		
 		curl_setopt($ch, CURLOPT_URL, $fileUrl);
 		curl_setopt($ch, CURLOPT_USERAGENT, "curl/7.11.1");
-		curl_setopt($ch, CURLOPT_BINARYTRANSFER, 1);
 		$range_to = ($range_from + $range_length) - 1;
 		curl_setopt($ch, CURLOPT_RANGE, "$range_from-$range_to");
 		

--- a/infra/storage/shared_file_system_managers/kS3SharedFileSystemMgr_V3_SDK.php
+++ b/infra/storage/shared_file_system_managers/kS3SharedFileSystemMgr_V3_SDK.php
@@ -603,7 +603,6 @@ class kS3SharedFileSystemMgr_V3_SDK extends kSharedFileSystemMgr
 		
 		curl_setopt($ch, CURLOPT_URL, $fileUrl);
 		curl_setopt($ch, CURLOPT_USERAGENT, "curl/7.11.1");
-		curl_setopt($ch, CURLOPT_BINARYTRANSFER, 1);
 		$range_to = ($range_from + $range_length) - 1;
 		curl_setopt($ch, CURLOPT_RANGE, "$range_from-$range_to");
 		curl_setopt($ch, CURLOPT_WRITEFUNCTION, 'kFileUtils::read_body');


### PR DESCRIPTION
The `CURLOPT_BINARYTRANSFER` PHP constant from the Curl extension was no-op since PHP 5.1, and is deprecated in PHP 8.4. This removes the constant usage to avoid the deprecation notice in PHP 8.4 and later.

Because this constant was no-op since PHP 5.1 (circa 2005), this change has no impact.

See:

 - [PHP.Watch - PHP 8.4 - Curl: CURLOPT_BINARYTRANSFER deprecated](https://php.watch/versions/8.4/CURLOPT_BINARYTRANSFER-deprecated)
 - [commit](https://github.com/php/php-src/commit/fc16285538e96ecb35d017231051f83dcbd8b55b)