### PR TITLE
SUP-43374: add "TZID" to iCal response if scheduled_event recurrance timezone exists

### DIFF
--- a/plugins/schedule/base/lib/iCal/kSchedulingICalEvent.php
+++ b/plugins/schedule/base/lib/iCal/kSchedulingICalEvent.php
@@ -219,6 +219,7 @@ class kSchedulingICalEvent extends kSchedulingICalComponent
 	            if (in_array($event->recurrence->timeZone, $timeZones))
 	            {
 	                $timeZoneId = $event->recurrence->timeZone;
+	                $object->setField(self::$timeZoneField, $timeZoneId);
 	            }
 	        }
 	


### PR DESCRIPTION
@bw-kaltura 
https://github.com/kaltura/server/pull/12641/files at line 222 you removed the 'setField' for TZID - was that on purpose?