### PR TITLE
VCP-19323: Fix log output formatting in mergeNewlyCreatedDuplicatedUsers script

### DIFF
--- a/alpha/scripts/utils/mergeNewlyCreatedDuplicatedUsers.php
+++ b/alpha/scripts/utils/mergeNewlyCreatedDuplicatedUsers.php
@@ -256,7 +256,7 @@ function writeSuccess($filePath = null): void
 	$description = 'Successfully finished mergeNewlyCreatedDuplicatedUsers.php script';
 	$timestamp = date("Y-m-d H:i:s");
 	$hostname = gethostname();
-	$data = "merge_newly_created_duplicate_users{timestamp=\"$timestamp\", host=\"$hostname\", description=\"$description\"} 0";
+	$data = "merge_newly_created_duplicate_users{timestamp=\"$timestamp\", host=\"$hostname\", description=\"$description\"} 0".PHP_EOL;
 	
 	file_put_contents($filePath, $data, LOCK_EX);
 }
@@ -271,7 +271,7 @@ function writeFailure($e, $filePath = null): void
 	$message = $e->getMessage();
 	$code = $e->getCode();
 	$hostname = gethostname();
-	$data = "merge_newly_created_duplicate_users{timestamp=\"$timestamp\", host=\"$hostname\", description=\"$description\", message=\"$message\", code=\"$code\"} 1";
+	$data = "merge_newly_created_duplicate_users{timestamp=\"$timestamp\", host=\"$hostname\", description=\"$description\", message=\"$message\", code=\"$code\"} 1".PHP_EOL;
 	
 	file_put_contents($filePath, $data, LOCK_EX);
 }

--- a/alpha/scripts/utils/mergeNewlyCreatedDuplicatedUsers.php
+++ b/alpha/scripts/utils/mergeNewlyCreatedDuplicatedUsers.php
@@ -257,7 +257,7 @@ function writeSuccess($filePath = null): void
 	$timestamp = time();
 	$date = date("Y-m-d H:i:s", $timestamp);
 	$hostname = gethostname();
-	$data = "merge_newly_created_duplicate_users_success{timestamp=\"$date\", host=\"$hostname\", description=\"$description\"} $timestamp".PHP_EOL;
+	$data = "merge_newly_created_duplicate_users{timestamp=\"$date\", host=\"$hostname\", description=\"$description\", success=\"true\"} $timestamp".PHP_EOL;
 
 	file_put_contents($filePath, $data, LOCK_EX);
 }
@@ -273,7 +273,7 @@ function writeFailure($e, $filePath = null): void
 	$message = $e->getMessage();
 	$code = $e->getCode();
 	$hostname = gethostname();
-	$data = "merge_newly_created_duplicate_users_failure{timestamp=\"$date\", host=\"$hostname\", description=\"$description\", message=\"$message\", code=\"$code\"} $timestamp".PHP_EOL;
+	$data = "merge_newly_created_duplicate_users{timestamp=\"$date\", host=\"$hostname\", description=\"$description\", success=\"false\", message=\"$message\", code=\"$code\"} $timestamp".PHP_EOL;
 
 	file_put_contents($filePath, $data, LOCK_EX);
 }

--- a/alpha/scripts/utils/mergeNewlyCreatedDuplicatedUsers.php
+++ b/alpha/scripts/utils/mergeNewlyCreatedDuplicatedUsers.php
@@ -255,9 +255,10 @@ function writeSuccess($filePath = null): void
 	
 	$description = 'Successfully finished mergeNewlyCreatedDuplicatedUsers.php script';
 	$timestamp = time();
+	$date = date("Y-m-d H:i:s", $timestamp);
 	$hostname = gethostname();
-	$data = "merge_newly_created_duplicate_users{timestamp=\"$timestamp\", host=\"$hostname\", description=\"$description\"} 0".PHP_EOL;
-	
+	$data = "merge_newly_created_duplicate_users_success{timestamp=\"$date\", host=\"$hostname\", description=\"$description\"} $timestamp".PHP_EOL;
+
 	file_put_contents($filePath, $data, LOCK_EX);
 }
 
@@ -265,14 +266,15 @@ function writeFailure($e, $filePath = null): void
 {
 	$filePath = $filePath ?? DEFAULT_PROM_FILE;
 	createDirPath($filePath);
-	
+
 	$description = 'Error in mergeNewlyCreatedDuplicatedUsers.php script';
 	$timestamp = time();
+	$date = date("Y-m-d H:i:s", $timestamp);
 	$message = $e->getMessage();
 	$code = $e->getCode();
 	$hostname = gethostname();
-	$data = "merge_newly_created_duplicate_users{timestamp=\"$timestamp\", host=\"$hostname\", description=\"$description\", message=\"$message\", code=\"$code\"} 1".PHP_EOL;
-	
+	$data = "merge_newly_created_duplicate_users{timestamp=\"$date\", host=\"$hostname\", description=\"$description\", message=\"$message\", code=\"$code\"} $timestamp".PHP_EOL;
+
 	file_put_contents($filePath, $data, LOCK_EX);
 }
 

--- a/alpha/scripts/utils/mergeNewlyCreatedDuplicatedUsers.php
+++ b/alpha/scripts/utils/mergeNewlyCreatedDuplicatedUsers.php
@@ -254,7 +254,7 @@ function writeSuccess($filePath = null): void
 	createDirPath($filePath);
 	
 	$description = 'Successfully finished mergeNewlyCreatedDuplicatedUsers.php script';
-	$timestamp = date("Y-m-d H:i:s");
+	$timestamp = time();
 	$hostname = gethostname();
 	$data = "merge_newly_created_duplicate_users{timestamp=\"$timestamp\", host=\"$hostname\", description=\"$description\"} 0".PHP_EOL;
 	
@@ -267,7 +267,7 @@ function writeFailure($e, $filePath = null): void
 	createDirPath($filePath);
 	
 	$description = 'Error in mergeNewlyCreatedDuplicatedUsers.php script';
-	$timestamp = date("Y-m-d H:i:s");
+	$timestamp = time();
 	$message = $e->getMessage();
 	$code = $e->getCode();
 	$hostname = gethostname();

--- a/alpha/scripts/utils/mergeNewlyCreatedDuplicatedUsers.php
+++ b/alpha/scripts/utils/mergeNewlyCreatedDuplicatedUsers.php
@@ -273,7 +273,7 @@ function writeFailure($e, $filePath = null): void
 	$message = $e->getMessage();
 	$code = $e->getCode();
 	$hostname = gethostname();
-	$data = "merge_newly_created_duplicate_users{timestamp=\"$date\", host=\"$hostname\", description=\"$description\", message=\"$message\", code=\"$code\"} $timestamp".PHP_EOL;
+	$data = "merge_newly_created_duplicate_users_failure{timestamp=\"$date\", host=\"$hostname\", description=\"$description\", message=\"$message\", code=\"$code\"} $timestamp".PHP_EOL;
 
 	file_put_contents($filePath, $data, LOCK_EX);
 }


### PR DESCRIPTION
Improve log output by ensuring each log entry ends with a newline character to conform to prom text file format:
https://prometheus.io/docs/instrumenting/exposition_formats/#text-format-details