### PR TITLE
PLAT-24996: allow adding external source to kaltura player

### DIFF
--- a/alpha/apps/kaltura/modules/extwidget/actions/embedPlaykitJsAction.class.php
+++ b/alpha/apps/kaltura/modules/extwidget/actions/embedPlaykitJsAction.class.php
@@ -484,7 +484,7 @@ class embedPlaykitJsAction extends sfAction
 			$loadContentMethod = "kalturaPlayer.setMedia({\"sources\":$external_source});";
 		}
 		else {
-			KExternalErrors::dieError(KExternalErrors::MISSING_PARAMETER, "Entry and Playlist ID not defined");
+			KExternalErrors::dieError(KExternalErrors::MISSING_PARAMETER, "One of the following params must be defined: entry_id, playlist_id, external_source");
 		}
 		$config = $this->getRequestParameter(self::CONFIG_PARAM_NAME, array());
 		//enable passing nested config options
@@ -810,7 +810,7 @@ class embedPlaykitJsAction extends sfAction
 
 
 		}
-		catch (Exception $ex)
+		catch (ion $ex)
 		{
 			KExternalErrors::dieError(KExternalErrors::INTERNAL_SERVER_ERROR);
 		}

--- a/alpha/apps/kaltura/modules/extwidget/actions/embedPlaykitJsAction.class.php
+++ b/alpha/apps/kaltura/modules/extwidget/actions/embedPlaykitJsAction.class.php
@@ -11,6 +11,7 @@ class embedPlaykitJsAction extends sfAction
 	const LANGS_PARAM_NAME = "langs";
 	const ENTRY_ID_PARAM_NAME = "entry_id";
 	const PLAYLIST_ID_PARAM_NAME = "playlist_id";
+	const EXTERNAL_SOURCE_PARAM_NAME = "external_source";
 	const KS_PARAM_NAME = "ks";
 	const CONFIG_PARAM_NAME = "config";
 	const REGENERATE_PARAM_NAME = "regenerate";
@@ -473,13 +474,17 @@ class embedPlaykitJsAction extends sfAction
 
 		$entry_id = $this->getRequestParameter(self::ENTRY_ID_PARAM_NAME);
 		$playlist_id = $this->getRequestParameter(self::PLAYLIST_ID_PARAM_NAME);
+		$external_source = $this->getRequestParameter(self::EXTERNAL_SOURCE_PARAM_NAME);
 		$loadContentMethod = "";
 		if (!is_null($entry_id)) {
 		    $loadContentMethod = "kalturaPlayer.loadMedia({\"entryId\":\"$entry_id\"});";
 		} elseif (!is_null($playlist_id)) {
 		    $loadContentMethod = "kalturaPlayer.loadPlaylist({\"playlistId\":\"$playlist_id\"});";
-		} else {
-		    KExternalErrors::dieError(KExternalErrors::MISSING_PARAMETER, "Entry and Playlist ID not defined");
+		} elseif (!is_null($external_source)) {
+			$loadContentMethod = "kalturaPlayer.setMedia({\"sources\":$external_source});";
+		}
+		else {
+			KExternalErrors::dieError(KExternalErrors::MISSING_PARAMETER, "Entry and Playlist ID not defined");
 		}
 		$config = $this->getRequestParameter(self::CONFIG_PARAM_NAME, array());
 		//enable passing nested config options

--- a/alpha/apps/kaltura/modules/extwidget/actions/embedPlaykitJsAction.class.php
+++ b/alpha/apps/kaltura/modules/extwidget/actions/embedPlaykitJsAction.class.php
@@ -810,7 +810,7 @@ class embedPlaykitJsAction extends sfAction
 
 
 		}
-		catch (ion $ex)
+		catch (Exception $ex)
 		{
 			KExternalErrors::dieError(KExternalErrors::INTERNAL_SERVER_ERROR);
 		}


### PR DESCRIPTION
Using this feature, user can embed iframe request that can play external source in kaltura player such as youtube entries,
for example, add this to you query params - 
`&external_source={"progressive":[{"mimetype":"video/youtube","url":"aqz-KE-bpKQ"}]}`
(make sure you have youtube plugin enabled) and kaltura player will playit.

FYI - this ability exists in dynamic embed, now its added to iframe embed also