### PR TITLE
Update/ deprecated notes for old json outputs

### DIFF
--- a/plugins/reach/lib/api/data/entryVendorTaks/KalturaClipsVendorTaskData.php
+++ b/plugins/reach/lib/api/data/entryVendorTaks/KalturaClipsVendorTaskData.php
@@ -36,6 +36,7 @@ class KalturaClipsVendorTaskData extends KalturaLocalizedVendorTaskData
 	 * For example: [{"title": "Title of the first clip", "description": "Description of the first clip", "tags": "Tagged-Example", "start": 127, "duration": 30}]
 	 *
 	 * @var string
+	 * @deprecated Please use outputJson instead.
 	 */
 	public $clipsOutputJson;
 

--- a/plugins/reach/lib/api/data/entryVendorTaks/KalturaQuizVendorTaskData.php
+++ b/plugins/reach/lib/api/data/entryVendorTaks/KalturaQuizVendorTaskData.php
@@ -46,6 +46,7 @@ class KalturaQuizVendorTaskData extends KalturaLocalizedVendorTaskData
 	 * Quiz entry Id
 	 *
 	 * @var string
+	 * @deprecated please use outputJson instead.
 	 */
 	public $quizOutput;
 

--- a/plugins/reach/lib/api/data/entryVendorTaks/KalturaSummaryVendorTaskData.php
+++ b/plugins/reach/lib/api/data/entryVendorTaks/KalturaSummaryVendorTaskData.php
@@ -25,6 +25,7 @@ class KalturaSummaryVendorTaskData extends KalturaLocalizedVendorTaskData
 	 * JSON string containing the summary output.
 	 *
 	 * @var string
+	 * @deprecated Please use outputJson instead.
 	 */
 	public $summaryOutputJson;
 


### PR DESCRIPTION
Added deprecation notices for legacy output JSON fields in the following vendor task data classes:

```
KalturaSummaryVendorTaskData → $summaryOutputJson
KalturaClipsVendorTaskData → $clipsOutputJson
KalturaQuizVendorTaskData → $quizOutput
```