### PR TITLE
fix(SIP-49053)

### DIFF
--- a/tests/standAloneClient/uniqueMediaspaceNotificationsTemplates.xml
+++ b/tests/standAloneClient/uniqueMediaspaceNotificationsTemplates.xml
@@ -240,11 +240,7 @@
 								<code>($entry = entryPeer::retrieveByPk($scope->getObject()->getEntryId())) ? $entry->getkuser()->getEmail() : ''</code>
 							</email>
 							<name objectType="KalturaEvalStringField">
-								<code>
-									($entry = entryPeer::retrieveByPk($scope->getObject()->getEntryId()))
-									? (($kuser = $entry->getkuser()) ? $kuser->getFirstName().' '.$kuser->getLastName() : '')
-									: ''
-								</code>
+								<code>($entry = entryPeer::retrieveByPk($scope->getObject()->getEntryId())) ? $entry->getkuser()->getFirstName().' '.$entry->getkuser()->getLastName() : ''</code>
 							</name>
 						</item>
 					</emailRecipients>
@@ -338,11 +334,7 @@
 								<code>($entry = entryPeer::retrieveByPk($scope->getObject()->getEntryId())) ? $entry->getkuser()->getEmail() : ''</code>
 							</email>
 							<name objectType="KalturaEvalStringField">
-								<code>
-									($entry = entryPeer::retrieveByPk($scope->getObject()->getEntryId()))
-									? (($kuser = $entry->getkuser()) ? $kuser->getFirstName().' '.$kuser->getLastName() : 'Unknown User')
-									: ''
-								</code>
+								<code>($entry = entryPeer::retrieveByPk($scope->getObject()->getEntryId())) ? $entry->getkuser()->getFirstName().' '.$entry->getkuser()->getLastName() : ''</code>
 							</name>
 						</item>
 					</emailRecipients>

--- a/tests/standAloneClient/uniqueMediaspaceNotificationsTemplates.xml
+++ b/tests/standAloneClient/uniqueMediaspaceNotificationsTemplates.xml
@@ -240,7 +240,11 @@
 								<code>($entry = entryPeer::retrieveByPk($scope->getObject()->getEntryId())) ? $entry->getkuser()->getEmail() : ''</code>
 							</email>
 							<name objectType="KalturaEvalStringField">
-								<code>($entry = entryPeer::retrieveByPk($scope->getObject()->getEntryId())) ? $entry->getkuser()->getFirstName().' '.$entry->getkuser()->getLastName() : ''</code>
+								<code>
+									($entry = entryPeer::retrieveByPk($scope->getObject()->getEntryId()))
+									? (($kuser = $entry->getkuser()) ? $kuser->getFirstName().' '.$kuser->getLastName() : '')
+									: ''
+								</code>
 							</name>
 						</item>
 					</emailRecipients>
@@ -334,7 +338,11 @@
 								<code>($entry = entryPeer::retrieveByPk($scope->getObject()->getEntryId())) ? $entry->getkuser()->getEmail() : ''</code>
 							</email>
 							<name objectType="KalturaEvalStringField">
-								<code>($entry = entryPeer::retrieveByPk($scope->getObject()->getEntryId())) ? $entry->getkuser()->getFirstName().' '.$entry->getkuser()->getLastName() : ''</code>
+								<code>
+									($entry = entryPeer::retrieveByPk($scope->getObject()->getEntryId()))
+									? (($kuser = $entry->getkuser()) ? $kuser->getFirstName().' '.$kuser->getLastName() : 'Unknown User')
+									: ''
+								</code>
 							</name>
 						</item>
 					</emailRecipients>

--- a/tests/standAloneClient/uniqueMediaspaceNotificationsTemplates.xml
+++ b/tests/standAloneClient/uniqueMediaspaceNotificationsTemplates.xml
@@ -240,7 +240,12 @@
 								<code>($entry = entryPeer::retrieveByPk($scope->getObject()->getEntryId())) ? $entry->getkuser()->getEmail() : ''</code>
 							</email>
 							<name objectType="KalturaEvalStringField">
-								<code>($entry = entryPeer::retrieveByPk($scope->getObject()->getEntryId())) ? $entry->getkuser()->getFirstName().' '.$entry->getkuser()->getLastName() : ''</code>
+								<code>
+									($entry = entryPeer::retrieveByPk($scope->getObject()->getEntryId()))
+									&amp;&amp; ($kuser = $entry->getkuser())
+									? $kuser->getFirstName().' '.$kuser->getLastName()
+									: ''
+								</code>
 							</name>
 						</item>
 					</emailRecipients>
@@ -334,7 +339,12 @@
 								<code>($entry = entryPeer::retrieveByPk($scope->getObject()->getEntryId())) ? $entry->getkuser()->getEmail() : ''</code>
 							</email>
 							<name objectType="KalturaEvalStringField">
-								<code>($entry = entryPeer::retrieveByPk($scope->getObject()->getEntryId())) ? $entry->getkuser()->getFirstName().' '.$entry->getkuser()->getLastName() : ''</code>
+								<code>
+									($entry = entryPeer::retrieveByPk($scope->getObject()->getEntryId()))
+									&amp;&amp; ($kuser = $entry->getkuser())
+									? $kuser->getFirstName().' '.$kuser->getLastName()
+									: ''
+								</code>
 							</name>
 						</item>
 					</emailRecipients>


### PR DESCRIPTION
**Description:**
This change ensures that the email notification logic safely handles cases where the entry’s associated user (kuser) is inactive or deleted. Previously, the notification EvalStringField would call $entry->getkuser()->getFirstName() and $entry->getkuser()->getLastName() without checking if getkuser() returned null, which caused a fatal error when the user was inactive (status = 2).

Key points handled by this fix:

1. Prevents fatal errors when kuser is null.
2. Avoids sending emails to inactive or deleted users.
3. Ensures both the name and email fields are evaluated safely.

**Implementation:**

1. Added a null check for $entry->getkuser() before accessing its properties.
2. Returns an empty string ('') if the user is null, effectively skipping the notification.
## Pull Request Checklist

Please complete the following before submitting:

General notes - 
- [ ] I have tested the changes locally.
- [ ] I have written unit tests where applicable.
- [ ] I have updated documentation where needed.
- [ ] I have added comments to complex code.
- [ ] This PR follows the coding style guidelines.
- [ ] I have updated release notes with new feature

New Kaltura Types
- [ ] I have created new clients
- [ ] I have notified related apps - KMCNG / KMS / EP .... about new clients

New Kaltura Services / Actions
- [ ] I have added a deployment script

### Questions

1. What is the purpose of this PR?
   - _Enter your answer here_

2. Does this change affect production code or infrastructure?
   - [ ] Yes
   - [ ] No

3. If yes, what is the rollback plan?
   - _Enter your answer here_
