### PR TITLE
fix: shouldUseClosedCaptions func

### DIFF
--- a/alpha/apps/kaltura/lib/kManifestRenderers.php
+++ b/alpha/apps/kaltura/lib/kManifestRenderers.php
@@ -1031,15 +1031,11 @@ class kM3U8ManifestRenderer extends kMultiFlavorManifestRenderer
 
 	protected function shouldUseClosedCaptions(): bool
 	{
-		$dbEntry = entryPeer::retrieveByPK($this->entryId);
-		if($dbEntry)
+		foreach ($this->contributors as $contributor)
 		{
-			foreach ($this->contributors as $contributor)
+			if($contributor instanceof WebVttCaptionsManifestEditor)
 			{
-				if($contributor instanceof WebVttCaptionsManifestEditor && $dbEntry->getType() == entryType::LIVE_STREAM)
-				{
-					return false;
-				}
+				return false;
 			}
 		}
 		return true;


### PR DESCRIPTION
We cannot use retrieveByPK since this code can be served from the cache layer.
We added the type checker to be on the safe side.
The same behavior happens with VOD.