### PR TITLE
PLAT-25007: clustered dyamic embed

### DIFF
--- a/alpha/apps/kaltura/modules/extwidget/actions/embedPlaykitJsAction.class.php
+++ b/alpha/apps/kaltura/modules/extwidget/actions/embedPlaykitJsAction.class.php
@@ -12,6 +12,7 @@ class embedPlaykitJsAction extends sfAction
 	const ENTRY_ID_PARAM_NAME = "entry_id";
 	const PLAYLIST_ID_PARAM_NAME = "playlist_id";
 	const EXTERNAL_SOURCE_PARAM_NAME = "external_source";
+	const EMBED_FACTORY_PARAM_NAME = "embed_factory";
 	const KS_PARAM_NAME = "ks";
 	const CONFIG_PARAM_NAME = "config";
 	const REGENERATE_PARAM_NAME = "regenerate";
@@ -173,6 +174,19 @@ class embedPlaykitJsAction extends sfAction
 		elseif ($iframeEmbed)
 		{
 			$bundleContent = $this->getIfarmEmbedCode($bundleContent);
+		}
+		else
+		{
+			//Embed factory is only relevant in dynamic embed
+			if ($this->getRequestParameter(self::EMBED_FACTORY_PARAM_NAME, false))
+			{
+				$bundleContent = "function getNamespacedKalturaPlayer() {  
+										$bundleContent
+										return KalturaPlayer;
+									}; 
+								const kalturaPlayerFactory = getNamespacedKalturaPlayer();
+								export { kalturaPlayerFactory }";
+			}
 		}
 
 		$protocol = infraRequestUtils::getProtocol();


### PR DESCRIPTION
Example of how the dynamic embed code should look like if client wants to have multiple players on the same page.

` <div id="kaltura_player_379896348" style="width: 528px;height: 327px"></div>
                  <script type="text/javascript">
                   import("http://www.kaltura.local/p/102/embedPlaykitJs/uiconf_id/23448135?embed_factory=true").
then(({ kalturaPlayerFactory }) => {
        try {
                      var kalturaPlayer = kalturaPlayerFactory.setup({
                        targetId: "kaltura_player_379896348",
                        provider: {
                          partnerId: 102,
                          uiConfId: 23448135
                        }
                      });
                      kalturaPlayer.loadMedia({entryId: '0_r37zt2c2'});
                    } catch (e) {
                      console.error(e.message)
                    }
});
</script>`