### PR TITLE
ONPREM-66: :Add NO_LOG_DIRS constant to KProcessWrapper class

### DIFF
--- a/batch/scheduler/KProcessWrapper.class.php
+++ b/batch/scheduler/KProcessWrapper.class.php
@@ -7,6 +7,12 @@
  */
 class KProcessWrapper
 {
+	const NO_LOG_DIRS = [
+		'/dev/stdout',
+		'/dev/stderr',
+		'/proc/self/fd/1',
+		'/proc/self/fd/2',
+	];
 	/**
 	 * @var resource
 	 */
@@ -82,7 +88,8 @@ class KProcessWrapper
 		$cmdLine .= realpath(__DIR__ . '/../') . '/' . $this->taskConfig->scriptPath . ' ';
 		$cmdLine .= "$taskConfigStr ";
 		$cmdLine .= "'[" . mt_rand() . "]' ";
-		$cmdLine .= ">> $logFileOut 2>> $logFileErr";
+		if($logDir && !in_array($logDir, self::NO_LOG_DIRS))
+			$cmdLine .= ">> $logFileOut 2>> $logFileErr";
 		
 		
 		$descriptorspec = array(); // stdin is a pipe that the child will read from


### PR DESCRIPTION
This pull request adds a new constant, `NO_LOG_DIRS`, to the `KProcessWrapper` class. This constant contains a list of directories that should not be logged when executing a command. The `init` method has been updated to check if the provided log directory is in the `NO_LOG_DIRS` list before redirecting the output to log files. This change improves the flexibility and control over logging in the `KProcessWrapper` class.