### PR TITLE
SUP-46884: In parent-child case, KS view will contain the parent ID, but we still want the child to skip the schedule by checking the sview of the parent id

### DIFF
--- a/alpha/apps/kaltura/lib/KSecureEntryHelper.class.php
+++ b/alpha/apps/kaltura/lib/KSecureEntryHelper.class.php
@@ -166,10 +166,12 @@ class KSecureEntryHelper
 		
 	    if ($this->contexts != array(ContextType::THUMBNAIL))
         {
-            if ( ! ($this->ks &&
+			$parentId = $this->entry->getParentEntryId();
+			$privilegeEntryId = $parentId ?? $this->entry->getId();
+			if ( ! ($this->ks &&
                    ($this->isKsAdmin() ||
                     $this->ks->verifyPrivileges(ks::PRIVILEGE_VIEW, ks::PRIVILEGE_WILDCARD) ||
-                    $this->ks->verifyPrivileges(ks::PRIVILEGE_VIEW, $this->entry->getId()) ))){
+                    $this->ks->verifyPrivileges(ks::PRIVILEGE_VIEW, $privilegeEntryId) ))){
                 $this->validateModeration();
                 $this->validateScheduling();
             }

--- a/api_v3/services/BaseEntryService.php
+++ b/api_v3/services/BaseEntryService.php
@@ -1041,9 +1041,22 @@ class BaseEntryService extends KalturaEntryService
 
 		$isScheduledNow = $dbEntry->isScheduledNow($contextDataParams->time);
 		if (!($isScheduledNow) && $this->getKs() && !$this->getKs()->isWidgetSession()){
-			if ( $this->getKs()->verifyPrivileges(ks::PRIVILEGE_VIEW, ks::PRIVILEGE_WILDCARD) ||
-				$this->getKs()->verifyPrivileges(ks::PRIVILEGE_VIEW, $entryId)) {
-				$isScheduledNow = true;
+			if ($parentEntryId)
+			{
+				// In parent-child case, KS view will contain the parent ID, but we still want the child to skip the schedule by checking the sview of the parent id:
+				if ($this->getKs()->verifyPrivileges(ks::PRIVILEGE_VIEW, ks::PRIVILEGE_WILDCARD) ||
+					$this->getKs()->verifyPrivileges(ks::PRIVILEGE_VIEW, $parentEntryId))
+				{
+					$isScheduledNow = true;
+				}
+			}
+			else
+			{
+				if ($this->getKs()->verifyPrivileges(ks::PRIVILEGE_VIEW, ks::PRIVILEGE_WILDCARD) ||
+					$this->getKs()->verifyPrivileges(ks::PRIVILEGE_VIEW, $entryId))
+				{
+					$isScheduledNow = true;
+				}
 			}
 		}
 

--- a/api_v3/services/BaseEntryService.php
+++ b/api_v3/services/BaseEntryService.php
@@ -1043,7 +1043,7 @@ class BaseEntryService extends KalturaEntryService
 		
 		if (!($isScheduledNow) && $this->getKs() && !$this->getKs()->isWidgetSession())
 		{
-		  $privilegeEntryId = $parentEntryId ? $parentEntryId : $entryId;
+		  $privilegeEntryId = $parentEntryId ?? $entryId;
 		    if (
 		        $this->getKs()->verifyPrivileges(ks::PRIVILEGE_VIEW, ks::PRIVILEGE_WILDCARD) ||
 		        $this->getKs()->verifyPrivileges(ks::PRIVILEGE_VIEW, $privilegeEntryId)

--- a/api_v3/services/BaseEntryService.php
+++ b/api_v3/services/BaseEntryService.php
@@ -1040,24 +1040,16 @@ class BaseEntryService extends KalturaEntryService
 			KalturaResponseCacher::disableCache();
 
 		$isScheduledNow = $dbEntry->isScheduledNow($contextDataParams->time);
-		if (!($isScheduledNow) && $this->getKs() && !$this->getKs()->isWidgetSession()){
-			if ($parentEntryId)
-			{
-				// In parent-child case, KS view will contain the parent ID, but we still want the child to skip the schedule by checking the sview of the parent id:
-				if ($this->getKs()->verifyPrivileges(ks::PRIVILEGE_VIEW, ks::PRIVILEGE_WILDCARD) ||
-					$this->getKs()->verifyPrivileges(ks::PRIVILEGE_VIEW, $parentEntryId))
-				{
-					$isScheduledNow = true;
-				}
-			}
-			else
-			{
-				if ($this->getKs()->verifyPrivileges(ks::PRIVILEGE_VIEW, ks::PRIVILEGE_WILDCARD) ||
-					$this->getKs()->verifyPrivileges(ks::PRIVILEGE_VIEW, $entryId))
-				{
-					$isScheduledNow = true;
-				}
-			}
+		
+		if (!($isScheduledNow) && $this->getKs() && !$this->getKs()->isWidgetSession())
+		{
+		  $privilegeEntryId = $parentEntryId ? $parentEntryId : $entryId;
+		    if (
+		        $this->getKs()->verifyPrivileges(ks::PRIVILEGE_VIEW, ks::PRIVILEGE_WILDCARD) ||
+		        $this->getKs()->verifyPrivileges(ks::PRIVILEGE_VIEW, $privilegeEntryId)
+		    ) {
+		        $isScheduledNow = true;
+		    }
 		}
 
 		$contextDataHelper->setMediaProtocol($contextDataParams->mediaProtocol);


### PR DESCRIPTION


## Pull Request Checklist

Please complete the following before submitting:

General notes - 
- [ ] I have tested the changes locally.
- [ ] I have written unit tests where applicable.
- [ ] I have updated documentation where needed.
- [ ] I have added comments to complex code.
- [ ] This PR follows the coding style guidelines.
- [ ] I have updated release notes with new feature

New Kaltura Types
- [ ] I have created new clients
- [ ] I have notified related apps - KMCNG / KMS / EP .... about new clients

New Kaltura Services / Actions
- [ ] I have added a deployment script

### Questions

1. What is the purpose of this PR?
   - _Enter your answer here_

2. Does this change affect production code or infrastructure?
   - [ ] Yes
   - [ ] No

3. If yes, what is the rollback plan?
   - _Enter your answer here_
