### PR TITLE
LIV-1253: Force fmp4 in mix container

### DIFF
--- a/alpha/lib/model/DeliveryProfileLive.php
+++ b/alpha/lib/model/DeliveryProfileLive.php
@@ -382,7 +382,7 @@ abstract class DeliveryProfileLive extends DeliveryProfile {
 
 		$livePackagerUrl .= $serverNode->getExplicitLiveUrl($livePackagerUrl, $entry);
 		$livePackagerUrl .= $serverNode->getSessionType($entryServerNode);
-		$livePackagerUrl .= $serverNode->getAdditionalUrlParam($entry);
+		$livePackagerUrl .= $serverNode->getAdditionalUrlParam($entry, $entryServerNode);
 		$secureToken = $this->generateLiveSecuredPackagerToken($livePackagerUrl);
 		$livePackagerUrl .= "t/$secureToken/";
 

--- a/alpha/lib/model/MediaServerNode.php
+++ b/alpha/lib/model/MediaServerNode.php
@@ -140,7 +140,7 @@ abstract class MediaServerNode extends DeliveryServerNode {
     /**
      * @return string
      */
-    public function getAdditionalUrlParam(LiveStreamEntry $entry)
+    public function getAdditionalUrlParam(LiveStreamEntry $entry, LiveEntryServerNode $liveEntryServerNode)
     {
         return '';
     }

--- a/plugins/media/live_cluster/lib/model/LiveClusterMediaServerNode.php
+++ b/plugins/media/live_cluster/lib/model/LiveClusterMediaServerNode.php
@@ -7,7 +7,7 @@ class LiveClusterMediaServerNode extends MediaServerNode
     const SESSION_TYPE = 'st';
     const TIMELINE_URL_PARAM = 'tl';
     const LOW_LATENCY_URL_PARAM = 'll';
-	const CONTAINER_URL_PARAM = 'container';
+    const CONTAINER_URL_PARAM = 'container';
     const EXPLICIT_LIVE_VIEWER_TYPE_URL = 'tl';
     const USER_TYPE_ADMIN = 'main';
     const USER_TYPE_USER = 'viewer';

--- a/plugins/media/live_cluster/lib/model/LiveClusterMediaServerNode.php
+++ b/plugins/media/live_cluster/lib/model/LiveClusterMediaServerNode.php
@@ -128,7 +128,8 @@ class LiveClusterMediaServerNode extends MediaServerNode
 
 		foreach($streams as $stream)
 		{
-			if ($stream->getCodec() == flavorParams::VIDEO_CODEC_H265) {
+			if ($stream->getCodec() == flavorParams::VIDEO_CODEC_H265)
+			{
 				KalturaLog::debug("Stream has h265 video codec - force fmp4 container");
 				$res .= self::CONTAINER_URL_PARAM . '/fmp4/';
 				break;

--- a/plugins/media/live_cluster/lib/model/LiveClusterMediaServerNode.php
+++ b/plugins/media/live_cluster/lib/model/LiveClusterMediaServerNode.php
@@ -7,6 +7,7 @@ class LiveClusterMediaServerNode extends MediaServerNode
     const SESSION_TYPE = 'st';
     const TIMELINE_URL_PARAM = 'tl';
     const LOW_LATENCY_URL_PARAM = 'll';
+	const CONTAINER_URL_PARAM = 'container';
     const EXPLICIT_LIVE_VIEWER_TYPE_URL = 'tl';
     const USER_TYPE_ADMIN = 'main';
     const USER_TYPE_USER = 'viewer';
@@ -115,13 +116,26 @@ class LiveClusterMediaServerNode extends MediaServerNode
 	/**
 	 * @return string
 	 */
-	public function getAdditionalUrlParam(LiveStreamEntry $entry)
+	public function getAdditionalUrlParam(LiveStreamEntry $entry, LiveEntryServerNode $liveEntryServerNode)
 	{
 		$res = '';
 		if ($entry->isLowLatencyEntry())
 		{
 			$res .= self::LOW_LATENCY_URL_PARAM . '/1/';
 		}
+
+		$streams = $liveEntryServerNode->getStreams();
+		$this->sanitizeAndFilterStreamIdsByBitrate($streams);
+
+		foreach($streams as $stream)
+		{
+			if ($stream->getCodec() == flavorParams::VIDEO_CODEC_H265) {
+				KalturaLog::debug("Stream has h265 video codec - force fmp4 container");
+				$res .= self::CONTAINER_URL_PARAM . '/fmp4/';
+				break;
+			}
+		}
+
 		return $res;
 	}
 }

--- a/plugins/media/live_cluster/lib/model/LiveClusterMediaServerNode.php
+++ b/plugins/media/live_cluster/lib/model/LiveClusterMediaServerNode.php
@@ -125,7 +125,6 @@ class LiveClusterMediaServerNode extends MediaServerNode
 		}
 
 		$streams = $liveEntryServerNode->getStreams();
-		$this->sanitizeAndFilterStreamIdsByBitrate($streams);
 
 		foreach($streams as $stream)
 		{


### PR DESCRIPTION
If the is a flavor with H265 put add to the URL container with fmp4 value that will tell the live to use fmp4 and not mpegts