### PR TITLE
LIV-1295: fix live webvtt captions

### DIFF
--- a/plugins/content/caption/base/CaptionPlugin.php
+++ b/plugins/content/caption/base/CaptionPlugin.php
@@ -657,7 +657,7 @@ class CaptionPlugin extends KalturaPlugin implements IKalturaServices, IKalturaP
 
 	protected static function getLiveCaptionArray($entryId, $deliveryProfile): array
 	{
-		$liveEntryServerNodes = $deliveryProfile->getSortedLiveEntryServerNodes($entryId, array(EntryServerNodeStatus::PLAYABLE));
+		$liveEntryServerNodes = $deliveryProfile->getSortedLiveEntryServerNodes($entryId, array(EntryServerNodeStatus::PLAYABLE, EntryServerNodeStatus::MARKED_FOR_DELETION));
 		if(!count($liveEntryServerNodes))
 		{
 			return array();


### PR DESCRIPTION
get entryServerNode with status MARKED_FOR_DELETION.