### PR TITLE
NR2-8250: add KME reset password link for Kaltura domain

### DIFF
--- a/alpha/lib/enums/resetPassLinkType.php
+++ b/alpha/lib/enums/resetPassLinkType.php
@@ -9,4 +9,5 @@ interface resetPassLinkType extends BaseEnum
 	const KMS = 2;
 	const KME = 3;
 	const EP  = 4;
+	const KME_NR  = 5;
 }

--- a/alpha/lib/model/UserLoginDataPeer.php
+++ b/alpha/lib/model/UserLoginDataPeer.php
@@ -501,6 +501,10 @@ class UserLoginDataPeer extends BaseUserLoginDataPeer implements IRelatedObjectP
 		{
 			return $resetLinksArray['kme'];
 		}
+		else if($linkType == resetPassLinkType::KME_NR)
+		{
+			return $resetLinksArray['kme_nr'];
+		}
 		else
 		{
 			return $resetLinksArray['default'];

--- a/configurations/local.template.ini
+++ b/configurations/local.template.ini
@@ -222,6 +222,7 @@ app_registry_base_url = @APP_REGISTRY_BASE_URL@
 default = @SERVICE_URL@/index.php/kmcng/actions/restore-password/
 kms = "https://%s.mediaspace.kaltura.com/user/set-initial-password?hashKey="
 kme = "@KME_SERVICE_URL@/u/#/forgotPassword/"
+kme_nr = "@KME_NR_SERVICE_URL@/u/#/forgotPassword/"
 admin_console = @SERVICE_URL@/admin_console/index.php/user/reset-password-link/token/
 
 [reports_db_config]

--- a/release-notes.md
+++ b/release-notes.md
@@ -1,3 +1,12 @@
+# Tucana-20.17.0
+## New KME user reset password link  ##
+- Issue Type: Bug
+- Issue ID: NR2-8250
+
+### Configuration ###
+add the following to 'local.ini' under 'password_reset_links' (with the service url of the required KME environment):
+kme_nr = @KME_NR_SERVICE_URL@/u/#/forgotPassword/
+
 # Tucana-20.16.0
 # Add permissions for session get ##
 - Issue Type: Task


### PR DESCRIPTION
before this PR - only "newrow.com" link was generated. this PR purpose is to add the option to choose between newrow.com domain (kme_nr) to kaltura.com domain (kme). the logic done outside Kaltura server (based on the URL the user used)