### PR TITLE
Fix default v7 player in init_content

### DIFF
--- a/deployment/base/scripts/init_content/01.uiConf.99.template.xml
+++ b/deployment/base/scripts/init_content/01.uiConf.99.template.xml
@@ -40,7 +40,7 @@
 			<html5Url></html5Url>
 			<useCdn>1</useCdn>
 			<tags>autodeploy,kalturaPlayerJs,player,ovp</tags>
-			<confvars>{"kaltura-ovp-player":"{latest}", "playkit-flash":"{latest}"}</confvars>
+			<confVars>{"kaltura-ovp-player":"{latest}", "playkit-flash":"{latest}"}</confVars>
 			<creationMode>2</creationMode>
 			<config path="ui_conf/V7Player.json" />
 		</uiConf>


### PR DESCRIPTION
Currently the player is deployed without flashvars due to an issue with the deployment XML. I have adjusted the xml to match the param name according to API docs: https://developer.kaltura.com/api-docs/service/uiConf/action/add