### PR TITLE
Security: Enforce security.ini by default via KCurlWrapper (control h…

### DIFF
--- a/infra/general/KCurlWrapper.class.php
+++ b/infra/general/KCurlWrapper.class.php
@@ -722,7 +722,7 @@ class KCurlWrapper
 	protected static function isWhiteListedInternalUrl($url)
 	{
 		if(!kConf::hasMap('security'))
-			return true;
+			return false;
 
 		$whiteListedInternalPatterns = kConf::get('internal_url_whitelist', 'security', array());
 		foreach ($whiteListedInternalPatterns as $pattern)


### PR DESCRIPTION
https://kaltura.atlassian.net/browse/PLAT-25789

### Questions

1. What is the purpose of this PR?
   - By default security.ini should be enforced ,if file does not exist all internal API's are blocked

2. Does this change affect production code or infrastructure?
   - [ ] Yes
   - [ ] No

3. If yes, what is the rollback plan?
   - _Enter your answer here_
