### PR TITLE
SUP-44991: Password change fails if user is deleted from login PID

### DIFF
--- a/alpha/lib/model/UserLoginDataPeer.php
+++ b/alpha/lib/model/UserLoginDataPeer.php
@@ -421,24 +421,55 @@ class UserLoginDataPeer extends BaseUserLoginDataPeer implements IRelatedObjectP
 
 		return $loginData;
 	}
-	
+
+	// Retrieves all partner IDs where the kuser associated with the given loginDataId is active.
+	public static function getPartnerIdsByLoginData($loginDataId)
+	{
+		if (!$loginDataId) {
+			return array();
+		}
+
+		$criteria = new Criteria();
+		$criteria->addSelectColumn(kuserPeer::PARTNER_ID);
+		$criteria->add(kuserPeer::LOGIN_DATA_ID, $loginDataId);
+		$criteria->add(kuserPeer::STATUS, KuserStatus::ACTIVE);
+		//$c->addAnd(kuserPeer::IS_ADMIN, true, Criteria::EQUAL);
+		kuserPeer::setUseCriteriaFilter(false);
+		$partnerIds = kuserPeer::doSelectStmt($criteria)->fetchAll(PDO::FETCH_COLUMN);
+		kuserPeer::setUseCriteriaFilter(true);
+
+		return $partnerIds;
+	}
+
 	public static function setInitialPassword($hashKey, $newPassword)
 	{
 		// might throw exception
 		$hashKey = str_replace('.','=', $hashKey);
 		$loginData = self::isHashKeyValid($hashKey);
-		
+
 		if (!$loginData) {
 			throw new kUserException ('', kUserException::NEW_PASSWORD_HASH_KEY_INVALID);
 		}
-		
+
 		self::checkPasswordValidation($newPassword, $loginData);
-		
+
 		$loginData->resetPassword($newPassword);
 		myPartnerUtils::initialPasswordSetForFreeTrial($loginData);
 
 		kuserPeer::setUseCriteriaFilter(false);
-		$dbUser = kuserPeer::getByLoginDataAndPartner($loginData->getId(), $loginData->getConfigPartnerId());
+		$partner_id = $loginData->getLastLoginPartnerId();
+		$dbUser = null;
+		if($partner_id)
+		{
+			$dbUser = kuserPeer::getByLoginDataAndPartner($loginData->getId(),$partner_id);
+		}
+		if (!$partner_id || !$dbUser){
+			$valid_partner_ids= self::getPartnerIdsByLoginData($loginData->getId());
+			if(count($valid_partner_ids))
+			{
+				$dbUser = kuserPeer::getByLoginDataAndPartner($loginData->getId(), $valid_partner_ids[0]);
+			}
+		}
 		kuserPeer::setUseCriteriaFilter(true);
 		if (!$dbUser)
 		{
@@ -453,7 +484,7 @@ class UserLoginDataPeer extends BaseUserLoginDataPeer implements IRelatedObjectP
 
 		return true;
 	}
-	
+
 	public static function getPassResetLink($hashKey, $linkType = resetPassLinkType::KMC, $dynamicLink = null)
 	{
 		if (!$hashKey) {

--- a/alpha/lib/model/UserLoginDataPeer.php
+++ b/alpha/lib/model/UserLoginDataPeer.php
@@ -425,7 +425,8 @@ class UserLoginDataPeer extends BaseUserLoginDataPeer implements IRelatedObjectP
 	// Retrieves all partner IDs where the kuser associated with the given loginDataId is active.
 	public static function getPartnerIdsByLoginData($loginDataId)
 	{
-		if (!$loginDataId) {
+		if (!$loginDataId) 
+		{
 			return array();
 		}
 
@@ -433,7 +434,6 @@ class UserLoginDataPeer extends BaseUserLoginDataPeer implements IRelatedObjectP
 		$criteria->addSelectColumn(kuserPeer::PARTNER_ID);
 		$criteria->add(kuserPeer::LOGIN_DATA_ID, $loginDataId);
 		$criteria->add(kuserPeer::STATUS, KuserStatus::ACTIVE);
-		//$c->addAnd(kuserPeer::IS_ADMIN, true, Criteria::EQUAL);
 		kuserPeer::setUseCriteriaFilter(false);
 		$partnerIds = kuserPeer::doSelectStmt($criteria)->fetchAll(PDO::FETCH_COLUMN);
 		kuserPeer::setUseCriteriaFilter(true);


### PR DESCRIPTION
Fix the issue where password change fails if user is deleted from login PID but exists in another PID

## Pull Request Checklist

Please complete the following before submitting:

General notes - 
- [ ] I have tested the changes locally.
- [ ] I have written unit tests where applicable.
- [ ] I have updated documentation where needed.
- [ ] I have added comments to complex code.
- [ ] This PR follows the coding style guidelines.
- [ ] I have updated release notes with new feature

New Kaltura Types
- [ ] I have created new clients
- [ ] I have notified related apps - KMCNG / KMS / EP .... about new clients

New Kaltura Services / Actions
- [ ] I have added a deployment script

### Questions

1. What is the purpose of this PR?
   - _Enter your answer here_

2. Does this change affect production code or infrastructure?
   - [ ] Yes
   - [ ] No

3. If yes, what is the rollback plan?
   - _Enter your answer here_
