### PR TITLE
Fix apcu_fetch call in kApcWrapper

### DIFF
--- a/infra/cache/kApcWrapper.php
+++ b/infra/cache/kApcWrapper.php
@@ -11,8 +11,7 @@ class kApcWrapper
 		if (function_exists('apc_fetch'))
 			return apc_fetch($key, $success);
 		if (function_exists('apcu_fetch'))
-			return apcu_fetch($key, $sy
-			);
+			return apcu_fetch($key, $success);
 		
 		return false;
 	}


### PR DESCRIPTION
Correct the argument passed to the `apcu_fetch` function to ensure it properly returns the success status.