### PR TITLE
KAI-96: Fix PHP error

### DIFF
--- a/plugins/reach/lib/model/data/kQuizVendorTaskData.php
+++ b/plugins/reach/lib/model/data/kQuizVendorTaskData.php
@@ -7,7 +7,7 @@
 class kQuizVendorTaskData extends kVendorTaskData
 {
 	public int $numberOfQuestions = 0;
-	public string $questionsType = null;
+	public ?string $questionsType = null;
 	public string $context = "";
 	public ?string $quizOutput = null;
 


### PR DESCRIPTION
Fix this error Default value for property of type string may not be null. Use the nullable type ?string to allow null default value