### PR TITLE
Ursa 21.16.0 plat 25298

### DIFF
--- a/alpha/apps/kaltura/lib/kManifestRenderers.php
+++ b/alpha/apps/kaltura/lib/kManifestRenderers.php
@@ -993,7 +993,7 @@ class kM3U8ManifestRenderer extends kMultiFlavorManifestRenderer
 		{
 			// Sperate audio flavors from video flavors
 			if ( isset($flavor['audioLanguage']) || isset($flavor['audioLabel']) ) {
-				if(count($audioFlavorsArr) == 0) {
+				if(count($audioFlavorsArr) == 0) {//TODO add logic to change default audio stream when feature is on
 					$isFirstAudioStream = "YES";
 					$firstAudioStream = $flavor;
 				}

--- a/alpha/lib/model/AudioDescriptionAsset.php
+++ b/alpha/lib/model/AudioDescriptionAsset.php
@@ -1,0 +1,24 @@
+<?php
+
+/**
+ * Subclass for representing a row from the 'flavor_asset' table.
+ *
+ *
+ *
+ * @package Core
+ * @subpackage model
+ */
+class AudioDescriptionAsset extends flavorAsset
+{
+	const CUSTOM_DATA_FIELD_ORDER = "order";
+
+	public function getOrder()
+	{
+		return $this->getFromCustomData(self::CUSTOM_DATA_FIELD_ORDER);
+	}
+	
+	public function setOrder($v)
+	{
+		$this->putInCustomData(self::CUSTOM_DATA_FIELD_ORDER, $v);
+	}
+}

--- a/api_v3/lib/types/conversionProfile/KalturaAsset.php
+++ b/api_v3/lib/types/conversionProfile/KalturaAsset.php
@@ -166,8 +166,15 @@ class KalturaAsset extends KalturaObject implements IRelatedFilterable, IApiObje
 	     switch ($type)
 	     {
 	         case KalturaAssetType::FLAVOR:
-	             $object = new KalturaFlavorAsset();
-	             break;
+	         {
+				 if (strpos($sourceObject->getTags(), 'audio_description') === false)
+				 {
+					 $object = new KalturaFlavorAsset();
+					 break;
+				 }
+				 $object = new KalturaAudioDescriptionFlavorAsset();
+				 break;
+	         }
 	         case KalturaAssetType::LIVE:
 	             $object = new KalturaLiveAsset();
 	             break;

--- a/api_v3/lib/types/conversionProfile/KalturaAudioDescriptionFlavorAsset.php
+++ b/api_v3/lib/types/conversionProfile/KalturaAudioDescriptionFlavorAsset.php
@@ -6,5 +6,26 @@
  */
 class KalturaAudioDescriptionFlavorAsset extends KalturaFlavorAsset
 {
-    // You can add audio description specific properties or methods here if needed
+	/**
+	 * The desired order of the flavor
+	 *
+	 * @var int
+	 */
+	public $order;
+
+	private static $map_between_objects = array
+	(
+		"order"
+	);
+
+	public function getMapBetweenObjects ( )
+	{
+		return array_merge ( parent::getMapBetweenObjects() , self::$map_between_objects );
+	}
+
+	public function toInsertableObject($sourceObject = null, $propsToSkip = array())
+	{
+		$sourceObject = new AudioDescriptionAsset();
+		return parent::toInsertableObject ($sourceObject, $propsToSkip);
+	}
 }

--- a/api_v3/lib/types/conversionProfile/KalturaAudioDescriptionFlavorAsset.php
+++ b/api_v3/lib/types/conversionProfile/KalturaAudioDescriptionFlavorAsset.php
@@ -1,0 +1,10 @@
+<?php
+/**
+ * @package api
+ * @subpackage objects
+ * @relatedService FlavorAssetService
+ */
+class KalturaAudioDescriptionFlavorAsset extends KalturaFlavorAsset
+{
+    // You can add audio description specific properties or methods here if needed
+}


### PR DESCRIPTION
This pull request introduces functionality related to audio description assets, including new classes and logic updates to handle these assets.

### New Classes for Audio Description Assets:
* [`alpha/lib/model/AudioDescriptionAsset.php`]: Added a new `AudioDescriptionAsset` class to represent rows from the `flavor_asset` table, with custom data field handling for the "order" attribute.
* [`api_v3/lib/types/conversionProfile/KalturaAudioDescriptionFlavorAsset.php`]: Introduced the `KalturaAudioDescriptionFlavorAsset` class to extend `KalturaFlavorAsset`, adding support for the "order" property and mapping it between objects.

### Logic Updates for Asset Differentiation:
* [`api_v3/lib/types/conversionProfile/KalturaAsset.php`]: Updated the `getInstance` method to create a `KalturaAudioDescriptionFlavorAsset` object if the source object contains the "audio_description" tag, otherwise defaulting to `KalturaFlavorAsset`.