### PR TITLE
Fix missing comma in entry_vendor_task index definition

### DIFF
--- a/deployment/base/sql/01.kaltura_ce_tables.sql
+++ b/deployment/base/sql/01.kaltura_ce_tables.sql
@@ -965,7 +965,7 @@ CREATE TABLE IF NOT EXISTS `entry_vendor_task` (
   KEY `vendor_partner_id_status_index` (`vendor_partner_id`,`status`),
   KEY `updated_at` (`updated_at`),
   KEY `entry_id` (`entry_id`),
-  KEY `reach_profile_queue_time` (`reach_profile_id`,`queue_time`)
+  KEY `reach_profile_queue_time` (`reach_profile_id`,`queue_time`),
   KEY `reach_profile_finish_time` (`reach_profile_id`,`finish_time`)
 )ENGINE=InnoDB DEFAULT CHARSET=utf8;
 


### PR DESCRIPTION
CREATE TABLE fails with a syntax error on MySQL 5.7 fresh installs due to
a missing comma after the reach_profile_queue_time index definition.

## Pull Request Checklist

Please complete the following before submitting:

General notes - 
- [x] I have tested the changes locally.
- [ ] I have written unit tests where applicable.
- [ ] I have updated documentation where needed.
- [ ] I have added comments to complex code.
- [x] This PR follows the coding style guidelines.
- [ ] I have updated release notes with new feature

New Kaltura Types
- [ ] I have created new clients
- [ ] I have notified related apps - KMCNG / KMS / EP .... about new clients

New Kaltura Services / Actions
- [ ] I have added a deployment script

### Questions

1. What is the purpose of this PR?
   - Fixes a MySQL syntax error in the `entry_vendor_task` table DDL where a missing comma between index definitions caused fresh installation scripts to fail.

2. Does this change affect production code or infrastructure?
   - [ ] Yes
   - [x] No

3. If yes, what is the rollback plan?
   - N/A (It's a one-character syntax fix for a table definition).