### PR TITLE
SUP-40797 Reorder array to ensure kuserId inclusion in Sphinx search …

### DIFF
--- a/alpha/lib/model/categoryPeer.php
+++ b/alpha/lib/model/categoryPeer.php
@@ -80,8 +80,7 @@ class categoryPeer extends BasecategoryPeer implements IRelatedObjectPeer
 			if($kuser)
 			{
 				// get the groups that the user belongs to in case she is not associated to the category directly
-				$kgroupIds = KuserKgroupPeer::retrieveKgroupIdsByKuserId($kuser->getId());
-				$kgroupIds[] = $kuser->getId();
+				$kgroupIds = array_merge([$kuser->getId()], KuserKgroupPeer::retrieveKgroupIdsByKuserId($kuser->getId()));
 				$membersCrit = $c->getNewCriterion ( self::MEMBERS , $kgroupIds, KalturaCriteria::IN_LIKE);
 				$membersCrit->addTag(KalturaCriterion::TAG_ENTITLEMENT_CATEGORY);
      			$crit->addOr($membersCrit);


### PR DESCRIPTION
…when reaching Sphinx limit (MAX_IN_VALUES = 150).
Use case: when a user belongs to 150 groups or more.